### PR TITLE
fix(tests): add list_coercion_enabled behavior to api_list_access tests

### DIFF
--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -2,7 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "tests": [
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 3,
         "entries": [
@@ -31,7 +33,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -56,7 +60,9 @@
       "args": [
         "servers"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 3,
         "list": [
@@ -76,7 +82,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 20,
         "entries": [
@@ -173,7 +181,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -215,7 +225,9 @@
       "args": [
         "items"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 20,
         "list": [
@@ -252,7 +264,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 5,
         "entries": [
@@ -291,7 +305,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -322,7 +338,9 @@
       "args": [
         "servers"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "expected": {
         "count": 3,
         "list": [

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -14,7 +14,7 @@ import (
 
 
 
-// basic_list_from_duplicates_parse - function:parse
+// basic_list_from_duplicates_parse - function:parse behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesParse(t *testing.T) {
 	
 	
@@ -41,7 +41,7 @@ servers = web3`
 }
 
 
-// basic_list_from_duplicates_build_hierarchy - function:build_hierarchy
+// basic_list_from_duplicates_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
 	
 	
@@ -69,7 +69,7 @@ servers = web3`
 }
 
 
-// basic_list_from_duplicates_get_list - function:get_list
+// basic_list_from_duplicates_get_list - function:get_list behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesGetList(t *testing.T) {
 	
 	
@@ -98,7 +98,7 @@ servers = web3`
 }
 
 
-// large_list_parse - function:parse
+// large_list_parse - function:parse behavior:list_coercion_enabled
 func TestLargeListParse(t *testing.T) {
 	
 	
@@ -142,7 +142,7 @@ items = item20`
 }
 
 
-// large_list_build_hierarchy - function:build_hierarchy
+// large_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled
 func TestLargeListBuildHierarchy(t *testing.T) {
 	
 	
@@ -187,7 +187,7 @@ items = item20`
 }
 
 
-// large_list_get_list - function:get_list
+// large_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestLargeListGetList(t *testing.T) {
 	
 	
@@ -233,7 +233,7 @@ items = item20`
 }
 
 
-// list_with_comments_parse - function:parse feature:comments
+// list_with_comments_parse - function:parse feature:comments behavior:list_coercion_enabled
 func TestListWithCommentsParse(t *testing.T) {
 	
 	
@@ -262,7 +262,7 @@ servers = web3
 }
 
 
-// list_with_comments_build_hierarchy - function:build_hierarchy feature:comments
+// list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:list_coercion_enabled
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
 	
 	
@@ -292,7 +292,7 @@ servers = web3
 }
 
 
-// list_with_comments_get_list - function:get_list feature:comments
+// list_with_comments_get_list - function:get_list feature:comments behavior:list_coercion_enabled
 func TestListWithCommentsGetList(t *testing.T) {
 	
 	

--- a/source_tests/core/api_list_access.json
+++ b/source_tests/core/api_list_access.json
@@ -43,6 +43,9 @@
             "servers"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ]
     },
     {
@@ -189,6 +192,9 @@
             "items"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ]
     },
     {
@@ -245,6 +251,9 @@
             "servers"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ],
       "features": [
         "comments"


### PR DESCRIPTION
## Summary

Fixes missing behavior declarations in `api_list_access.json` test suite that were causing false failures for reference-compliant implementations.

## Problem

Tests in `api_list_access` expected `list_coercion_enabled` behavior (duplicate keys create lists accessible via `get_list()`) but had empty `behaviors` arrays, making them indistinguishable from behavior-agnostic tests.

### Affected Tests
- `basic_list_from_duplicates`
- `large_list`
- `list_with_comments`

## Root Cause

These tests use duplicate keys to create lists and expect `get_list()` to return the actual array values. However, without the `list_coercion_enabled` behavior declaration:

1. Test runners cannot properly filter based on implementation capabilities
2. Reference-compliant implementations (using `list_coercion_disabled`) see spurious failures
3. Results misleadingly show failures instead of skipped tests

## Behavior Semantics

**`list_coercion_disabled` (reference-compliant)**:
- `build_hierarchy()` creates arrays from duplicate keys: `{"ports": ["80", "443"]}`
- `get_list("ports")` returns `null` (refuses to return the array)

**`list_coercion_enabled` (proposed behavior)**:
- `build_hierarchy()` creates arrays from duplicate keys: `{"servers": ["web1", "web2", "web3"]}`
- `get_list("servers")` returns `["web1", "web2", "web3"]` (returns the actual array)

## Changes

Added explicit `"behaviors": ["list_coercion_enabled"]` to all three affected tests in `source_tests/core/api_list_access.json`.

## Verification

✅ JSON schema validation passed  
✅ Test regeneration completed successfully  
✅ Statistics now show: **`behavior:list_coercion_enabled`: 8 tests** (up from 5)  
✅ Generated tests include proper behavior declarations  

## Comparison with Other Suites

- ✅ `api_reference_compliant` properly declares `["list_coercion_disabled"]`
- ✅ `api_proposed_behavior` properly declares `["list_coercion_enabled"]`
- ✅ `api_list_access` now properly declares behavior requirements

## Impact

Reference-compliant implementations using `list_coercion_disabled` will now correctly **skip these tests** instead of seeing false failures.