### PR TITLE
refactor(tests): simplify whitespace behavior model

### DIFF
--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -463,7 +463,7 @@
         "entries": [
           {
             "key": "text",
-            "value": "First\n    four spaces\n\ttab preserved"
+            "value": "First\n   four spaces\n\ttab preserved"
           }
         ]
       },
@@ -474,7 +474,7 @@
         "parse_indented"
       ],
       "inputs": [
-        "text = First\n    four spaces\n\ttab preserved"
+        "text = First\n    four spaces\n \ttab preserved"
       ],
       "name": "spaces_vs_tabs_continuation_parse_indented",
       "source_test": "spaces_vs_tabs_continuation",
@@ -490,7 +490,7 @@
         "entries": [
           {
             "key": "text",
-            "value": "First\n    four spaces\n tab preserved"
+            "value": "First\n   four spaces\n\ttab preserved"
           }
         ]
       },
@@ -501,7 +501,7 @@
         "parse_indented"
       ],
       "inputs": [
-        "text = First\n    four spaces\n\ttab preserved"
+        "text = First\n    four spaces\n \ttab preserved"
       ],
       "name": "spaces_vs_tabs_continuation_ocaml_reference_parse_indented",
       "source_test": "spaces_vs_tabs_continuation_ocaml_reference",

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -590,7 +590,7 @@
         "entries": [
           {
             "key": "section",
-            "value": "\n\t\tindented_with_tabs\n\t\tanother_line"
+            "value": "\n \tindented_with_tabs\n \tanother_line"
           }
         ]
       },
@@ -602,7 +602,7 @@
         "parse"
       ],
       "inputs": [
-        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+        "section =\n \tindented_with_tabs\n \tanother_line"
       ],
       "name": "tabs_preserve_multiline_parse",
       "source_test": "tabs_preserve_multiline",
@@ -634,6 +634,34 @@
       ],
       "name": "tabs_to_spaces_multiline_parse",
       "source_test": "tabs_to_spaces_multiline",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "tabs_to_spaces"
+      ],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "section",
+            "value": "\n  mixed_indent\n  another_line"
+          }
+        ]
+      },
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n \tmixed_indent\n\t another_line"
+      ],
+      "name": "tabs_to_spaces_mixed_indent_parse",
+      "source_test": "tabs_to_spaces_mixed_indent",
       "validation": "parse",
       "variants": []
     },
@@ -679,6 +707,49 @@
       "name": "tabs_canonical_format_to_spaces_canonical_format",
       "source_test": "tabs_canonical_format_to_spaces",
       "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "tabs_to_spaces"
+      ],
+      "expected": {
+        "count": 1,
+        "value": "section =\n  indented\n  another"
+      },
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "functions": [
+        "canonical_format"
+      ],
+      "inputs": [
+        "section =\n\t\tindented\n\t\tanother"
+      ],
+      "name": "tabs_to_spaces_multiline_print_canonical_format",
+      "source_test": "tabs_to_spaces_multiline_print",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "key =  value with tabs"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "round_trip"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs"
+      ],
+      "name": "tabs_to_spaces_round_trip_round_trip",
+      "source_test": "tabs_to_spaces_round_trip",
+      "validation": "round_trip",
       "variants": []
     },
     {
@@ -1005,141 +1076,6 @@
       "name": "crlf_nested_structure_build_hierarchy",
       "source_test": "crlf_nested_structure",
       "validation": "build_hierarchy",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key = value"
-      ],
-      "name": "strict_spacing_standard_format_parse",
-      "source_test": "strict_spacing_standard_format",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key=value",
-            "value": ""
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key=value"
-      ],
-      "name": "strict_spacing_rejects_no_spaces_parse",
-      "source_test": "strict_spacing_rejects_no_spaces",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key =value",
-            "value": ""
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key =value"
-      ],
-      "name": "strict_spacing_rejects_left_space_only_parse",
-      "source_test": "strict_spacing_rejects_left_space_only",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key= value",
-            "value": ""
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key= value"
-      ],
-      "name": "strict_spacing_rejects_right_space_only_parse",
-      "source_test": "strict_spacing_rejects_right_space_only",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key\t=\tvalue",
-            "value": ""
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key\t=\tvalue"
-      ],
-      "name": "strict_spacing_rejects_tabs_parse",
-      "source_test": "strict_spacing_rejects_tabs",
-      "validation": "parse",
       "variants": []
     },
     {

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -240,6 +240,11 @@ func TestTabsToSpacesMultilineParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_to_spaces")
 }
 
