### PR TITLE
feat(tests): add comprehensive behavior tests

### DIFF
--- a/generated_tests/api_typed_access.json
+++ b/generated_tests/api_typed_access.json
@@ -1881,6 +1881,536 @@
       "source_test": "parse_missing_path_error",
       "validation": "get_string",
       "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "upper_true",
+            "value": "TRUE"
+          },
+          {
+            "key": "upper_false",
+            "value": "FALSE"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "upper_true = TRUE\nupper_false = FALSE"
+      ],
+      "name": "boolean_case_sensitivity_uppercase_parse",
+      "source_test": "boolean_case_sensitivity_uppercase",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "upper_true"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "upper_true = TRUE\nupper_false = FALSE"
+      ],
+      "name": "boolean_case_sensitivity_uppercase_get_bool",
+      "source_test": "boolean_case_sensitivity_uppercase",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "mixed_true",
+            "value": "True"
+          },
+          {
+            "key": "mixed_false",
+            "value": "False"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "mixed_true = True\nmixed_false = False"
+      ],
+      "name": "boolean_case_sensitivity_mixed_parse",
+      "source_test": "boolean_case_sensitivity_mixed",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "mixed_true"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "mixed_true = True\nmixed_false = False"
+      ],
+      "name": "boolean_case_sensitivity_mixed_get_bool",
+      "source_test": "boolean_case_sensitivity_mixed",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "upper_yes",
+            "value": "YES"
+          },
+          {
+            "key": "upper_no",
+            "value": "NO"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "upper_yes = YES\nupper_no = NO"
+      ],
+      "name": "boolean_lenient_uppercase_yes_no_parse",
+      "source_test": "boolean_lenient_uppercase_yes_no",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "upper_yes"
+      ],
+      "behaviors": [
+        "boolean_lenient"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "upper_yes = YES\nupper_no = NO"
+      ],
+      "name": "boolean_lenient_uppercase_yes_no_get_bool",
+      "source_test": "boolean_lenient_uppercase_yes_no",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "one",
+            "value": "1"
+          },
+          {
+            "key": "zero",
+            "value": "0"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "one = 1\nzero = 0"
+      ],
+      "name": "boolean_numeric_one_zero_strict_parse",
+      "source_test": "boolean_numeric_one_zero_strict",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "one"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "one = 1\nzero = 0"
+      ],
+      "name": "boolean_numeric_one_zero_strict_get_int",
+      "source_test": "boolean_numeric_one_zero_strict",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "args": [
+        "one"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "one = 1\nzero = 0"
+      ],
+      "name": "boolean_numeric_one_zero_strict_get_bool",
+      "source_test": "boolean_numeric_one_zero_strict",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "padded",
+            "value": "true"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "padded =   true   "
+      ],
+      "name": "boolean_with_whitespace_parse",
+      "source_test": "boolean_with_whitespace",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "padded"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1,
+        "value": true
+      },
+      "features": [
+        "optional_typed_accessors",
+        "whitespace"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "padded =   true   "
+      ],
+      "name": "boolean_with_whitespace_get_bool",
+      "source_test": "boolean_with_whitespace",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "debug": "true",
+            "experimental": "yes",
+            "verbose": "false"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "config =\n  debug = true\n  verbose = false\n  experimental = yes"
+      ],
+      "name": "boolean_nested_object_build_hierarchy",
+      "source_test": "boolean_nested_object",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "flag",
+            "value": "true"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "flag = true"
+      ],
+      "name": "type_mismatch_get_int_on_bool_parse",
+      "source_test": "type_mismatch_get_int_on_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "flag"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "flag = true"
+      ],
+      "name": "type_mismatch_get_int_on_bool_get_int",
+      "source_test": "type_mismatch_get_int_on_bool",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "number",
+            "value": "42"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "number = 42"
+      ],
+      "name": "type_mismatch_get_bool_on_int_parse",
+      "source_test": "type_mismatch_get_bool_on_int",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "number"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "number = 42"
+      ],
+      "name": "type_mismatch_get_bool_on_int_get_bool",
+      "source_test": "type_mismatch_get_bool_on_int",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "flag",
+            "value": "false"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "flag = false"
+      ],
+      "name": "type_mismatch_get_float_on_bool_parse",
+      "source_test": "type_mismatch_get_float_on_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "flag"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "flag = false"
+      ],
+      "name": "type_mismatch_get_float_on_bool_get_float",
+      "source_test": "type_mismatch_get_float_on_bool",
+      "validation": "get_float",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "count": "abc",
+            "name": "test"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "config =\n  name = test\n  count = abc"
+      ],
+      "name": "type_mismatch_nested_path_build_hierarchy",
+      "source_test": "type_mismatch_nested_path",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "empty",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "empty ="
+      ],
+      "name": "boolean_empty_value_error_parse",
+      "source_test": "boolean_empty_value_error",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "args": [
+        "empty"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "expected": {
+        "count": 1
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "empty ="
+      ],
+      "name": "boolean_empty_value_error_get_bool",
+      "source_test": "boolean_empty_value_error",
+      "validation": "get_bool",
+      "variants": []
     }
   ]
 }

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -778,6 +778,430 @@
       "source_test": "deeply_nested_bare_list_indentation",
       "validation": "canonical_format",
       "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "key1",
