### PR TITLE
fix(schema): add continuation baseline behaviors to config schema

### DIFF
--- a/ccl-config-schema.json
+++ b/ccl-config-schema.json
@@ -71,7 +71,9 @@
           "list_coercion_enabled",
           "list_coercion_disabled",
           "array_order_insertion",
-          "array_order_lexicographic"
+          "array_order_lexicographic",
+          "toplevel_indent_strip",
+          "toplevel_indent_preserve"
         ]
       }
     },


### PR DESCRIPTION
## Summary

- Adds `toplevel_indent_strip` and `toplevel_indent_preserve` behaviors to `ccl-config-schema.json`
- These behaviors were already present in `source-format.json` and `generated-format.json` but missing from the user-facing config schema
- Fixes consistency issue identified during documentation review

## Context

The config schema is used by implementations to declare their test runner capabilities. Without these behavior options, implementations couldn't properly declare their continuation baseline behavior choice.