+// tabs_to_spaces_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_to_spaces
+func TestTabsToSpacesMixedIndentParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:tabs_to_spaces")
+}
+
 // tabs_canonical_format_preserve_canonical_format - function:canonical_format feature:whitespace behavior:tabs_preserve
 func TestTabsCanonicalFormatPreserveCanonicalFormat(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -247,6 +252,16 @@ func TestTabsCanonicalFormatPreserveCanonicalFormat(t *testing.T) {
 
 // tabs_canonical_format_to_spaces_canonical_format - function:canonical_format feature:whitespace behavior:tabs_to_spaces
 func TestTabsCanonicalFormatToSpacesCanonicalFormat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// tabs_to_spaces_multiline_print_canonical_format - function:canonical_format feature:whitespace feature:multiline behavior:tabs_to_spaces
+func TestTabsToSpacesMultilinePrintCanonicalFormat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+// tabs_to_spaces_round_trip_round_trip - function:round_trip feature:whitespace
+func TestTabsToSpacesRoundTripRoundTrip(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -360,31 +375,6 @@ func TestCrlfNestedStructureParse(t *testing.T) {
 // crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace
 func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// strict_spacing_standard_format_parse - function:parse feature:whitespace behavior:strict_spacing
-func TestStrictSpacingStandardFormatParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
-}
-
-// strict_spacing_rejects_no_spaces_parse - function:parse feature:whitespace behavior:strict_spacing
-func TestStrictSpacingRejectsNoSpacesParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
-}
-
-// strict_spacing_rejects_left_space_only_parse - function:parse feature:whitespace behavior:strict_spacing
-func TestStrictSpacingRejectsLeftSpaceOnlyParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
-}
-
-// strict_spacing_rejects_right_space_only_parse - function:parse feature:whitespace behavior:strict_spacing
-func TestStrictSpacingRejectsRightSpaceOnlyParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
-}
-
-// strict_spacing_rejects_tabs_parse - function:parse feature:whitespace behavior:strict_spacing
-func TestStrictSpacingRejectsTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:strict_spacing")
 }
 
 // behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_to_spaces behavior:crlf_normalize_to_lf

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -380,7 +380,7 @@
           "expect": [
             {
               "key": "text",
-              "value": "First\n    four spaces\n\ttab preserved"
+              "value": "First\n   four spaces\n\ttab preserved"
             }
           ]
         }
@@ -397,7 +397,7 @@
         ]
       },
       "inputs": [
-        "text = First\n    four spaces\n\ttab preserved"
+        "text = First\n    four spaces\n \ttab preserved"
       ]
     },
     {
@@ -408,7 +408,7 @@
           "expect": [
             {
               "key": "text",
-              "value": "First\n    four spaces\n tab preserved"
+              "value": "First\n   four spaces\n\ttab preserved"
             }
           ]
         }
@@ -425,7 +425,7 @@
         ]
       },
       "inputs": [
-        "text = First\n    four spaces\n\ttab preserved"
+        "text = First\n    four spaces\n \ttab preserved"
       ]
     },
     {

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -401,7 +401,7 @@
           "expect": [
             {
               "key": "section",
-              "value": "\n\t\tindented_with_tabs\n\t\tanother_line"
+              "value": "\n \tindented_with_tabs\n \tanother_line"
             }
           ]
         }