+            "value": "value1"
+          },
+          {
+            "key": "key2",
+            "value": "value2"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_normalize_to_lf_basic_parse",
+      "source_test": "crlf_normalize_to_lf_basic",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "key1": "value1",
+          "key2": "value2"
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_normalize_to_lf_basic_build_hierarchy",
+      "source_test": "crlf_normalize_to_lf_basic",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "key1",
+            "value": "value1\r"
+          },
+          {
+            "key": "key2",
+            "value": "value2\r"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_preserve_literal_basic_parse",
+      "source_test": "crlf_preserve_literal_basic",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "multiline",
+            "value": "\n  line1\n  line2"
+          }
+        ]
+      },
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "multiline =\r\n  line1\r\n  line2"
+      ],
+      "name": "crlf_normalize_multiline_value_parse",
+      "source_test": "crlf_normalize_multiline_value",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "multiline",
+            "value": "\r\n  line1\r\n  line2"
+          }
+        ]
+      },
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "multiline =\r\n  line1\r\n  line2"
+      ],
+      "name": "crlf_preserve_multiline_value_parse",
+      "source_test": "crlf_preserve_multiline_value",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "lf_line",
+            "value": "value1"
+          },
+          {
+            "key": "crlf_line",
+            "value": "value2"
+          },
+          {
+            "key": "lf_again",
+            "value": "value3"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
+      ],
+      "name": "crlf_mixed_line_endings_parse",
+      "source_test": "crlf_mixed_line_endings",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "config",
+            "value": "\n  host = localhost\n  port = 8080"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_nested_structure_parse",
+      "source_test": "crlf_nested_structure",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "host": "localhost",
+            "port": "8080"
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_nested_structure_build_hierarchy",
+      "source_test": "crlf_nested_structure",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "value"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "name": "strict_spacing_standard_format_parse",
+      "source_test": "strict_spacing_standard_format",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key=value",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key=value"
+      ],
+      "name": "strict_spacing_rejects_no_spaces_parse",
+      "source_test": "strict_spacing_rejects_no_spaces",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key =value",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key =value"
+      ],
+      "name": "strict_spacing_rejects_left_space_only_parse",
+      "source_test": "strict_spacing_rejects_left_space_only",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key= value",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key= value"
+      ],
+      "name": "strict_spacing_rejects_right_space_only_parse",
+      "source_test": "strict_spacing_rejects_right_space_only",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key\t=\tvalue",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\t=\tvalue"
+      ],
+      "name": "strict_spacing_rejects_tabs_parse",
+      "source_test": "strict_spacing_rejects_tabs",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "tabs_to_spaces",
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "  value  with  tabs"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs\r\n"
+      ],
+      "name": "behavior_combo_tabs_and_crlf_parse",
+      "source_test": "behavior_combo_tabs_and_crlf",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "loose_spacing",
+        "tabs_preserve",
+        "crlf_normalize_to_lf"
+      ],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "key1",
+            "value": "\tvalue1"
+          },
+          {
+            "key": "key2",
+            "value": "\tvalue2"
+          }
+        ]
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key1=\tvalue1\r\nkey2\t=\tvalue2\r\n"
+      ],
+      "name": "behavior_combo_loose_tabs_crlf_parse",
+      "source_test": "behavior_combo_loose_tabs_crlf",
+      "validation": "parse",
+      "variants": []
     }
   ]
 }

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -669,3 +669,229 @@ func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
 func TestParseMissingPathErrorGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
