### PR TITLE
ci: switch to standard vX.Y.Z version tags

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -3,7 +3,7 @@ name: Release Test Data
 on:
   push:
     tags:
-      - 'data-v*.*.*'
+      - 'v*.*.*'
 
 permissions:
   contents: write
@@ -34,7 +34,7 @@ jobs:
         id: version
         run: |
           TAG_NAME="${GITHUB_REF#refs/tags/}"
-          VERSION="${TAG_NAME#data-}"
+          VERSION="${TAG_NAME#v}"
           echo "tag=$TAG_NAME" >> $GITHUB_OUTPUT
           echo "version=$VERSION" >> $GITHUB_OUTPUT
 
@@ -61,10 +61,20 @@ jobs:
             jq --arg schema "$SCHEMA_URL" '.["$schema"] = $schema' "$file" > "release_assets/$filename"
           done
 
-      - name: Create ZIP archive
+      - name: Create generated tests ZIP archive
         run: |
           cd release_assets
-          zip -r ../ccl-test-data-${{ steps.version.outputs.tag }}.zip *.json
+          zip -r ../ccl-test-data-generated-${{ steps.version.outputs.tag }}.zip *.json
+
+      - name: Create source tests ZIP archive
+        run: |
+          zip -r ccl-test-data-source-${{ steps.version.outputs.tag }}.zip source_tests/
+
+      - name: Generate SHA256 checksums
+        run: |
+          sha256sum ccl-test-data-generated-${{ steps.version.outputs.tag }}.zip \
+                    ccl-test-data-source-${{ steps.version.outputs.tag }}.zip \
+                    > SHA256SUMS
 
       - name: Create GitHub Release
         uses: softprops/action-gh-release@v2
@@ -74,5 +84,7 @@ jobs:
           body_path: RELEASE_NOTES.md
           files: |
             release_assets/*.json
-            ccl-test-data-${{ steps.version.outputs.tag }}.zip
+            ccl-test-data-generated-${{ steps.version.outputs.tag }}.zip
+            ccl-test-data-source-${{ steps.version.outputs.tag }}.zip
+            SHA256SUMS
           fail_on_unmatched_files: true

--- a/cliff-by-type.toml
+++ b/cliff-by-type.toml
@@ -5,7 +5,7 @@ All notable changes to the CCL test data will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="data-") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [Unreleased]
 {% endif %}\
@@ -42,7 +42,7 @@ commit_parsers = [
     { message = "^test", group = "Testing", default_scope = "general" },
 ]
 filter_commits = false
-tag_pattern = "data-v[0-9].*"
+tag_pattern = "v[0-9].*"
 
 [bump]
 features_always_bump_minor = true

--- a/cliff.toml
+++ b/cliff.toml
@@ -5,7 +5,7 @@ All notable changes to the CCL test data will be documented in this file.\n
 """
 body = """
 {% if version %}\
-    ## [{{ version | trim_start_matches(pat="data-") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
+    ## [{{ version | trim_start_matches(pat="v") }}] - {{ timestamp | date(format="%Y-%m-%d") }}
 {% else %}\
     ## [Unreleased]
 {% endif %}\
@@ -42,7 +42,7 @@ commit_parsers = [
     { message = "^test", group = "Testing", default_scope = "general" },
 ]
 filter_commits = false
-tag_pattern = "data-v[0-9].*"
+tag_pattern = "v[0-9].*"
 
 [bump]
 features_always_bump_minor = true

--- a/docs/DEVELOPER_GUIDE.md
+++ b/docs/DEVELOPER_GUIDE.md
@@ -261,7 +261,7 @@ cargo install git-cliff
    This will:
    - Update CHANGELOG.md with all changes since last release
    - Commit the changelog
-   - Create tag `data-v1.2.0`
+   - Create tag `v1.2.0`
 
 4. **Push to trigger CI**:
    ```bash

--- a/justfile
+++ b/justfile
@@ -185,11 +185,11 @@ release-preview:
 
 # Create release: updates CHANGELOG.md, commits, and tags
 release version:
-    git cliff --tag data-v{{version}} -o CHANGELOG.md
+    git cliff --tag v{{version}} -o CHANGELOG.md
     git add CHANGELOG.md
-    git commit -m "chore(release): data-v{{version}}"
-    git tag data-v{{version}}
-    @echo "Release data-v{{version}} created. Push with: git push origin main --tags"
+    git commit -m "chore(release): v{{version}}"
+    git tag v{{version}}
+    @echo "Release v{{version}} created. Push with: git push origin main --tags"
 
 # === CONVENIENCE COMMANDS ===
 


### PR DESCRIPTION
## Summary

- Switch from `data-v*` prefix to standard `v*` semantic version tags
- Add source tests ZIP archive to release artifacts
- Add SHA256SUMS file for checksum validation

## Changes

| File | Change |
|------|--------|
| `.github/workflows/release.yml` | New tag pattern `v*.*.*`, add source ZIP + checksums |
| `cliff.toml` | Update `tag_pattern` and version display |
| `cliff-by-type.toml` | Update `tag_pattern` and version display |
| `justfile` | Update release commands |
| `docs/DEVELOPER_GUIDE.md` | Update example tag |

## Release Artifacts (after merge)

Releases will now include:
- `ccl-test-data-generated-vX.Y.Z.zip` - Generated/flat test JSON files
- `ccl-test-data-source-vX.Y.Z.zip` - Source test JSON files  
- `SHA256SUMS` - Checksums for validation
- Individual `*.json` files

## Motivation

Standard `vX.Y.Z` tags simplify integration with:
- mise/ubi for tool installation
- Automated dependency tools (Renovate, Dependabot)
- Go module versioning conventions

## Test plan

- [ ] Verify workflow syntax is valid
- [ ] Create test release after merge to validate artifacts