### PR TITLE
fix(tests): add list_coercion_enabled behavior to proposed_behavior tests

### DIFF
--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -430,8 +430,13 @@
       "args": [
         "empty_list"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -534,8 +539,13 @@
       "args": [
         "numbers"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -641,8 +651,13 @@
       "args": [
         "flags"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -752,8 +767,13 @@
       "args": [
         "items"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -877,8 +897,13 @@
         "production",
         "servers"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -987,8 +1012,13 @@
       "args": [
         "names"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -1096,8 +1126,13 @@
       "args": [
         "symbols"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]
@@ -1207,8 +1242,13 @@
       "args": [
         "descriptions"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ],
         "variants": [
           "reference_compliant"
         ]

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -134,7 +134,7 @@ func TestEmptyListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// empty_list_get_list - function:get_list variant:proposed_behavior
+// empty_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestEmptyListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -165,7 +165,7 @@ func TestListWithNumbersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_numbers_get_list - function:get_list variant:proposed_behavior
+// list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithNumbersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -196,7 +196,7 @@ func TestListWithBooleansBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_booleans_get_list - function:get_list variant:proposed_behavior
+// list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithBooleansGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -227,7 +227,7 @@ func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_whitespace_get_list - function:get_list feature:whitespace variant:proposed_behavior
+// list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithWhitespaceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -260,7 +260,7 @@ func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// deeply_nested_list_get_list - function:get_list variant:proposed_behavior
+// deeply_nested_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestDeeplyNestedListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -291,7 +291,7 @@ func TestListWithUnicodeBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_unicode_get_list - function:get_list feature:unicode variant:proposed_behavior
+// list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithUnicodeGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -322,7 +322,7 @@ func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_special_characters_get_list - function:get_list variant:proposed_behavior
+// list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithSpecialCharactersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -337,7 +337,7 @@ func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_multiline_values_get_list - function:get_list feature:multiline variant:proposed_behavior
+// list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestListMultilineValuesGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -238,6 +238,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "variants": [
         "proposed_behavior"
       ],
@@ -292,6 +295,9 @@
             "numbers"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ],
       "variants": [
         "proposed_behavior"
@@ -348,6 +354,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "variants": [
         "proposed_behavior"
       ],
@@ -402,6 +411,9 @@
             "items"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ],
       "features": [
         "whitespace"
@@ -476,6 +488,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "variants": [
         "proposed_behavior"
       ],
@@ -530,6 +545,9 @@
             "names"
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ],
       "features": [
         "unicode"
@@ -589,6 +607,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
       "variants": [
         "proposed_behavior"
       ],
@@ -642,6 +663,9 @@
             }
           ]
         }
+      ],
+      "behaviors": [
+        "list_coercion_enabled"
       ],
       "features": [
         "multiline"


### PR DESCRIPTION
## Summary
- Add missing `list_coercion_enabled` behavior tag to 8 tests in `api_proposed_behavior.json` that use `get_list` and expect list coercion behavior

## Affected Tests
- `empty_list`
- `list_with_numbers`
- `list_with_booleans`
- `list_with_whitespace`
- `deeply_nested_list`
- `list_with_unicode`
- `list_with_special_characters`
- `list_multiline_values`

## Context
Without this tag, implementations with `list_coercion_disabled` would incorrectly run these tests and fail.

Fixes #12