+// boolean_case_sensitivity_uppercase_parse - function:parse feature:optional_typed_accessors
+func TestBooleanCaseSensitivityUppercaseParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `upper_true = TRUE
+upper_false = FALSE`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "upper_true", Value: "TRUE"}, mock.Entry{Key: "upper_false", Value: "FALSE"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_case_sensitivity_uppercase_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
+func TestBooleanCaseSensitivityUppercaseGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_case_sensitivity_mixed_parse - function:parse feature:optional_typed_accessors
+func TestBooleanCaseSensitivityMixedParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `mixed_true = True
+mixed_false = False`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "mixed_true", Value: "True"}, mock.Entry{Key: "mixed_false", Value: "False"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_case_sensitivity_mixed_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
+func TestBooleanCaseSensitivityMixedGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_lenient_uppercase_yes_no_parse - function:parse feature:optional_typed_accessors
+func TestBooleanLenientUppercaseYesNoParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `upper_yes = YES
+upper_no = NO`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "upper_yes", Value: "YES"}, mock.Entry{Key: "upper_no", Value: "NO"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_lenient_uppercase_yes_no_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
+func TestBooleanLenientUppercaseYesNoGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_numeric_one_zero_strict_parse - function:parse feature:optional_typed_accessors
+func TestBooleanNumericOneZeroStrictParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "one", Value: "1"}, mock.Entry{Key: "zero", Value: "0"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_numeric_one_zero_strict_get_int - function:get_int feature:optional_typed_accessors
+func TestBooleanNumericOneZeroStrictGetInt(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_numeric_one_zero_strict_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
+func TestBooleanNumericOneZeroStrictGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_with_whitespace_parse - function:parse feature:optional_typed_accessors feature:whitespace
+func TestBooleanWithWhitespaceParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `padded =   true   `
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "padded", Value: "true"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_with_whitespace_get_bool - function:get_bool feature:optional_typed_accessors feature:whitespace behavior:boolean_strict
+func TestBooleanWithWhitespaceGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_nested_object_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// type_mismatch_get_int_on_bool_parse - function:parse feature:optional_typed_accessors
+func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `flag = true`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "flag", Value: "true"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// type_mismatch_get_int_on_bool_get_int - function:get_int feature:optional_typed_accessors
+func TestTypeMismatchGetIntOnBoolGetInt(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// type_mismatch_get_bool_on_int_parse - function:parse feature:optional_typed_accessors
+func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `number = 42`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "number", Value: "42"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// type_mismatch_get_bool_on_int_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
+func TestTypeMismatchGetBoolOnIntGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// type_mismatch_get_float_on_bool_parse - function:parse feature:optional_typed_accessors
+func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `flag = false`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "flag", Value: "false"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// type_mismatch_get_float_on_bool_get_float - function:get_float feature:optional_typed_accessors
+func TestTypeMismatchGetFloatOnBoolGetFloat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// type_mismatch_nested_path_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// boolean_empty_value_error_parse - function:parse feature:optional_typed_accessors
+func TestBooleanEmptyValueErrorParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := `empty =`
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "empty", Value: ""}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// boolean_empty_value_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
+func TestBooleanEmptyValueErrorGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -269,3 +269,130 @@ func TestNestedBareListIndentationCanonicalFormat(t *testing.T) {
 func TestDeeplyNestedBareListIndentationCanonicalFormat(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
+// crlf_normalize_to_lf_basic_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1"}, mock.Entry{Key: "key2", Value: "value2"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace
+func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// crlf_preserve_literal_basic_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+}
+
+// crlf_normalize_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := "multiline =\r\n  line1\r\n  line2"
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "multiline", Value: "\n  line1\n  line2"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_preserve_literal
+func TestCrlfPreserveMultilineValueParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+}
+
+// crlf_mixed_line_endings_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfMixedLineEndingsParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "lf_line", Value: "value1"}, mock.Entry{Key: "crlf_line", Value: "value2"}, mock.Entry{Key: "lf_again", Value: "value3"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// crlf_nested_structure_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNestedStructureParse(t *testing.T) {
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+
+	// Declare variables for reuse across validations
+
+	var err error
+
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "config", Value: "\n  host = localhost\n  port = 8080"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace
+func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// strict_spacing_standard_format_parse - function:parse feature:whitespace behavior:strict_spacing
+func TestStrictSpacingStandardFormatParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
+}
+
+// strict_spacing_rejects_no_spaces_parse - function:parse feature:whitespace behavior:strict_spacing
+func TestStrictSpacingRejectsNoSpacesParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
+}
+
+// strict_spacing_rejects_left_space_only_parse - function:parse feature:whitespace behavior:strict_spacing
+func TestStrictSpacingRejectsLeftSpaceOnlyParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
+}
+
+// strict_spacing_rejects_right_space_only_parse - function:parse feature:whitespace behavior:strict_spacing
+func TestStrictSpacingRejectsRightSpaceOnlyParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
+}
+
+// strict_spacing_rejects_tabs_parse - function:parse feature:whitespace behavior:strict_spacing
+func TestStrictSpacingRejectsTabsParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
+}
+
+// behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_to_spaces behavior:crlf_normalize_to_lf
+func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:tabs_to_spaces")
+}
+
+// behavior_combo_loose_tabs_crlf_parse - function:parse feature:whitespace behavior:loose_spacing behavior:tabs_preserve behavior:crlf_normalize_to_lf
+func TestBehaviorComboLooseTabsCrlfParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:tabs_preserve")
+}

