### PR TITLE
fix(tests): correct tabs_to_spaces behavior to use single space

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -439,7 +439,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "  value  with  tabs"
+            "value": " value with tabs"
           }
         ]
       },
@@ -464,7 +464,7 @@
       "expected": {
         "count": 1,
         "object": {
-          "key": "  value  with  tabs"
+          "key": " value with tabs"
         }
       },
       "features": [
@@ -488,7 +488,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "  value  with  tabs"
+        "value": " value with tabs"
       },
       "features": [
         "whitespace"
@@ -513,7 +513,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "  indented"
+            "value": " indented"
           }
         ]
       },
@@ -538,7 +538,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "  indented"
+        "value": " indented"
       },
       "features": [
         "whitespace"
@@ -563,7 +563,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "      three_tabs"
+            "value": "   three_tabs"
           }
         ]
       },
@@ -618,7 +618,7 @@
         "entries": [
           {
             "key": "section",
-            "value": "\n    indented_with_tabs\n    another_line"
+            "value": "\n  indented_with_tabs\n  another_line"
           }
         ]
       },
@@ -665,7 +665,7 @@
       ],
       "expected": {
         "count": 1,
-        "value": "key =   value"
+        "value": "key =  value"
       },
       "features": [
         "whitespace"
@@ -719,7 +719,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "  value  with  tabs"
+            "value": " value with tabs"
           }
         ]
       },
@@ -1152,7 +1152,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "  value  with  tabs"
+            "value": " value with tabs"
           }
         ]
       },

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -312,14 +312,14 @@
           "expect": [
             {
               "key": "key",
-              "value": "  value  with  tabs"
+              "value": " value with tabs"
             }
           ]
         },
         {
           "function": "build_hierarchy",
           "expect": {
-            "key": "  value  with  tabs"
+            "key": " value with tabs"
           }
         },
         {
@@ -327,7 +327,7 @@
           "args": [
             "key"
           ],
-          "expect": "  value  with  tabs"
+          "expect": " value with tabs"
         }
       ],
       "behaviors": [
@@ -348,7 +348,7 @@
           "expect": [
             {
               "key": "key",
-              "value": "  indented"
+              "value": " indented"
             }
           ]
         },
@@ -357,7 +357,7 @@
           "args": [
             "key"
           ],
-          "expect": "  indented"
+          "expect": " indented"
         }
       ],
       "behaviors": [
@@ -378,7 +378,7 @@
           "expect": [
             {
               "key": "key",
-              "value": "      three_tabs"
+              "value": "   three_tabs"
             }
           ]
         }
@@ -425,7 +425,7 @@
           "expect": [
             {
               "key": "section",
-              "value": "\n    indented_with_tabs\n    another_line"
+              "value": "\n  indented_with_tabs\n  another_line"
             }
           ]
         }
@@ -464,7 +464,7 @@
       "tests": [
         {
           "function": "canonical_format",
-          "expect": "key =   value"
+          "expect": "key =  value"
         }
       ],
       "behaviors": [
@@ -509,7 +509,7 @@
           "expect": [
             {
               "key": "key",
-              "value": "  value  with  tabs"
+              "value": " value with tabs"
             }
           ]
         }
@@ -852,7 +852,7 @@
           "expect": [
             {
               "key": "key",
-              "value": "  value  with  tabs"
+              "value": " value with tabs"
             }
           ]
         }


### PR DESCRIPTION
The tabs_to_spaces behavior should convert each tab to a single space, not two spaces. Fixed expectations in 7 tests:

- tabs_to_spaces_in_value
- tabs_to_spaces_leading_tab
- tabs_to_spaces_multiple_tabs
- tabs_to_spaces_multiline
- tabs_canonical_format_to_spaces
- spacing_and_tabs_combined_loose_to_spaces
- behavior_combo_tabs_and_crlf