@@ -414,7 +414,7 @@
         "multiline"
       ],
       "inputs": [
-        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+        "section =\n \tindented_with_tabs\n \tanother_line"
       ]
     },
     {
@@ -439,6 +439,30 @@
       ],
       "inputs": [
         "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+      ]
+    },
+    {
+      "name": "tabs_to_spaces_mixed_indent",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "section",
+              "value": "\n  mixed_indent\n  another_line"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "tabs_to_spaces"
+      ],
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "inputs": [
+        "section =\n \tmixed_indent\n\t another_line"
       ]
     },
     {
@@ -475,6 +499,43 @@
       ],
       "inputs": [
         "key = \tvalue"
+      ]
+    },
+    {
+      "name": "tabs_to_spaces_multiline_print",
+      "tests": [
+        {
+          "function": "canonical_format",
+          "expect": "section =\n  indented\n  another"
+        }
+      ],
+      "behaviors": [
+        "tabs_to_spaces"
+      ],
+      "features": [
+        "whitespace",
+        "multiline"
+      ],
+      "inputs": [
+        "section =\n\t\tindented\n\t\tanother"
+      ]
+    },
+    {
+      "name": "tabs_to_spaces_round_trip",
+      "tests": [
+        {
+          "function": "round_trip",
+          "expect": "key =  value with tabs"
+        }
+      ],
+      "behaviors": [
+        "tabs_to_spaces"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs"
       ]
     },
     {
@@ -727,121 +788,6 @@
       ],
       "inputs": [
         "config =\r\n  host = localhost\r\n  port = 8080"
-      ]
-    },
-    {
-      "name": "strict_spacing_standard_format",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "value"
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = value"
-      ]
-    },
-    {
-      "name": "strict_spacing_rejects_no_spaces",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key=value",
-              "value": ""
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key=value"
-      ]
-    },
-    {
-      "name": "strict_spacing_rejects_left_space_only",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key =value",
-              "value": ""
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key =value"
-      ]
-    },
-    {
-      "name": "strict_spacing_rejects_right_space_only",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key= value",
-              "value": ""
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key= value"
-      ]
-    },
-    {
-      "name": "strict_spacing_rejects_tabs",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key\t=\tvalue",
-              "value": ""
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "strict_spacing"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key\t=\tvalue"
       ]
     },
     {

--- a/source_tests/experimental/api_spacing_behaviors.json
+++ b/source_tests/experimental/api_spacing_behaviors.json
@@ -1,0 +1,120 @@
+{
+  "$schema": "../../schemas/source-format.json",
+  "tests": [
+    {
+      "name": "strict_spacing_standard_format",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "value"
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key = value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_no_spaces",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key=value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key=value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_left_space_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key =value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key =value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_right_space_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key= value",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key= value"
+      ]
+    },
+    {
+      "name": "strict_spacing_rejects_tabs",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key\t=\tvalue",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "behaviors": [
+        "strict_spacing"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "inputs": [
+        "key\t=\tvalue"
+      ]
+    }
+  ]
+}


### PR DESCRIPTION
## Summary

Simplifies the CCL whitespace behavior model by:
- Moving `strict_spacing` tests to experimental (not part of core spec)
- Fixing `tabs_preserve` tests to use spaces for indentation
- Adding tests for tabs→spaces conversion in print/round_trip

## Whitespace Model Clarification

**Default behavior:**
- Whitespace = spaces + tabs
- Keys are fully trimmed (leading and trailing whitespace removed)
- Values have leading whitespace trimmed
- Tabs converted to single space in multiline continuation

**`tabs_preserve` behavior:**
- Whitespace = spaces only (tabs are content)
- Keys trimmed of spaces only; tabs in keys are preserved
- Values have leading spaces trimmed; leading tabs are preserved
- Tabs in multiline continuations preserved as-is

**`tabs_to_spaces` behavior (default):**
- Tabs converted to single space
- Both tabs-only and mixed space/tab indentation supported
- Print/round_trip outputs spaces instead of tabs

## Changes

- **Moved to experimental**: 5 `strict_spacing_*` tests
- **Kept in core**: All `loose_spacing_*` tests (default behavior)
- **Fixed**: `tabs_preserve_multiline`, `spaces_vs_tabs_continuation*` tests
- **Added**: 
  - `tabs_to_spaces_mixed_indent` - mixed space/tab indentation
  - `tabs_to_spaces_multiline_print` - canonical_format outputs spaces
  - `tabs_to_spaces_round_trip` - round trip converts tabs to spaces

## Test plan

- [x] `just validate` passes
- [x] `just reset` passes (409 tests, 247 skipped)
- [x] `just lint` passes

Resolves: #31, #32, #33
Related: #30 (generator bug in ccl-test-lib)