--- a/source_tests/core/api_typed_access.json
+++ b/source_tests/core/api_typed_access.json
@@ -930,6 +930,335 @@
       "inputs": [
         "existing = value"
       ]
+    },
+    {
+      "name": "boolean_case_sensitivity_uppercase",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "upper_true",
+              "value": "TRUE"
+            },
+            {
+              "key": "upper_false",
+              "value": "FALSE"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "upper_true"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "upper_true = TRUE\nupper_false = FALSE"
+      ]
+    },
+    {
+      "name": "boolean_case_sensitivity_mixed",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "mixed_true",
+              "value": "True"
+            },
+            {
+              "key": "mixed_false",
+              "value": "False"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "mixed_true"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "mixed_true = True\nmixed_false = False"
+      ]
+    },
+    {
+      "name": "boolean_lenient_uppercase_yes_no",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "upper_yes",
+              "value": "YES"
+            },
+            {
+              "key": "upper_no",
+              "value": "NO"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "upper_yes"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_lenient"
+      ],
+      "inputs": [
+        "upper_yes = YES\nupper_no = NO"
+      ]
+    },
+    {
+      "name": "boolean_numeric_one_zero_strict",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "one",
+              "value": "1"
+            },
+            {
+              "key": "zero",
+              "value": "0"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "one"
+          ]
+        },
+        {
+          "function": "get_int",
+          "expect": 1,
+          "args": [
+            "one"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "one = 1\nzero = 0"
+      ]
+    },
+    {
+      "name": "boolean_with_whitespace",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "padded",
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": true,
+          "args": [
+            "padded"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "whitespace"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "padded =   true   "
+      ]
+    },
+    {
+      "name": "boolean_nested_object",
+      "tests": [
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "config": {
+              "debug": "true",
+              "verbose": "false",
+              "experimental": "yes"
+            }
+          }
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "inputs": [
+        "config =\n  debug = true\n  verbose = false\n  experimental = yes"
+      ]
+    },
+    {
+      "name": "type_mismatch_get_int_on_bool",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "flag",
+              "value": "true"
+            }
+          ]
+        },
+        {
+          "function": "get_int",
+          "expect": null,
+          "args": [
+            "flag"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "inputs": [
+        "flag = true"
+      ]
+    },
+    {
+      "name": "type_mismatch_get_bool_on_int",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "number",
+              "value": "42"
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "number"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "number = 42"
+      ]
+    },
+    {
+      "name": "type_mismatch_get_float_on_bool",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "flag",
+              "value": "false"
+            }
+          ]
+        },
+        {
+          "function": "get_float",
+          "expect": null,
+          "args": [
+            "flag"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "inputs": [
+        "flag = false"
+      ]
+    },
+    {
+      "name": "type_mismatch_nested_path",
+      "tests": [
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "config": {
+              "name": "test",
+              "count": "abc"
+            }
+          }
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "inputs": [
+        "config =\n  name = test\n  count = abc"
+      ]
+    },
+    {
+      "name": "boolean_empty_value_error",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "empty",
+              "value": ""
+            }
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": null,
+          "args": [
+            "empty"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "inputs": [
+        "empty ="
+      ]
     }
   ]
 }

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -556,6 +556,346 @@
       "inputs": [
         "app =\n  = item1\n  config =\n    = nested1\n    = nested2\n    deep =\n      = level3a\n      = level3b\n  = item2"
       ]
