### PR TITLE
refactor: remove outdated 'counted format' terminology

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ This repository contains a **comprehensive JSON test suite** for CCL implementat
 ### Key Features
 
 > \[!IMPORTANT]
-> All tests use a **counted format** with required `count` fields for precise validation verification. Each validation declares exactly how many assertions it represents.
+> All tests include required `count` fields for precise validation verification. Each validation declares exactly how many assertions it represents.
 
 ✅ **Dual-format architecture** - Source format for maintainability, generated flat format for implementation\
 ✅ **Direct API mapping** - Each validation maps to a specific API function\
@@ -96,7 +96,7 @@ The test suite is organized by feature category:
 ### Using the Test Suite
 
 > \[!IMPORTANT]
-> **Counted Format Required**: All validations must include a `count` field that matches the number of expected results. This enables precise assertion counting and self-validating test suites.
+> **Count Fields Required**: All validations must include a `count` field that matches the number of expected results. This enables precise assertion counting and self-validating test suites.
 
 #### Source Format Structure (Maintainable)
 
@@ -368,7 +368,7 @@ supportedTests.forEach(test => {
 > \[!IMPORTANT]
 > **Self-Validating Tests**: The `count` field enables test runners to verify they're executing the expected number of assertions, preventing silent test failures and ensuring comprehensive coverage.
 
-All validations use the **counted format** with required `count` fields:
+All validations include required `count` fields:
 
 ### Count Field Guidelines
 
@@ -478,13 +478,13 @@ just test --functions core      # Run core function tests (all should pass)
 ## Contributing
 
 > \[!IMPORTANT]
-> **Test Quality Standards**: All new tests must use the counted format, include proper typed fields metadata, and pass JSON schema validation before being accepted.
+> **Test Quality Standards**: All new tests must include proper count fields and typed fields metadata, and pass JSON schema validation before being accepted.
 
 When adding test cases:
 
 1. **Add to appropriate JSON file** by feature level and category
 1. **Include descriptive name and metadata** with typed fields (functions, features, behaviors, variants)
-1. **Use counted format** with appropriate `count` values matching result arrays
+1. **Include count fields** with appropriate `count` values matching result arrays
 1. **Validate JSON structure** with `just validate` before submitting
 1. **Generate flat format** with `just generate-flat` and ensure tests pass
 1. **Update test counts** in documentation and ensure `just stats` reflects changes

--- a/docs/generated-schema.md
+++ b/docs/generated-schema.md
@@ -376,7 +376,7 @@
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Counted format: Expected entries with assertion count
+**Description:** Expected entries with assertion count
 
 | Property                                                        | Pattern | Type    | Deprecated | Definition | Title/Description                               |
 | --------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------- |
@@ -554,7 +554,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Counted format: Expected entries with assertion count
+**Description:** Expected entries with assertion count
 
 | Property                                                         | Pattern | Type    | Deprecated | Definition | Title/Description                               |
 | ---------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------- |
@@ -797,7 +797,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Counted format: Expected entries with assertion count
+**Description:** Expected entries with assertion count
 
 | Property                                                                | Pattern | Type    | Deprecated | Definition | Title/Description                               |
 | ----------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------- |
@@ -930,7 +930,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Counted format: Expected object with assertion count
+**Description:** Expected object with assertion count
 
 | Property                                                               | Pattern | Type    | Deprecated | Definition | Title/Description                               |
 | ---------------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------- |
@@ -1243,7 +1243,7 @@ Must be one of:
 | **Required**              | No               |
 | **Additional properties** | Any type allowed |
 
-**Description:** Counted format: Multiple typed access tests with count
+**Description:** Multiple typed access tests with count
 
 | Property                                                       | Pattern | Type    | Deprecated | Definition | Title/Description                               |
 | -------------------------------------------------------------- | ------- | ------- | ---------- | ---------- | ----------------------------------------------- |

--- a/docs/schema-reference.md
+++ b/docs/schema-reference.md
@@ -136,7 +136,7 @@ Each test case uses explicit `validations` objects that specify which API functi
 
 ## Validation Format Requirements
 
-**IMPORTANT: All validations now use the counted format** with a required `count` field that specifies the number of assertions the validation represents.
+**IMPORTANT: All validations include** a required `count` field that specifies the number of assertions the validation represents.
 
 ### Count Field
 

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -304,7 +304,7 @@ func (g *Generator) generateParseValidation(validation interface{}) (string, err
 	assert.Equal(t, expectedParse, parseResult)`, inputVar, formatEntryArray(entries)), nil
 	}
 
-	// Try to parse as counted format with expected field
+	// Try to parse as validation with expected field
 	if countedValidation, ok := g.parseAsCountedValidation(validation); ok {
 		inputVar := "input"
 		if len(countedValidation.Expected) == 0 {
@@ -317,13 +317,13 @@ func (g *Generator) generateParseValidation(validation interface{}) (string, err
 	assert.Equal(t, expectedParse, parseResult)`, inputVar, formatEntryArray(countedValidation.Expected)), nil
 	}
 
-	// Try to parse as counted format or error format
+	// Try to parse as validation with count or error format
 	return g.generateComplexValidation("Parse", validation)
 }
 
 // generateFilterValidation creates assertion for filter validation
 func (g *Generator) generateFilterValidation(validation interface{}) (string, error) {
-	// Try to parse as counted format with expected field (current schema format)
+	// Try to parse as validation with expected field (current schema format)
 	if countedValidation, ok := g.parseAsCountedValidation(validation); ok {
 		inputVar := "input"
 		if len(countedValidation.Expected) == 0 {
@@ -357,7 +357,7 @@ func (g *Generator) generateFilterValidation(validation interface{}) (string, er
 
 // generateBuildHierarchyValidation creates assertion for make_objects validation
 func (g *Generator) generateBuildHierarchyValidation(validation interface{}) (string, error) {
-	// Try to parse as counted format first
+	// Try to parse as validation with count field first
 	if countedValidation, ok := g.parseAsCountedObjectValidation(validation); ok {
 		return fmt.Sprintf(`// BuildHierarchy validation
 	parseResult, err = ccl.Parse(input)
@@ -369,7 +369,7 @@ func (g *Generator) generateBuildHierarchyValidation(validation interface{}) (st
 
 	// Try to parse as direct object (legacy format)
 	if obj, ok := validation.(map[string]interface{}); ok {
-		// Check if it has count field (which would make it counted format we missed)
+		// Check if it has count field (which would make it a validation we missed)
 		if _, hasCount := obj["count"]; hasCount {
 			return g.generateComplexValidation("BuildHierarchy", validation)
 		}
@@ -1208,7 +1208,7 @@ func (g *Generator) countAssertions(validations *types.ValidationSet) int {
 
 // getValidationCount extracts the count from a validation, defaulting to 1
 func (g *Generator) getValidationCount(validation interface{}) int {
-	// Try to parse as counted format
+	// Try to parse as validation with count field
 	jsonData, err := json.Marshal(validation)
 	if err != nil {
 		return 1 // Default to 1 assertion

--- a/internal/stats/collector.go
+++ b/internal/stats/collector.go
@@ -80,9 +80,9 @@ func countAssertions(validationData interface{}) int {
 		return 0
 	}
 
-	// Handle map structure (counted format or error format)
+	// Handle map structure (with count field or error format)
 	if m, ok := validationData.(map[string]interface{}); ok {
-		// Check for counted format with explicit count field
+		// Check for explicit count field
 		if count, exists := m["count"]; exists {
 			if countFloat, ok := count.(float64); ok {
 				return int(countFloat)


### PR DESCRIPTION
## Summary

Removes references to the outdated 'counted format' terminology throughout the codebase, replacing it with clearer language about count fields.

## Changes Made

- **Documentation updates**:
  - README.md: Replace "counted format" with "count fields" 
  - Schema reference docs: Simplify descriptions
  - Generated schema docs: Remove "Counted format:" prefixes

- **Code comment improvements**:
  - Update internal/generator/templates.go comments
  - Simplify internal/stats/collector.go comments

## Impact

- ✅ **No functional changes** - all count field functionality remains identical
- ✅ **Improved clarity** - terminology is now more direct and less confusing
- ✅ **Consistent language** - unified approach to describing count fields
- ✅ **Maintains compatibility** - all existing APIs and schemas unchanged

## Testing

All existing tests continue to pass. The changes are purely cosmetic improvements to documentation and comments.