### PR TITLE
fix(generation): propagate conflicts field to generated flat format

### DIFF
--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -342,6 +342,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -381,6 +386,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },

--- a/generated_tests/api_core_ccl_integration.json
+++ b/generated_tests/api_core_ccl_integration.json
@@ -186,6 +186,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -247,6 +252,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {

--- a/generated_tests/api_core_ccl_parsing.json
+++ b/generated_tests/api_core_ccl_parsing.json
@@ -215,6 +215,11 @@
       "behaviors": [
         "toplevel_indent_strip"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_preserve"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -273,6 +278,11 @@
       "behaviors": [
         "toplevel_indent_preserve"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_strip"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -378,6 +378,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -405,6 +410,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -458,6 +468,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -485,6 +500,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [

--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -63,6 +63,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -230,6 +235,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 20,
         "list": [
@@ -312,6 +322,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -348,6 +363,12 @@
         "list_coercion_enabled",
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic",
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -415,6 +436,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -451,6 +477,12 @@
         "list_coercion_enabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -830,6 +862,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -866,6 +903,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -917,6 +959,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -953,6 +1000,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1005,6 +1057,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1040,6 +1097,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1093,6 +1155,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1128,6 +1195,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1180,6 +1252,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1222,6 +1299,11 @@
       "behaviors": [
         "array_order_insertion"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1273,6 +1355,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1315,6 +1402,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1473,6 +1565,11 @@
       "behaviors": [
         "list_coercion_disabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -129,6 +129,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 2,
         "list": [
@@ -275,6 +280,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "list": [
@@ -361,6 +371,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "list": [
@@ -442,6 +457,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "list": [
@@ -516,6 +536,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "list": [
@@ -607,6 +632,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "list": [
@@ -701,6 +731,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "list": [
@@ -799,6 +834,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "list": [
@@ -899,6 +939,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "list": [
@@ -995,6 +1040,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "list": [
@@ -1093,6 +1143,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1229,6 +1284,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "list": [
@@ -1305,6 +1365,11 @@
       "behaviors": [
         "list_coercion_enabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "list": [

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -55,6 +55,11 @@
       "behaviors": [
         "list_coercion_disabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -107,6 +112,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -137,6 +147,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -213,6 +229,11 @@
       "behaviors": [
         "list_coercion_disabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -338,6 +359,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -369,6 +395,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -423,6 +455,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -454,6 +491,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -510,6 +553,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -541,6 +589,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -599,6 +653,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -632,6 +691,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -684,6 +749,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -714,6 +784,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -733,6 +809,11 @@
       "behaviors": [
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -777,6 +858,12 @@
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },
@@ -846,6 +933,11 @@
       "behaviors": [
         "list_coercion_disabled"
       ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 0
       },

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -5,6 +5,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -32,6 +37,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -79,6 +89,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -129,6 +144,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -156,6 +176,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -203,6 +228,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -253,6 +283,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -280,6 +315,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -308,6 +348,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -336,6 +381,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -364,6 +414,11 @@
       "behaviors": [
         "tabs_as_content"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "key = \tvalue"
@@ -386,6 +441,11 @@
       "behaviors": [
         "tabs_as_whitespace"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "key = value"
@@ -409,6 +469,11 @@
         "tabs_as_whitespace",
         "indent_spaces"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "section =\n  indented\n  another"
@@ -498,6 +563,11 @@
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -552,6 +622,11 @@
       "behaviors": [
         "crlf_preserve_literal"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -583,6 +658,11 @@
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -611,6 +691,11 @@
       "behaviors": [
         "crlf_preserve_literal"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -639,6 +724,11 @@
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 3,
         "entries": [
@@ -674,6 +764,11 @@
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -727,6 +822,12 @@
         "tabs_as_whitespace",
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content",
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -755,6 +856,12 @@
         "tabs_as_content",
         "crlf_normalize_to_lf"
       ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace",
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [

--- a/generated_tests/property_round_trip.json
+++ b/generated_tests/property_round_trip.json
@@ -50,6 +50,11 @@
       "behaviors": [
         "toplevel_indent_strip"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_preserve"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -79,6 +84,11 @@
       "behaviors": [
         "toplevel_indent_strip"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_preserve"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": true
@@ -103,6 +113,11 @@
       "behaviors": [
         "toplevel_indent_preserve"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_strip"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -134,6 +149,11 @@
       "behaviors": [
         "toplevel_indent_preserve"
       ],
+      "conflicts": {
+        "behaviors": [
+          "toplevel_indent_strip"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": true

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -375,6 +375,7 @@ func (fg *FlatGenerator) convertToFlatFormat(test types.TestCase) generated.Gene
 	features := fg.convertFeatures(testFeatures)
 	variants := fg.convertVariants(testVariants)
 	functions := fg.convertFunctions(testFunctions)
+	conflicts := fg.convertConflicts(test.Conflicts)
 
 	// Create the flat test directly using the generated type
 	flatTest := generated.GeneratedFormatSimpleJsonTestsElem{
@@ -386,6 +387,7 @@ func (fg *FlatGenerator) convertToFlatFormat(test types.TestCase) generated.Gene
 		Features:   features,
 		Behaviors:  behaviors,
 		Variants:   variants,
+		Conflicts:  conflicts,
 		Args:       fg.getArgsForValidation(test.Validation, test.Args),
 		SourceTest: &test.SourceTest,
 	}
@@ -491,6 +493,18 @@ func (fg *FlatGenerator) convertFunctions(functions []string) []generated.Genera
 		result = append(result, generated.GeneratedFormatSimpleJsonTestsElemFunctionsElem(f))
 	}
 	return result
+}
+
+func (fg *FlatGenerator) convertConflicts(conflicts *types.ConflictSet) *generated.GeneratedFormatSimpleJsonTestsElemConflicts {
+	if conflicts == nil {
+		return nil
+	}
+	return &generated.GeneratedFormatSimpleJsonTestsElemConflicts{
+		Behaviors: conflicts.Behaviors,
+		Features:  conflicts.Features,
+		Functions: conflicts.Functions,
+		Variants:  conflicts.Variants,
+	}
 }
 
 // Helper functions


### PR DESCRIPTION
## Summary

Fixes the `conflicts` field not being propagated from source tests to the generated flat format.

## Changes

- Add `convertConflicts()` function in `generator/generator.go` to convert `*types.ConflictSet` to `*generated.GeneratedFormatSimpleJsonTestsElemConflicts`
- Include `Conflicts` field in the struct initialization within `convertToFlatFormat()`

## Impact

Implementations consuming the flat format can now use `conflicts` metadata for test filtering directly, without parsing the source format or duplicating conflict logic.

Fixes #49