+    },
+    {
+      "name": "crlf_normalize_to_lf_basic",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key1",
+              "value": "value1"
+            },
+            {
+              "key": "key2",
+              "value": "value2"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "key1": "value1",
+            "key2": "value2"
+          }
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ]
+    },
+    {
+      "name": "crlf_preserve_literal_basic",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key1",
+              "value": "value1\r"
+            },
+            {
+              "key": "key2",
+              "value": "value2\r"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ]
+    },
+    {
+      "name": "crlf_normalize_multiline_value",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "multiline",
+              "value": "\n  line1\n  line2"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "inputs": [
+        "multiline =\r\n  line1\r\n  line2"
+      ]
+    },
+    {
+      "name": "crlf_preserve_multiline_value",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "multiline",
+              "value": "\r\n  line1\r\n  line2"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "inputs": [
+        "multiline =\r\n  line1\r\n  line2"
+      ]
+    },
+    {
+      "name": "crlf_mixed_line_endings",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "lf_line",
+              "value": "value1"
+            },
+            {
+              "key": "crlf_line",
+              "value": "value2"
+            },
+            {
+              "key": "lf_again",
+              "value": "value3"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
+      ]
+    },
+    {
+      "name": "crlf_nested_structure",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "config",
+              "value": "\n  host = localhost\n  port = 8080"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "config": {
+              "host": "localhost",
+              "port": "8080"
+            }
+          }
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ]
+    },
+    {
+      "name": "strict_spacing_standard_format",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "value"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key = value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_no_spaces",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key=value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key=value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_left_space_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key =value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key =value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_right_space_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key= value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key= value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_tabs",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key\t=\tvalue",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key\t=\tvalue"
+      ]
+    },
+    {
+      "name": "behavior_combo_tabs_and_crlf",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "  value  with  tabs"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "tabs_to_spaces",
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs\r\n"
+      ]
+    },
+    {
+      "name": "behavior_combo_loose_tabs_crlf",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key1",
+              "value": "\tvalue1"
+            },
+            {
+              "key": "key2",
+              "value": "\tvalue2"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "loose_spacing",
+        "tabs_preserve",
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key1=\tvalue1\r\nkey2\t=\tvalue2\r\n"
+      ]
     }
   ]
 }


### PR DESCRIPTION
## Summary

Adds 26 new test cases to improve coverage of parse-time and access-time configurable behaviors:

- **CRLF handling** (6 tests): normalize vs preserve, multiline values, nested structures, mixed line endings
- **Strict spacing** (5 tests): validates rejection of non-standard formats like `key=value`, `key =value`
- **Boolean edge cases** (7 tests): case sensitivity, numeric 1/0, whitespace handling, empty values, nested objects
- **Type mismatch errors** (4 tests): get_int on bool, get_bool on int, get_float on bool
- **Behavior combinations** (2 tests): tabs+crlf, loose+tabs+crlf triple combos

## Test plan

- [x] JSON validates successfully
- [x] `just reset` regenerates tests without errors
- [x] All new tests follow source format schema