### PR TITLE
fix(generation): remove behaviorFunctionMap to restore self-contained source format

### DIFF
--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -316,7 +316,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -340,11 +349,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {

--- a/generated_tests/api_core_ccl_integration.json
+++ b/generated_tests/api_core_ccl_integration.json
@@ -156,7 +156,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -222,7 +229,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [

--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -2,7 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "tests": [
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "entries": [
@@ -33,7 +40,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -89,7 +103,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 20,
         "entries": [
@@ -188,7 +209,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -278,7 +306,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic",
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 5,
         "entries": [
@@ -320,11 +357,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_enabled",
         "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_lexicographic"
+          "array_order_lexicographic",
+          "list_coercion_disabled"
         ]
       },
       "expected": {
@@ -392,7 +431,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 5,
         "entries": [
@@ -434,11 +482,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_enabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_disabled"
         ]
       },
       "expected": {
@@ -834,7 +884,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -931,7 +988,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1028,7 +1092,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1126,7 +1197,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1224,7 +1302,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1327,7 +1412,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1513,7 +1605,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1536,7 +1635,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -65,7 +65,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 2,
         "entries": [
@@ -96,7 +103,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -227,7 +241,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -252,7 +273,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -306,7 +334,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "entries": [
@@ -339,7 +374,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -397,7 +439,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -422,7 +471,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -483,7 +539,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -508,7 +571,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -562,7 +632,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -599,7 +676,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -661,7 +745,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -698,7 +789,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -760,7 +858,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -799,7 +904,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -865,7 +977,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -904,7 +1023,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -970,7 +1096,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -1007,7 +1140,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1069,7 +1209,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -1108,7 +1255,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1173,7 +1327,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 11,
         "entries": [
@@ -1238,7 +1399,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1312,7 +1480,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -1337,7 +1512,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_disabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -2,7 +2,14 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "tests": [
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -27,7 +34,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -78,7 +92,16 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "entries": [
@@ -110,11 +133,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -169,7 +194,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -194,7 +226,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -321,7 +360,16 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -357,11 +405,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -417,7 +467,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -453,11 +512,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -513,7 +574,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -551,11 +621,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -613,7 +685,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 4,
         "entries": [
@@ -651,11 +732,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -715,7 +798,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_insertion",
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 3,
         "entries": [
@@ -747,11 +839,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -807,11 +901,13 @@
     },
     {
       "behaviors": [
+        "list_coercion_disabled",
         "array_order_lexicographic"
       ],
       "conflicts": {
         "behaviors": [
-          "array_order_insertion"
+          "array_order_insertion",
+          "list_coercion_enabled"
         ]
       },
       "expected": {
@@ -880,7 +976,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -905,7 +1008,14 @@
       ]
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "list_coercion_enabled"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {

--- a/generated_tests/api_typed_access.json
+++ b/generated_tests/api_typed_access.json
@@ -142,7 +142,10 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -167,7 +170,10 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -215,7 +221,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -240,7 +248,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -287,7 +297,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -312,7 +324,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -358,7 +372,10 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -383,7 +400,10 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -565,7 +585,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 3,
         "entries": [
@@ -599,7 +621,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -627,7 +651,9 @@
       "args": [
         "count"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": 0
@@ -677,7 +703,9 @@
       "args": [
         "distance"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": 0
@@ -698,7 +726,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 3,
         "entries": [
@@ -732,7 +762,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -760,7 +792,9 @@
       "args": [
         "count"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 0
@@ -809,7 +843,9 @@
       "args": [
         "distance"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 0
@@ -830,7 +866,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 7,
         "entries": [
@@ -879,7 +917,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -910,7 +950,9 @@
       "args": [
         "flag3"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": 1
@@ -955,7 +997,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 7,
         "entries": [
@@ -1004,7 +1048,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -1035,7 +1081,9 @@
       "args": [
         "flag3"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 1
@@ -1079,7 +1127,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 5,
         "entries": [
@@ -1120,7 +1170,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -1149,7 +1201,9 @@
       "args": [
         "host"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": "localhost"
@@ -1172,7 +1226,9 @@
       "args": [
         "port"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": 8080
@@ -1220,7 +1276,9 @@
       "args": [
         "timeout"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 1,
         "value": 30.5
@@ -1240,7 +1298,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 5,
         "entries": [
@@ -1281,7 +1341,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -1310,7 +1372,9 @@
       "args": [
         "host"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": "localhost"
@@ -1333,7 +1397,9 @@
       "args": [
         "port"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 8080
@@ -1381,7 +1447,9 @@
       "args": [
         "timeout"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 30.5
@@ -1749,7 +1817,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -1774,7 +1844,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -1883,7 +1955,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -1936,7 +2010,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -1989,7 +2065,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_lenient"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -2042,7 +2120,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -2074,7 +2154,9 @@
       "args": [
         "one"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "value": 1
@@ -2118,7 +2200,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -2243,7 +2327,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -2364,7 +2450,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "boolean_strict"
+      ],
       "expected": {
         "count": 1,
         "entries": [

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -66,7 +66,14 @@
       "args": [
         "key"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "tabs_as_content"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "\tvalue\twith\ttabs"
@@ -121,7 +128,14 @@
       "args": [
         "key"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "tabs_as_content"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_whitespace"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "\tindented"
@@ -205,7 +219,14 @@
       "args": [
         "key"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "tabs_as_whitespace"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "value with tabs"
@@ -260,7 +281,14 @@
       "args": [
         "key"
       ],
-      "behaviors": [],
+      "behaviors": [
+        "tabs_as_whitespace"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "indented"
@@ -494,7 +522,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "tabs_as_whitespace"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "tabs_as_content"
+        ]
+      },
       "expected": {
         "count": 1,
         "value": "key = value with tabs"
@@ -596,7 +631,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -793,7 +835,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {

--- a/go_tests/parsing/api_advanced_processing_test.go
+++ b/go_tests/parsing/api_advanced_processing_test.go
@@ -2,29 +2,34 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_advanced_processing.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // composition_stability_duplicate_keys_parse - function:parse
 func TestCompositionStabilityDuplicateKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a = 1
 b = 2
 b = 20
 c = 3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -33,18 +38,22 @@ c = 3`
 
 }
 
+
 // multiple_values_same_key_parse - function:parse
 func TestMultipleValuesSameKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 8000
 ports = 8001
 ports = 8002`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -53,18 +62,22 @@ ports = 8002`
 
 }
 
+
 // list_with_empty_keys_parse - function:parse feature:empty_keys
 func TestListWithEmptyKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= 3
 = 1
 = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -73,16 +86,20 @@ func TestListWithEmptyKeysParse(t *testing.T) {
 
 }
 
+
 // section_style_syntax_parse - function:parse feature:empty_keys
 func TestSectionStyleSyntaxParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Section 2 ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -91,19 +108,23 @@ func TestSectionStyleSyntaxParse(t *testing.T) {
 
 }
 
+
 // composition_stability_ba_parse - function:parse
 func TestCompositionStabilityBaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `b = 20
 c = 3
 a = 1
 b = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -112,19 +133,23 @@ b = 2`
 
 }
 
+
 // mixed_keys_with_duplicates_parse - function:parse feature:empty_keys
 func TestMixedKeysWithDuplicatesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = app
 ports = 8000
 name = service
 ports = 8001`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -133,18 +158,22 @@ ports = 8001`
 
 }
 
+
 // array_style_list_parse - function:parse feature:empty_keys
 func TestArrayStyleListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `1 =
 2 =
 3 =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -153,18 +182,22 @@ func TestArrayStyleListParse(t *testing.T) {
 
 }
 
+
 // section_header_double_equals_parse - function:parse feature:empty_keys
 func TestSectionHeaderDoubleEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config ==
 host = localhost
 port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -173,18 +206,22 @@ port = 5432`
 
 }
 
+
 // section_header_triple_equals_parse - function:parse feature:empty_keys
 func TestSectionHeaderTripleEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `=== Server Settings ===
 host = 0.0.0.0
 ssl = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -193,8 +230,10 @@ ssl = true`
 
 }
 
+
 // multiple_sections_with_entries_parse - function:parse feature:empty_keys
 func TestMultipleSectionsWithEntriesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database ==
@@ -205,11 +244,13 @@ redis = enabled
 
 == Logging ==
 level = info`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -218,8 +259,10 @@ level = info`
 
 }
 
+
 // section_headers_mixed_with_lists_parse - function:parse feature:empty_keys
 func TestSectionHeadersMixedWithListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Configuration ==
@@ -228,11 +271,13 @@ func TestSectionHeadersMixedWithListsParse(t *testing.T) {
 key = value
 === Next Section ===
 other = data`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -241,16 +286,20 @@ other = data`
 
 }
 
+
 // empty_section_header_only_parse - function:parse
 func TestEmptySectionHeaderOnlyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Empty Section ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -259,17 +308,21 @@ func TestEmptySectionHeaderOnlyParse(t *testing.T) {
 
 }
 
+
 // section_header_at_end_parse - function:parse feature:empty_keys
 func TestSectionHeaderAtEndParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 == Final Section ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -278,19 +331,23 @@ func TestSectionHeaderAtEndParse(t *testing.T) {
 
 }
 
+
 // section_headers_no_trailing_equals_parse - function:parse feature:empty_keys
 func TestSectionHeadersNoTrailingEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config
 host = localhost
 === Server Settings
 port = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -299,19 +356,23 @@ port = 8080`
 
 }
 
+
 // section_headers_with_colons_parse - function:parse feature:empty_keys
 func TestSectionHeadersWithColonsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database: Production ==
 host = db.prod.com
 === Cache: Redis Config ===
 port = 6379`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -320,19 +381,23 @@ port = 6379`
 
 }
 
+
 // spaced_equals_not_section_header_parse - function:parse feature:empty_keys
 func TestSpacedEqualsNotSectionHeaderParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= = spaced equals
 =  = wide spaces
 == Real Header ==
 key = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -341,19 +406,23 @@ key = value`
 
 }
 
+
 // consecutive_section_headers_parse - function:parse feature:empty_keys
 func TestConsecutiveSectionHeadersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== First Section ==
 === Nested Section ===
 ==== Deep Section ====
 key = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -361,3 +430,5 @@ key = value`
 	assert.Equal(t, expected, parseResult)
 
 }
+
+

--- a/go_tests/parsing/api_comments_test.go
+++ b/go_tests/parsing/api_comments_test.go
@@ -2,18 +2,21 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_comments.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // comment_extension_parse - function:parse feature:comments
 func TestCommentExtensionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= This is an environment section
@@ -22,11 +25,13 @@ serve = index.html
 /= Database section
 mode = in-memory
 connections = 16`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -35,21 +40,46 @@ connections = 16`
 
 }
 
+
 // comment_extension_filter - function:filter feature:comments
 func TestCommentExtensionFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is an environment section
+port = 8080
+serve = index.html
+/= Database section
+mode = in-memory
+connections = 16`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // comment_syntax_slash_equals_parse - function:parse feature:comments
 func TestCommentSyntaxSlashEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= this is a comment`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -58,13 +88,31 @@ func TestCommentSyntaxSlashEqualsParse(t *testing.T) {
 
 }
 
+
 // comment_syntax_slash_equals_filter - function:filter feature:comments
 func TestCommentSyntaxSlashEqualsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= this is a comment`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // section_headers_with_comments_parse - function:parse feature:comments feature:empty_keys
 func TestSectionHeadersWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config ==
@@ -73,11 +121,13 @@ host = localhost
 === Cache Config ===
 /= Redis configuration
 port = 6379`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -86,7 +136,30 @@ port = 6379`
 
 }
 
+
 // section_headers_with_comments_filter - function:filter feature:comments feature:empty_keys
 func TestSectionHeadersWithCommentsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Database Config ==
+/= Connection settings
+host = localhost
+=== Cache Config ===
+/= Redis configuration
+port = 6379`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -2,27 +2,32 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_hierarchy.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_object_construction_parse - function:parse
 func TestBasicObjectConstructionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,13 +36,34 @@ age = 42`
 
 }
 
+
 // basic_object_construction_build_hierarchy - function:build_hierarchy
 func TestBasicObjectConstructionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // deep_nested_objects_parse - function:parse
 func TestDeepNestedObjectsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `server =
@@ -46,11 +72,13 @@ func TestDeepNestedObjectsParse(t *testing.T) {
     port = 5432
   cache =
     enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -59,23 +87,50 @@ func TestDeepNestedObjectsParse(t *testing.T) {
 
 }
 
+
 // deep_nested_objects_build_hierarchy - function:build_hierarchy
 func TestDeepNestedObjectsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": map[string]interface{}{"cache": map[string]interface{}{"enabled": "true"}, "database": map[string]interface{}{"host": "localhost", "port": "5432"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // duplicate_keys_to_lists_parse - function:parse
 func TestDuplicateKeysToListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = first
 item = second
 item = third`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,24 +139,48 @@ item = third`
 
 }
 
+
 // duplicate_keys_to_lists_build_hierarchy - function:build_hierarchy
 func TestDuplicateKeysToListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second
+item = third`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": []interface{}{"first", "second", "third"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_duplicate_keys_parse - function:parse
 func TestNestedDuplicateKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   server = web1
   server = web2
   port = 80`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -110,13 +189,36 @@ func TestNestedDuplicateKeysParse(t *testing.T) {
 
 }
 
+
 // nested_duplicate_keys_build_hierarchy - function:build_hierarchy
 func TestNestedDuplicateKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1
+  server = web2
+  port = 80`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_flat_and_nested_parse - function:parse
 func TestMixedFlatAndNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
@@ -124,11 +226,13 @@ config =
   debug = true
   timeout = 30
 version = 1.0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -137,13 +241,37 @@ version = 1.0`
 
 }
 
+
 // mixed_flat_and_nested_build_hierarchy - function:build_hierarchy
 func TestMixedFlatAndNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+  debug = true
+  timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "timeout": "30"}, "name": "Alice", "version": "1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_objects_with_lists_parse - function:parse
 func TestNestedObjectsWithListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `environments =
@@ -154,11 +282,13 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
   dev =
     server = localhost
     port = 3000`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -167,13 +297,40 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
 
 }
 
+
 // nested_objects_with_lists_build_hierarchy - function:build_hierarchy
 func TestNestedObjectsWithListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `environments =
+  prod =
+    server = web1
+    server = web2
+    port = 80
+  dev =
+    server = localhost
+    port = 3000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"environments": map[string]interface{}{"dev": map[string]interface{}{"port": "3000", "server": "localhost"}, "prod": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// deeply_nested_list_parse - function:parse
+
+// deeply_nested_list_parse - function:parse behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -182,11 +339,13 @@ func TestDeeplyNestedListParse(t *testing.T) {
       servers = web1
       servers = web2
       servers = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -195,12 +354,64 @@ func TestDeeplyNestedListParse(t *testing.T) {
 
 }
 
-// deeply_nested_list_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// deeply_nested_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": []interface{}{"api1", "web1", "web2"}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // deeply_nested_list_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -2,27 +2,32 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_integration.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // complete_basic_workflow_parse - function:parse
 func TestCompleteBasicWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,24 +36,47 @@ age = 42`
 
 }
 
+
 // complete_basic_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteBasicWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_nested_workflow_parse - function:parse
 func TestCompleteNestedWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   host = localhost
   port = 5432
   enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -57,13 +85,36 @@ func TestCompleteNestedWorkflowParse(t *testing.T) {
 
 }
 
+
 // complete_nested_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteNestedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"enabled": "true", "host": "localhost", "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_mixed_workflow_parse - function:parse
 func TestCompleteMixedWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app = MyApp
@@ -73,11 +124,13 @@ config =
   features =
     feature1 = enabled
     feature2 = disabled`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -86,13 +139,39 @@ config =
 
 }
 
+
 // complete_mixed_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteMixedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app = MyApp
+version = 1.0.0
+config =
+  debug = true
+  features =
+    feature1 = enabled
+    feature2 = disabled`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"app": "MyApp", "config": map[string]interface{}{"debug": "true", "features": map[string]interface{}{"feature1": "enabled", "feature2": "disabled"}}, "version": "1.0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// complete_lists_workflow_parse - function:parse
+
+// complete_lists_workflow_parse - function:parse behavior:array_order_insertion
 func TestCompleteListsWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
@@ -102,11 +181,13 @@ func TestCompleteListsWorkflowParse(t *testing.T) {
 ports =
   port = 80
   port = 443`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -114,14 +195,11 @@ ports =
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // complete_lists_workflow_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestCompleteListsWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// complete_lists_workflow_lexicographic_parse - function:parse
-func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
@@ -131,11 +209,42 @@ func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
 ports =
   port = 80
   port = 443`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"80", "443"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// complete_lists_workflow_lexicographic_parse - function:parse behavior:array_order_lexicographic
+func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -144,13 +253,39 @@ ports =
 
 }
 
+
 // complete_lists_workflow_lexicographic_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestCompleteListsWorkflowLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"443", "80"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_multiline_workflow_parse - function:parse feature:multiline
 func TestCompleteMultilineWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `description = Welcome to our app
@@ -160,11 +295,13 @@ config =
   settings =
     value1 = one
     value2 = two`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -173,13 +310,39 @@ config =
 
 }
 
+
 // complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = Welcome to our app
+  This is a multi-line description
+  With several lines
+config =
+  settings =
+    value1 = one
+    value2 = two`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"settings": map[string]interface{}{"value1": "one", "value2": "two"}}, "description": "Welcome to our app\n  This is a multi-line description\n  With several lines"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // real_world_complete_workflow_parse - function:parse
 func TestRealWorldCompleteWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `service = MyMicroservice
@@ -203,11 +366,13 @@ features =
   feature_a = enabled
   feature_b = disabled
   feature_c = experimental`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -216,7 +381,47 @@ features =
 
 }
 
+
 // real_world_complete_workflow_build_hierarchy - function:build_hierarchy
 func TestRealWorldCompleteWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `service = MyMicroservice
+version = 2.1.0
+database =
+  host = db.example.com
+  port = 5432
+  credentials =
+    user = service_user
+    password = secret123
+  pools =
+    read = 5
+    write = 2
+logging =
+  level = info
+  outputs =
+    output = console
+    output = file
+    output = syslog
+features =
+  feature_a = enabled
+  feature_b = disabled
+  feature_c = experimental`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"credentials": map[string]interface{}{"password": "secret123", "user": "service_user"}, "host": "db.example.com", "pools": map[string]interface{}{"read": "5", "write": "2"}, "port": "5432"}, "features": map[string]interface{}{"feature_a": "enabled", "feature_b": "disabled", "feature_c": "experimental"}, "logging": map[string]interface{}{"level": "info", "outputs": map[string]interface{}{"output": []interface{}{"console", "file", "syslog"}}}, "service": "MyMicroservice", "version": "2.1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -2,27 +2,32 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_parsing.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_key_value_pairs_parse - function:parse
 func TestBasicKeyValuePairsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,17 +36,21 @@ age = 42`
 
 }
 
+
 // equals_in_values_parse - function:parse
 func TestEqualsInValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `msg = k=v pairs work fine
 path = /bin/app=prod`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -50,17 +59,21 @@ path = /bin/app=prod`
 
 }
 
+
 // whitespace_trimming_parse - function:parse feature:whitespace
 func TestWhitespaceTrimmingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key   =    value with spaces   
 other = normal`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -69,19 +82,23 @@ other = normal`
 
 }
 
+
 // multiline_values_parse - function:parse feature:multiline
 func TestMultilineValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `description = First line
   Second line
   Third line
 done = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -90,17 +107,21 @@ done = yes`
 
 }
 
+
 // empty_values_parse - function:parse feature:empty_keys
 func TestEmptyValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty =
 other = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -109,18 +130,22 @@ other = value`
 
 }
 
+
 // nested_structure_parsing_parse - function:parse
 func TestNestedStructureParsingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   host = localhost
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -129,17 +154,21 @@ func TestNestedStructureParsingParse(t *testing.T) {
 
 }
 
+
 // unicode_parsing_parse - function:parse feature:unicode
 func TestUnicodeParsingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `emoji = 😀😃😄
 配置 = config`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -148,16 +177,20 @@ func TestUnicodeParsingParse(t *testing.T) {
 
 }
 
+
 // empty_input_parse - function:parse
 func TestEmptyInputParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ""
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -166,17 +199,21 @@ func TestEmptyInputParse(t *testing.T) {
 
 }
 
+
 // leading_whitespace_baseline_zero_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
 func TestLeadingWhitespaceBaselineZeroParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key = value
   second`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -185,17 +222,21 @@ func TestLeadingWhitespaceBaselineZeroParse(t *testing.T) {
 
 }
 
+
 // leading_whitespace_multiple_entries_parse - function:parse feature:whitespace
 func TestLeadingWhitespaceMultipleEntriesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key1 = value1
 key2 = value2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -204,7 +245,27 @@ key2 = value2`
 
 }
 
+
 // leading_whitespace_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestLeadingWhitespaceToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key = value
+  second = entry`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "second", Value: "entry"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
+

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -2,26 +2,31 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_edge_cases.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_single_no_spaces_parse - function:parse
 func TestBasicSingleNoSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key=val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -29,17 +34,21 @@ func TestBasicSingleNoSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // basic_with_spaces_parse - function:parse feature:whitespace
 func TestBasicWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -47,22 +56,42 @@ func TestBasicWithSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // indented_key_parse_indented - function:parse_indented feature:whitespace
 func TestIndentedKeyParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  key = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // value_trailing_spaces_parse - function:parse feature:whitespace
 func TestValueTrailingSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -70,17 +99,21 @@ func TestValueTrailingSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // key_value_surrounded_spaces_parse - function:parse feature:whitespace
 func TestKeyValueSurroundedSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -89,18 +122,22 @@ func TestKeyValueSurroundedSpacesParse(t *testing.T) {
 
 }
 
+
 // surrounded_by_newlines_parse - function:parse
 func TestSurroundedByNewlinesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
 key = val
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -109,16 +146,20 @@ key = val
 
 }
 
+
 // key_empty_value_parse - function:parse feature:empty_keys
 func TestKeyEmptyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -127,17 +168,21 @@ func TestKeyEmptyValueParse(t *testing.T) {
 
 }
 
+
 // empty_value_with_newline_parse - function:parse feature:empty_keys
 func TestEmptyValueWithNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -145,17 +190,21 @@ func TestEmptyValueWithNewlineParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // empty_value_with_spaces_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -164,22 +213,42 @@ func TestEmptyValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // empty_key_indented_parse_indented - function:parse_indented feature:empty_keys
 func TestEmptyKeyIndentedParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // empty_key_with_newline_parse - function:parse feature:empty_keys
 func TestEmptyKeyWithNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
   = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -188,16 +257,20 @@ func TestEmptyKeyWithNewlineParse(t *testing.T) {
 
 }
 
+
 // empty_key_value_with_spaces_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyKeyValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  =  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -206,16 +279,20 @@ func TestEmptyKeyValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // equals_in_value_no_spaces_parse - function:parse
 func TestEqualsInValueNoSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a=b=c`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -224,16 +301,20 @@ func TestEqualsInValueNoSpacesParse(t *testing.T) {
 
 }
 
+
 // equals_in_value_with_spaces_parse - function:parse feature:whitespace
 func TestEqualsInValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a = b = c`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -242,17 +323,21 @@ func TestEqualsInValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // multiple_key_value_pairs_parse - function:parse
 func TestMultipleKeyValuePairsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key1 = val1
 key2 = val2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -261,26 +346,64 @@ key2 = val2`
 
 }
 
+
 // key_with_tabs_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestKeyWithTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // key_with_tabs_ocaml_reference_parse - function:parse feature:whitespace behavior:tabs_as_content variant:reference_compliant
 func TestKeyWithTabsOcamlReferenceParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // whitespace_only_value_parse - function:parse feature:empty_keys feature:whitespace
 func TestWhitespaceOnlyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `onlyspaces =     `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -289,26 +412,66 @@ func TestWhitespaceOnlyValueParse(t *testing.T) {
 
 }
 
+
 // spaces_vs_tabs_continuation_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // spaces_vs_tabs_continuation_ocaml_reference_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationOcamlReferenceParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // multiple_empty_equality_parse - function:parse feature:empty_keys feature:whitespace
 func TestMultipleEmptyEqualityParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ` =  = `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -317,18 +480,22 @@ func TestMultipleEmptyEqualityParse(t *testing.T) {
 
 }
 
+
 // key_with_newline_before_equals_parse - function:parse feature:empty_keys feature:whitespace
 func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key 
 = val
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -337,19 +504,23 @@ func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 
 }
 
+
 // complex_multi_newline_whitespace_parse - function:parse feature:empty_keys feature:whitespace
 func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  
  key  
 =  val  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -358,17 +529,21 @@ func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
 
 }
 
+
 // empty_value_with_trailing_spaces_newline_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyValueWithTrailingSpacesNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -377,18 +552,22 @@ func TestEmptyValueWithTrailingSpacesNewlineParse(t *testing.T) {
 
 }
 
+
 // empty_key_value_with_surrounding_newlines_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyKeyValueWithSurroundingNewlinesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
   =  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -397,16 +576,20 @@ func TestEmptyKeyValueWithSurroundingNewlinesParse(t *testing.T) {
 
 }
 
+
 // quotes_treated_as_literal_unquoted_parse - function:parse
 func TestQuotesTreatedAsLiteralUnquotedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -415,16 +598,20 @@ func TestQuotesTreatedAsLiteralUnquotedParse(t *testing.T) {
 
 }
 
+
 // quotes_treated_as_literal_quoted_parse - function:parse
 func TestQuotesTreatedAsLiteralQuotedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = "localhost"`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -433,17 +620,21 @@ func TestQuotesTreatedAsLiteralQuotedParse(t *testing.T) {
 
 }
 
+
 // nested_single_line_parse - function:parse
 func TestNestedSingleLineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
   val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -452,18 +643,22 @@ func TestNestedSingleLineParse(t *testing.T) {
 
 }
 
+
 // nested_multi_line_parse - function:parse feature:multiline
 func TestNestedMultiLineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
   line1
   line2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -472,29 +667,72 @@ func TestNestedMultiLineParse(t *testing.T) {
 
 }
 
+
 // nested_with_blank_line_parse_indented - function:parse_indented feature:multiline
 func TestNestedWithBlankLineParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  line1
+
+  line2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deep_nested_structure_parse_indented - function:parse_indented
 func TestDeepNestedStructureParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  field1 = value1
+  field2 =
+    subfield = x
+    another = y`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // realistic_stress_test_parse - function:parse
 func TestRealisticStressTestParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Dmitrii Kovanikov
 login = chshersh
 language = OCaml
 date = 2024-05-25`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -503,8 +741,10 @@ date = 2024-05-25`
 
 }
 
+
 // ocaml_stress_test_original_parse - function:parse feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= This is a CCL document
@@ -526,11 +766,13 @@ user =
 user =
   login = chshersh
   createdAt = 2024-12-31`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -539,12 +781,87 @@ user =
 
 }
 
+
 // ocaml_stress_test_original_build_hierarchy - function:build_hierarchy feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": "This is a CCL document", "database": map[string]interface{}{"enabled": "true", "limits": map[string]interface{}{"cpu": "1500mi", "memory": "10Gb"}, "ports": map[string]interface{}{"": []interface{}{"8000", "8001", "8002"}}}, "title": "CCL Example", "user": map[string]interface{}{"createdAt": "2024-12-31", "guestId": "42", "login": "chshersh"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // ocaml_stress_test_original_get_string - function:get_string feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"title"})
+	require.NoError(t, err)
+	assert.Equal(t, "CCL Example", result)
+
 }
+
+

--- a/go_tests/parsing/api_errors_test.go
+++ b/go_tests/parsing/api_errors_test.go
@@ -2,26 +2,31 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_errors.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // just_key_error_parse - function:parse
 func TestJustKeyErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -29,17 +34,21 @@ func TestJustKeyErrorParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // whitespace_only_error_parse - function:parse feature:whitespace
 func TestWhitespaceOnlyErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -47,17 +56,21 @@ func TestWhitespaceOnlyErrorParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // whitespace_only_error_ocaml_reference_parse - function:parse feature:whitespace
 func TestWhitespaceOnlyErrorOcamlReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -65,17 +78,21 @@ func TestWhitespaceOnlyErrorOcamlReferenceParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // just_string_error_parse - function:parse
 func TestJustStringErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,17 +101,21 @@ func TestJustStringErrorParse(t *testing.T) {
 
 }
 
+
 // multiline_plain_error_parse - function:parse feature:multiline
 func TestMultilinePlainErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `val
   next`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -103,18 +124,22 @@ func TestMultilinePlainErrorParse(t *testing.T) {
 
 }
 
+
 // multiline_plain_nested_error_parse - function:parse feature:multiline
 func TestMultilinePlainNestedErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
 val
   next`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -122,3 +147,5 @@ val
 	assert.Equal(t, expected, parseResult)
 
 }
+
+

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -2,28 +2,33 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_list_access.json
 // Suite: Flat Format
 // Version: 1.0
 
-// basic_list_from_duplicates_parse - function:parse
+
+
+// basic_list_from_duplicates_parse - function:parse behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
 servers = web2
 servers = web3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -32,18 +37,61 @@ servers = web3`
 
 }
 
-// basic_list_from_duplicates_build_hierarchy - function:build_hierarchy
+
+// basic_list_from_duplicates_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // basic_list_from_duplicates_get_list - function:get_list behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
-// large_list_parse - function:parse
+
+// large_list_parse - function:parse behavior:list_coercion_enabled
 func TestLargeListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items = item01
@@ -66,11 +114,13 @@ items = item17
 items = item18
 items = item19
 items = item20`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -79,18 +129,95 @@ items = item20`
 
 }
 
-// large_list_build_hierarchy - function:build_hierarchy
+
+// large_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled
 func TestLargeListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // large_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestLargeListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}, result)
+
 }
 
-// list_with_comments_parse - function:parse feature:comments
+
+// list_with_comments_parse - function:parse feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
@@ -98,11 +225,13 @@ func TestListWithCommentsParse(t *testing.T) {
 servers = web2
 servers = web3
 /= End of list`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -111,18 +240,37 @@ servers = web3
 
 }
 
-// list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_insertion
+
+// list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"Production servers", "End of list"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_comments_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// list_with_comments_lexicographic_parse - function:parse feature:comments
-func TestListWithCommentsLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
@@ -130,11 +278,41 @@ func TestListWithCommentsLexicographicParse(t *testing.T) {
 servers = web2
 servers = web3
 /= End of list`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
 
+}
+
+
+// list_with_comments_lexicographic_parse - function:parse feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
+func TestListWithCommentsLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -143,26 +321,75 @@ servers = web3
 
 }
 
-// list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_lexicographic
+
+// list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"End of list", "Production servers"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_comments_lexicographic_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
+
 
 // list_error_missing_key_parse - function:parse
 func TestListErrorMissingKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `existing = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -171,27 +398,71 @@ func TestListErrorMissingKeyParse(t *testing.T) {
 
 }
 
+
 // list_error_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_missing_key_get_list - function:get_list
 func TestListErrorMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_error_nested_missing_key_parse - function:parse
 func TestListErrorNestedMissingKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   server = web1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -200,26 +471,72 @@ func TestListErrorNestedMissingKeyParse(t *testing.T) {
 
 }
 
+
 // list_error_nested_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorNestedMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"server": "web1"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_nested_missing_key_get_list - function:get_list
 func TestListErrorNestedMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_error_non_object_path_parse - function:parse
 func TestListErrorNonObjectPathParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `value = simple`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,26 +545,70 @@ func TestListErrorNonObjectPathParse(t *testing.T) {
 
 }
 
+
 // list_error_non_object_path_build_hierarchy - function:build_hierarchy
 func TestListErrorNonObjectPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"value": "simple"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_non_object_path_get_list - function:get_list
 func TestListErrorNonObjectPathGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"value", "nested"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_edge_case_zero_length_parse - function:parse
 func TestListEdgeCaseZeroLengthParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ""
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -256,29 +617,73 @@ func TestListEdgeCaseZeroLengthParse(t *testing.T) {
 
 }
 
+
 // list_edge_case_zero_length_build_hierarchy - function:build_hierarchy
 func TestListEdgeCaseZeroLengthBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_edge_case_zero_length_get_list - function:get_list
 func TestListEdgeCaseZeroLengthGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"nonexistent"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // bare_list_basic_parse - function:parse feature:empty_keys
 func TestBareListBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
   = web1
   = web2
   = web3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -287,18 +692,63 @@ func TestBareListBasicParse(t *testing.T) {
 
 }
 
+
 // bare_list_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_basic_get_list - function:get_list feature:empty_keys
 func TestBareListBasicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
-// bare_list_nested_parse - function:parse feature:empty_keys
+
+// bare_list_nested_parse - function:parse feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `network =
@@ -306,11 +756,13 @@ func TestBareListNestedParse(t *testing.T) {
     = 80
     = 443
     = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,19 +770,11 @@ func TestBareListNestedParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
-func TestBareListNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys
-func TestBareListNestedLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `network =
@@ -338,11 +782,68 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
     = 80
     = 443
     = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"80", "443", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+func TestBareListNestedGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"80", "443", "8080"}, result)
+
+}
+
+
+// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys behavior:array_order_lexicographic
+func TestBareListNestedLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -351,18 +852,65 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"443", "80", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"443", "80", "8080"}, result)
+
 }
 
-// bare_list_with_comments_parse - function:parse feature:empty_keys feature:comments
+
+// bare_list_with_comments_parse - function:parse feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `allowed_hosts =
@@ -370,11 +918,13 @@ func TestBareListWithCommentsParse(t *testing.T) {
   = localhost
   = 127.0.0.1
   = example.com`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -382,19 +932,11 @@ func TestBareListWithCommentsParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_with_comments_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
-func TestBareListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_with_comments_lexicographic_parse - function:parse feature:empty_keys feature:comments
-func TestBareListWithCommentsLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `allowed_hosts =
@@ -402,11 +944,68 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
   = localhost
   = 127.0.0.1
   = example.com`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"localhost", "127.0.0.1", "example.com"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
+func TestBareListWithCommentsGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost", "127.0.0.1", "example.com"}, result)
+
+}
+
+
+// bare_list_with_comments_lexicographic_parse - function:parse feature:empty_keys feature:comments behavior:array_order_lexicographic
+func TestBareListWithCommentsLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -415,18 +1014,65 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"127.0.0.1", "example.com", "localhost"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_with_comments_lexicographic_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"127.0.0.1", "example.com", "localhost"}, result)
+
 }
 
-// bare_list_deeply_nested_parse - function:parse feature:empty_keys
+
+// bare_list_deeply_nested_parse - function:parse feature:empty_keys behavior:array_order_insertion
 func TestBareListDeeplyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -436,11 +1082,13 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
         = web1
         = web2
         = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -448,19 +1096,11 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
-func TestBareListDeeplyNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys
-func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -470,11 +1110,72 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
         = web1
         = web2
         = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "api1"}}}}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+func TestBareListDeeplyNestedGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "api1"}, result)
+
+}
+
+
+// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys behavior:array_order_lexicographic
+func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -483,18 +1184,69 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"api1", "web1", "web2"}}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_deeply_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"api1", "web1", "web2"}, result)
+
 }
+
 
 // bare_list_mixed_with_other_keys_parse - function:parse feature:empty_keys
 func TestBareListMixedWithOtherKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
@@ -503,11 +1255,13 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
   replicas =
     = replica1
     = replica2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,27 +1270,78 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 
 }
 
+
 // bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"host": "localhost", "port": "5432", "replicas": map[string]interface{}{"": []interface{}{"replica1", "replica2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys
 func TestBareListMixedWithOtherKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "replicas"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"replica1", "replica2"}, result)
+
 }
 
-// bare_list_error_not_a_list_parse - function:parse
+
+// bare_list_error_not_a_list_parse - function:parse behavior:list_coercion_disabled
 func TestBareListErrorNotAListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   setting = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -545,12 +1350,56 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 
 }
 
-// bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy
+
+// bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"setting": "value"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_error_not_a_list_get_list - function:get_list behavior:list_coercion_disabled
 func TestBareListErrorNotAListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "setting"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
+

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -2,61 +2,203 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_proposed_behavior.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // multiline_section_header_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline variant:proposed_behavior
 func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+  This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // unindented_multiline_becomes_continuation_parse_indented - function:parse_indented feature:empty_keys variant:proposed_behavior
 func TestUnindentedMultilineBecomesContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
-// indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline variant:proposed_behavior
+
+// indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
-// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline variant:proposed_behavior
+
+// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line\n  second line", "Another item"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line\n  second line", "Another item"}, result)
+
 }
+
 
 // mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline feature:empty_keys variant:proposed_behavior
 func TestMixedIndentationLevelsParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline feature:empty_keys variant:proposed_behavior
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1\n  indented continuation", "key2": "value2", "not indented key": map[string]interface{}{"indented for not indented": ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// single_item_as_list_parse - function:parse variant:proposed_behavior
+
+// single_item_as_list_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestSingleItemAsListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = single`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -65,28 +207,69 @@ func TestSingleItemAsListParse(t *testing.T) {
 
 }
 
-// single_item_as_list_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// single_item_as_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestSingleItemAsListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // single_item_as_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestSingleItemAsListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"single"}, result)
+
 }
 
-// mixed_duplicate_single_keys_parse - function:parse variant:proposed_behavior
+
+// mixed_duplicate_single_keys_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestMixedDuplicateSingleKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 80
 ports = 443
 host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -95,29 +278,74 @@ host = localhost`
 
 }
 
-// mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"80", "443"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost"}, result)
+
 }
 
-// nested_list_access_parse - function:parse variant:proposed_behavior
+
+// nested_list_access_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestNestedListAccessParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   hosts = primary
   hosts = secondary
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -126,26 +354,73 @@ func TestNestedListAccessParse(t *testing.T) {
 
 }
 
-// nested_list_access_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// nested_list_access_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestNestedListAccessBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_list_access_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestNestedListAccessGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"5432"}, result)
+
 }
 
-// empty_list_parse - function:parse variant:proposed_behavior
+
+// empty_list_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestEmptyListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_list =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -154,29 +429,70 @@ func TestEmptyListParse(t *testing.T) {
 
 }
 
-// empty_list_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// empty_list_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestEmptyListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // empty_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestEmptyListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{""}, result)
+
 }
 
-// list_with_numbers_parse - function:parse variant:proposed_behavior
+
+// list_with_numbers_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithNumbersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `numbers = 1
 numbers = 42
 numbers = -17
 numbers = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -185,29 +501,76 @@ numbers = 0`
 
 }
 
-// list_with_numbers_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// list_with_numbers_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"1", "42", "-17", "0"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithNumbersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"1", "42", "-17", "0"}, result)
+
 }
 
-// list_with_booleans_parse - function:parse variant:proposed_behavior
+
+// list_with_booleans_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithBooleansParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flags = true
 flags = false
 flags = yes
 flags = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -216,29 +579,76 @@ flags = no`
 
 }
 
-// list_with_booleans_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// list_with_booleans_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"true", "false", "yes", "no"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithBooleansGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"true", "false", "yes", "no"}, result)
+
 }
 
-// list_with_whitespace_parse - function:parse feature:whitespace variant:proposed_behavior
+
+// list_with_whitespace_parse - function:parse feature:whitespace behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =   spaced   
 items = normal
 items =
 items =   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -247,29 +657,76 @@ items =   `
 
 }
 
-// list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace variant:proposed_behavior
+
+// list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"spaced", "normal", "", ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithWhitespaceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"spaced", "normal", "", ""}, result)
+
 }
 
-// list_with_unicode_parse - function:parse feature:unicode variant:proposed_behavior
+
+// list_with_unicode_parse - function:parse feature:unicode behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithUnicodeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `names = 张三
 names = José
 names = François
 names = العربية`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -278,29 +735,76 @@ names = العربية`
 
 }
 
-// list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode variant:proposed_behavior
+
+// list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"张三", "José", "François", "العربية"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithUnicodeGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"张三", "José", "François", "العربية"}, result)
+
 }
 
-// list_with_special_characters_parse - function:parse variant:proposed_behavior
+
+// list_with_special_characters_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithSpecialCharactersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `symbols = @#$%
 symbols = !^&*()
 symbols = []{}|
 symbols = <>=+`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -309,56 +813,248 @@ symbols = <>=+`
 
 }
 
-// list_with_special_characters_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// list_with_special_characters_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"@#$%", "!^&*()", "[]{}|", "<>=+"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithSpecialCharactersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"@#$%", "!^&*()", "[]{}|", "<>=+"}, result)
+
 }
 
-// list_multiline_values_parse_indented - function:parse_indented feature:multiline variant:proposed_behavior
+
+// list_multiline_values_parse_indented - function:parse_indented feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestListMultilineValuesParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
-// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline variant:proposed_behavior
+
+// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line", "Another item", "Third item"}, "second line": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestListMultilineValuesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line", "Another item", "Third item"}, result)
+
 }
 
-// complex_mixed_list_scenarios_parse_indented - function:parse_indented variant:proposed_behavior
+
+// complex_mixed_list_scenarios_parse_indented - function:parse_indented behavior:list_coercion_enabled variant:proposed_behavior
 func TestComplexMixedListScenariosParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
-// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"primary", "backup"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"auth", "api", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complex_mixed_list_scenarios_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestComplexMixedListScenariosGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"auth", "api", "ui"}, result)
+
 }
 
-// list_path_traversal_protection_parse - function:parse variant:proposed_behavior
+
+// list_path_traversal_protection_parse - function:parse behavior:list_coercion_enabled variant:proposed_behavior
 func TestListPathTraversalProtectionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `safe = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -367,26 +1063,67 @@ func TestListPathTraversalProtectionParse(t *testing.T) {
 
 }
 
-// list_path_traversal_protection_build_hierarchy - function:build_hierarchy variant:proposed_behavior
+
+// list_path_traversal_protection_build_hierarchy - function:build_hierarchy behavior:list_coercion_enabled variant:proposed_behavior
 func TestListPathTraversalProtectionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_path_traversal_protection_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListPathTraversalProtectionGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"value"}, result)
+
 }
+
 
 // parse_empty_value_parse - function:parse variant:proposed_behavior
 func TestParseEmptyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -395,12 +1132,51 @@ func TestParseEmptyValueParse(t *testing.T) {
 
 }
 
+
 // parse_empty_value_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestParseEmptyValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_empty_value_get_string - function:get_string variant:proposed_behavior
 func TestParseEmptyValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"empty_key"})
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+
 }
+
+

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -2,26 +2,31 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_reference_compliant.json
 // Suite: Flat Format
 // Version: 1.0
 
-// single_item_as_list_reference_parse - function:parse variant:reference_compliant
+
+
+// single_item_as_list_reference_parse - function:parse behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = single`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,28 +35,72 @@ func TestSingleItemAsListReferenceParse(t *testing.T) {
 
 }
 
-// single_item_as_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+
+// single_item_as_list_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // single_item_as_list_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// mixed_duplicate_single_keys_reference_parse - function:parse
+
+// mixed_duplicate_single_keys_reference_parse - function:parse behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 80
 ports = 443
 host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -60,29 +109,77 @@ host = localhost`
 
 }
 
-// mixed_duplicate_single_keys_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// mixed_duplicate_single_keys_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"443", "80"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_duplicate_single_keys_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// nested_list_access_reference_parse - function:parse variant:reference_compliant
+
+// nested_list_access_reference_parse - function:parse behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   hosts = primary
   hosts = secondary
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -91,26 +188,76 @@ func TestNestedListAccessReferenceParse(t *testing.T) {
 
 }
 
-// nested_list_access_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+
+// nested_list_access_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_list_access_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // empty_list_reference_parse - function:parse variant:reference_compliant
 func TestEmptyListReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_list =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -119,29 +266,73 @@ func TestEmptyListReferenceParse(t *testing.T) {
 
 }
 
+
 // empty_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // empty_list_reference_get_list - function:get_list variant:reference_compliant
 func TestEmptyListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_with_numbers_reference_parse - function:parse
+
+// list_with_numbers_reference_parse - function:parse behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `numbers = 1
 numbers = 42
 numbers = -17
 numbers = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -150,29 +341,79 @@ numbers = 0`
 
 }
 
-// list_with_numbers_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// list_with_numbers_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"-17", "0", "1", "42"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_numbers_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_with_booleans_reference_parse - function:parse
+
+// list_with_booleans_reference_parse - function:parse behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithBooleansReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flags = true
 flags = false
 flags = yes
 flags = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -181,29 +422,79 @@ flags = no`
 
 }
 
-// list_with_booleans_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// list_with_booleans_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithBooleansReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"false", "no", "true", "yes"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_booleans_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithBooleansReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_with_whitespace_reference_parse - function:parse feature:whitespace
+
+// list_with_whitespace_reference_parse - function:parse feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =   spaced   
 items = normal
 items =
 items =   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -212,29 +503,79 @@ items =   `
 
 }
 
-// list_with_whitespace_reference_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_lexicographic
+
+// list_with_whitespace_reference_build_hierarchy - function:build_hierarchy feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"normal", "spaced"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_whitespace_reference_get_list - function:get_list feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_with_unicode_reference_parse - function:parse feature:unicode
+
+// list_with_unicode_reference_parse - function:parse feature:unicode behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `names = 张三
 names = José
 names = François
 names = العربية`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -243,28 +584,78 @@ names = العربية`
 
 }
 
-// list_with_unicode_reference_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_lexicographic
+
+// list_with_unicode_reference_build_hierarchy - function:build_hierarchy feature:unicode behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"François", "José", "العربية", "张三"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_unicode_reference_get_list - function:get_list feature:unicode behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_with_special_characters_reference_parse - function:parse
+
+// list_with_special_characters_reference_parse - function:parse behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `symbols = @#$%
 symbols = !^&*()
 symbols = []{}|`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -273,36 +664,144 @@ symbols = []{}|`
 
 }
 
-// list_with_special_characters_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// list_with_special_characters_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"!^&*()", "@#$%", "[]{}|"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_special_characters_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+
+// complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"backup", "primary"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"api", "auth", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complex_mixed_list_scenarios_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
-// list_path_traversal_protection_reference_parse - function:parse variant:reference_compliant
+
+// list_path_traversal_protection_reference_parse - function:parse behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `safe = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -311,26 +810,70 @@ func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
 
 }
 
-// list_path_traversal_protection_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+
+// list_path_traversal_protection_reference_build_hierarchy - function:build_hierarchy behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_path_traversal_protection_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // empty_value_reference_behavior_parse - function:parse variant:reference_compliant
 func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -339,42 +882,180 @@ func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
 
 }
 
+
 // empty_value_reference_behavior_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyValueReferenceBehaviorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // canonical_format_empty_values_ocaml_reference_canonical_format - function:canonical_format variant:reference_compliant
 func TestCanonicalFormatEmptyValuesOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_tab_preservation_ocaml_reference_canonical_format - function:canonical_format behavior:tabs_as_content variant:reference_compliant
 func TestCanonicalFormatTabPreservationOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value_with_tabs = text		with	tabs	`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_unicode_ocaml_reference_canonical_format - function:canonical_format feature:unicode variant:reference_compliant
 func TestCanonicalFormatUnicodeOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `unicode = 你好世界
+emo = 🌟✨`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_line_endings_reference_behavior_parse - function:parse behavior:crlf_preserve_literal variant:reference_compliant
 func TestCanonicalFormatLineEndingsReferenceBehaviorParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // canonical_format_line_endings_reference_behavior_canonical_format - function:canonical_format behavior:crlf_preserve_literal variant:reference_compliant
 func TestCanonicalFormatLineEndingsReferenceBehaviorCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_consistent_spacing_ocaml_reference_canonical_format - function:canonical_format variant:reference_compliant
 func TestCanonicalFormatConsistentSpacingOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1=value1
+key2  =  value2
+key3	=	value3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deterministic_output_ocaml_reference_canonical_format - function:canonical_format variant:reference_compliant
 func TestDeterministicOutputOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `z = last
+a = first
+m = middle`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -2,26 +2,31 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_typed_access.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // parse_basic_integer_parse - function:parse feature:optional_typed_accessors
 func TestParseBasicIntegerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `port = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,26 +35,67 @@ func TestParseBasicIntegerParse(t *testing.T) {
 
 }
 
+
 // parse_basic_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "8080"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_basic_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBasicIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
+
 
 // parse_basic_float_parse - function:parse feature:optional_typed_accessors
 func TestParseBasicFloatParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `temperature = 98.6`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -58,26 +104,67 @@ func TestParseBasicFloatParse(t *testing.T) {
 
 }
 
+
 // parse_basic_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicFloatBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "98.6"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_basic_float_get_float - function:get_float feature:optional_typed_accessors
 func TestParseBasicFloatGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	require.NoError(t, err)
+	assert.Equal(t, 98.6, result)
+
 }
 
-// parse_boolean_true_parse - function:parse feature:optional_typed_accessors
+
+// parse_boolean_true_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -86,26 +173,67 @@ func TestParseBooleanTrueParse(t *testing.T) {
 
 }
 
-// parse_boolean_true_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_true_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "true"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_true_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
-// parse_boolean_yes_parse - function:parse feature:optional_typed_accessors
+
+// parse_boolean_yes_parse - function:parse feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanYesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `active = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -114,26 +242,67 @@ func TestParseBooleanYesParse(t *testing.T) {
 
 }
 
-// parse_boolean_yes_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_yes_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanYesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_yes_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanYesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_yes_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `active = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 
+}
+
+
+// parse_boolean_yes_strict_literal_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
+func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -142,26 +311,70 @@ func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
 
 }
 
-// parse_boolean_yes_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_yes_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanYesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_yes_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanYesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// parse_boolean_false_parse - function:parse feature:optional_typed_accessors
+
+// parse_boolean_false_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanFalseParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `disabled = false`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -170,26 +383,67 @@ func TestParseBooleanFalseParse(t *testing.T) {
 
 }
 
-// parse_boolean_false_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_false_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanFalseBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"disabled": "false"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_false_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanFalseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
+
 
 // parse_string_fallback_parse - function:parse
 func TestParseStringFallbackParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -198,26 +452,67 @@ func TestParseStringFallbackParse(t *testing.T) {
 
 }
 
+
 // parse_string_fallback_build_hierarchy - function:build_hierarchy
 func TestParseStringFallbackBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_string_fallback_get_string - function:get_string
 func TestParseStringFallbackGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", result)
+
 }
+
 
 // parse_negative_integer_parse - function:parse feature:optional_typed_accessors
 func TestParseNegativeIntegerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `offset = -42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -226,28 +521,69 @@ func TestParseNegativeIntegerParse(t *testing.T) {
 
 }
 
+
 // parse_negative_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseNegativeIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"offset": "-42"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_negative_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseNegativeIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"offset"})
+	require.NoError(t, err)
+	assert.Equal(t, -42, result)
+
 }
 
-// parse_zero_values_parse - function:parse feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_parse - function:parse feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseZeroValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `count = 0
 distance = 0.0
 disabled = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -256,38 +592,125 @@ disabled = no`
 
 }
 
-// parse_zero_values_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseZeroValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_zero_values_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseZeroValuesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
+
 
 // parse_zero_values_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseZeroValuesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
-func TestParseZeroValuesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_strict_literal_parse - function:parse feature:empty_keys feature:optional_typed_accessors
-func TestParseZeroValuesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `count = 0
 distance = 0.0
 disabled = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
 
+}
+
+
+// parse_zero_values_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseZeroValuesGetFloat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
+}
+
+
+// parse_zero_values_strict_literal_parse - function:parse feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
+func TestParseZeroValuesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -296,28 +719,116 @@ disabled = no`
 
 }
 
-// parse_zero_values_strict_literal_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_strict_literal_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_zero_values_strict_literal_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_strict_literal_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
+
 
 // parse_zero_values_strict_literal_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// parse_zero_values_strict_literal_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
+
+// parse_zero_values_strict_literal_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
 
-// parse_boolean_variants_parse - function:parse feature:optional_typed_accessors
+
+// parse_boolean_variants_parse - function:parse feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanVariantsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag1 = yes
@@ -327,11 +838,13 @@ flag4 = false
 flag5 = no
 flag6 = off
 flag7 = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -340,23 +853,69 @@ flag7 = 0`
 
 }
 
-// parse_boolean_variants_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_variants_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanVariantsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors
+
+// parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanVariantsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
+
 
 // parse_boolean_variants_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanVariantsGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_variants_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseBooleanVariantsStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag1 = yes
@@ -366,11 +925,43 @@ flag4 = false
 flag5 = no
 flag6 = off
 flag7 = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 
+}
+
+
+// parse_boolean_variants_strict_literal_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
+func TestParseBooleanVariantsStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -379,23 +970,102 @@ flag7 = 0`
 
 }
 
-// parse_boolean_variants_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_variants_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanVariantsStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_boolean_variants_strict_literal_get_int - function:get_int feature:optional_typed_accessors
+
+// parse_boolean_variants_strict_literal_get_int - function:get_int feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanVariantsStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
+
 
 // parse_boolean_variants_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanVariantsStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// parse_mixed_types_parse - function:parse feature:optional_typed_accessors
+
+// parse_mixed_types_parse - function:parse feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost
@@ -403,11 +1073,13 @@ port = 8080
 ssl = true
 timeout = 30.5
 debug = off`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -416,33 +1088,93 @@ debug = off`
 
 }
 
-// parse_mixed_types_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_mixed_types_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_mixed_types_get_string - function:get_string feature:optional_typed_accessors
+
+// parse_mixed_types_get_string - function:get_string feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
 }
 
-// parse_mixed_types_get_int - function:get_int feature:optional_typed_accessors
+
+// parse_mixed_types_get_int - function:get_int feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
+
 
 // parse_mixed_types_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_get_float - function:get_float feature:optional_typed_accessors
-func TestParseMixedTypesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseMixedTypesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost
@@ -450,11 +1182,69 @@ port = 8080
 ssl = true
 timeout = 30.5
 debug = off`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
 
+}
+
+
+// parse_mixed_types_get_float - function:get_float feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseMixedTypesGetFloat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
+}
+
+
+// parse_mixed_types_strict_literal_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
+func TestParseMixedTypesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -463,42 +1253,160 @@ debug = off`
 
 }
 
-// parse_mixed_types_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_mixed_types_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// parse_mixed_types_strict_literal_get_string - function:get_string feature:optional_typed_accessors
+
+// parse_mixed_types_strict_literal_get_string - function:get_string feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
 }
 
-// parse_mixed_types_strict_literal_get_int - function:get_int feature:optional_typed_accessors
+
+// parse_mixed_types_strict_literal_get_int - function:get_int feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
+
 
 // parse_mixed_types_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
-// parse_mixed_types_strict_literal_get_float - function:get_float feature:optional_typed_accessors
+
+// parse_mixed_types_strict_literal_get_float - function:get_float feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
 }
+
 
 // parse_with_whitespace_parse - function:parse feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number =   42   
 flag =  true  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -507,34 +1415,97 @@ flag =  true  `
 
 }
 
+
 // parse_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag": "true", "number": "42"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_with_whitespace_get_int - function:get_int feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
+
 
 // parse_with_whitespace_get_bool - function:get_bool feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // parse_with_conservative_options_parse - function:parse feature:optional_typed_accessors
 func TestParseWithConservativeOptionsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number = 42
 decimal = 3.14
 flag = true
 text = hello`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -543,31 +1514,100 @@ text = hello`
 
 }
 
+
 // parse_with_conservative_options_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseWithConservativeOptionsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"decimal": "3.14", "flag": "true", "number": "42", "text": "hello"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_with_conservative_options_get_string - function:get_string feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"decimal"})
+	require.NoError(t, err)
+	assert.Equal(t, "3.14", result)
+
 }
+
 
 // parse_with_conservative_options_get_int - function:get_int feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
+
 
 // parse_integer_error_parse - function:parse feature:optional_typed_accessors
 func TestParseIntegerErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `port = not_a_number`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -576,26 +1616,70 @@ func TestParseIntegerErrorParse(t *testing.T) {
 
 }
 
+
 // parse_integer_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseIntegerErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "not_a_number"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_integer_error_get_int - function:get_int feature:optional_typed_accessors
 func TestParseIntegerErrorGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
+
 
 // parse_float_error_parse - function:parse feature:optional_typed_accessors
 func TestParseFloatErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `temperature = invalid`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -604,26 +1688,70 @@ func TestParseFloatErrorParse(t *testing.T) {
 
 }
 
+
 // parse_float_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseFloatErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "invalid"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_float_error_get_float - function:get_float feature:optional_typed_accessors
 func TestParseFloatErrorGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
 
-// parse_boolean_error_parse - function:parse feature:optional_typed_accessors
+
+// parse_boolean_error_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `enabled = maybe`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -632,26 +1760,70 @@ func TestParseBooleanErrorParse(t *testing.T) {
 
 }
 
-// parse_boolean_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+
+// parse_boolean_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "maybe"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // parse_missing_path_error_parse - function:parse
 func TestParseMissingPathErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `existing = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,27 +1832,71 @@ func TestParseMissingPathErrorParse(t *testing.T) {
 
 }
 
+
 // parse_missing_path_error_build_hierarchy - function:build_hierarchy
 func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_missing_path_error_get_string - function:get_string
 func TestParseMissingPathErrorGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, "", result)
+	}
+
 }
 
-// boolean_case_sensitivity_uppercase_parse - function:parse feature:optional_typed_accessors
+
+// boolean_case_sensitivity_uppercase_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityUppercaseParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `upper_true = TRUE
 upper_false = FALSE`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -689,22 +1905,49 @@ upper_false = FALSE`
 
 }
 
+
 // boolean_case_sensitivity_uppercase_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityUppercaseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_true = TRUE
+upper_false = FALSE`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// boolean_case_sensitivity_mixed_parse - function:parse feature:optional_typed_accessors
+
+// boolean_case_sensitivity_mixed_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityMixedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `mixed_true = True
 mixed_false = False`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -713,22 +1956,49 @@ mixed_false = False`
 
 }
 
+
 // boolean_case_sensitivity_mixed_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityMixedGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mixed_true = True
+mixed_false = False`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"mixed_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// boolean_lenient_uppercase_yes_no_parse - function:parse feature:optional_typed_accessors
+
+// boolean_lenient_uppercase_yes_no_parse - function:parse feature:optional_typed_accessors behavior:boolean_lenient
 func TestBooleanLenientUppercaseYesNoParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `upper_yes = YES
 upper_no = NO`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -737,22 +2007,49 @@ upper_no = NO`
 
 }
 
+
 // boolean_lenient_uppercase_yes_no_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestBooleanLenientUppercaseYesNoGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_yes = YES
+upper_no = NO`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_yes"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// boolean_numeric_one_zero_strict_parse - function:parse feature:optional_typed_accessors
+
+// boolean_numeric_one_zero_strict_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanNumericOneZeroStrictParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `one = 1
 zero = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -761,26 +2058,73 @@ zero = 0`
 
 }
 
-// boolean_numeric_one_zero_strict_get_int - function:get_int feature:optional_typed_accessors
+
+// boolean_numeric_one_zero_strict_get_int - function:get_int feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanNumericOneZeroStrictGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
+
 
 // boolean_numeric_one_zero_strict_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanNumericOneZeroStrictGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"one"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
-// boolean_with_whitespace_parse - function:parse feature:optional_typed_accessors feature:whitespace
+
+// boolean_with_whitespace_parse - function:parse feature:optional_typed_accessors feature:whitespace behavior:boolean_strict
 func TestBooleanWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `padded =   true   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -789,26 +2133,70 @@ func TestBooleanWithWhitespaceParse(t *testing.T) {
 
 }
 
+
 // boolean_with_whitespace_get_bool - function:get_bool feature:optional_typed_accessors feature:whitespace behavior:boolean_strict
 func TestBooleanWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `padded =   true   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"padded"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // boolean_nested_object_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  debug = true
+  verbose = false
+  experimental = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "experimental": "yes", "verbose": "false"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // type_mismatch_get_int_on_bool_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -817,21 +2205,47 @@ func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_int_on_bool_get_int - function:get_int feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
 
-// type_mismatch_get_bool_on_int_parse - function:parse feature:optional_typed_accessors
+
+// type_mismatch_get_bool_on_int_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -840,21 +2254,47 @@ func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_bool_on_int_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestTypeMismatchGetBoolOnIntGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"number"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // type_mismatch_get_float_on_bool_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag = false`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -863,26 +2303,72 @@ func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_float_on_bool_get_float - function:get_float feature:optional_typed_accessors
 func TestTypeMismatchGetFloatOnBoolGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
+
 
 // type_mismatch_nested_path_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  name = test
+  count = abc`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"count": "abc", "name": "test"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// boolean_empty_value_error_parse - function:parse feature:optional_typed_accessors
+
+// boolean_empty_value_error_parse - function:parse feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanEmptyValueErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -891,7 +2377,31 @@ func TestBooleanEmptyValueErrorParse(t *testing.T) {
 
 }
 
+
 // boolean_empty_value_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanEmptyValueErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"empty"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
+

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -2,126 +2,494 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_whitespace_behaviors.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // tabs_as_content_in_value_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_as_content_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "\tvalue\twith\ttabs"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// tabs_as_content_in_value_get_string - function:get_string feature:whitespace
+
+// tabs_as_content_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tvalue\twith\ttabs", result)
+
 }
+
 
 // tabs_as_content_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tindented"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
-// tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace
+
+// tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tindented", result)
+
 }
+
 
 // tabs_as_whitespace_in_value_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value with tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "value with tabs"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
-// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace
+
+// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "value with tabs", result)
+
 }
+
 
 // tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "indented"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
-// tabs_as_whitespace_leading_tab_get_string - function:get_string feature:whitespace
+
+// tabs_as_whitespace_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "indented", result)
+
 }
+
 
 // tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 			three_tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "three_tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_content
 func TestTabsAsContentMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	indented_with_tabs
+ 	another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\n \tindented_with_tabs\n \tanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented_with_tabs
+		another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nindented_with_tabs\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	mixed_indent
+	 another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nmixed_indent\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // tabs_canonical_format_as_content_canonical_format - function:canonical_format feature:whitespace behavior:tabs_as_content
 func TestTabsCanonicalFormatAsContentCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // tabs_canonical_format_as_whitespace_canonical_format - function:canonical_format feature:whitespace behavior:tabs_as_whitespace
 func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // tabs_as_whitespace_multiline_print_canonical_format - function:canonical_format feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_spaces
 func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented
+		another`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
-// tabs_as_whitespace_round_trip_round_trip - function:round_trip feature:whitespace
+
+// tabs_as_whitespace_round_trip_round_trip - function:round_trip feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceRoundTripRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // nested_bare_list_indentation_canonical_format - function:canonical_format feature:empty_keys feature:whitespace behavior:indent_spaces
 func TestNestedBareListIndentationCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `package =
+  = brew
+  = scoop
+  = nix`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deeply_nested_bare_list_indentation_canonical_format - function:canonical_format feature:empty_keys feature:whitespace behavior:indent_spaces
 func TestDeeplyNestedBareListIndentationCanonicalFormat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app =
+  = item1
+  config =
+    = nested1
+    = nested2
+    deep =
+      = level3a
+      = level3b
+  = item2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // crlf_normalize_to_lf_basic_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "key1 = value1\r\nkey2 = value2\r\n"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -130,26 +498,65 @@ func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
 
 }
 
-// crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace
+
+// crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1", "key2": "value2"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // crlf_preserve_literal_basic_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // crlf_normalize_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "multiline =\r\n  line1\r\n  line2"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -158,21 +565,42 @@ func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
 
 }
 
+
 // crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_preserve_literal
 func TestCrlfPreserveMultilineValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "multiline =\r\n  line1\r\n  line2"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "multiline", Value: "\r\n  line1\r\n  line2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // crlf_mixed_line_endings_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfMixedLineEndingsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -181,16 +609,20 @@ func TestCrlfMixedLineEndingsParse(t *testing.T) {
 
 }
 
+
 // crlf_nested_structure_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "config =\r\n  host = localhost\r\n  port = 8080"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -199,17 +631,71 @@ func TestCrlfNestedStructureParse(t *testing.T) {
 
 }
 
-// crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace
+
+// crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"host": "localhost", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_as_whitespace behavior:crlf_normalize_to_lf
 func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := "key = \tvalue\twith\ttabs\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value with tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // behavior_combo_content_tabs_crlf_parse - function:parse feature:whitespace behavior:tabs_as_content behavior:crlf_normalize_to_lf
 func TestBehaviorComboContentTabsCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "\tvalue1"}, mock.Entry{Key: "key2", Value: "\tvalue2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
+

--- a/go_tests/parsing/property_algebraic_test.go
+++ b/go_tests/parsing/property_algebraic_test.go
@@ -2,72 +2,275 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/property_algebraic.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // semigroup_associativity_basic_compose_associative - function:compose_associative
 func TestSemigroupAssociativityBasicComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `a = 1`
+	input1 := `b = 2`
+	input2 := `c = 3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // semigroup_associativity_nested_compose_associative - function:compose_associative
 func TestSemigroupAssociativityNestedComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  host = localhost`
+	input1 := `config =
+  port = 8080`
+	input2 := `db =
+  name = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // semigroup_associativity_lists_compose_associative - function:compose_associative feature:empty_keys
 func TestSemigroupAssociativityListsComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1`
+	input1 := `= item2`
+	input2 := `= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_basic_identity_left - function:identity_left
 func TestMonoidLeftIdentityBasicIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_basic_identity_right - function:identity_right
 func TestMonoidRightIdentityBasicIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `key = value
+nested =
+  sub = val`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_nested_identity_left - function:identity_left
 func TestMonoidLeftIdentityNestedIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_nested_identity_right - function:identity_right
 func TestMonoidRightIdentityNestedIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_lists_identity_left - function:identity_left feature:empty_keys
 func TestMonoidLeftIdentityListsIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `= item1
+= item2
+= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_lists_identity_right - function:identity_right feature:empty_keys
 func TestMonoidRightIdentityListsIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1
+= item2
+= item3`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_property_basic_parse - function:parse
 func TestRoundTripPropertyBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 another = test`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -76,13 +279,32 @@ another = test`
 
 }
 
+
 // round_trip_property_basic_round_trip - function:round_trip
 func TestRoundTripPropertyBasicRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = value
+another = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_property_nested_parse - function:parse
 func TestRoundTripPropertyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -91,11 +313,13 @@ func TestRoundTripPropertyNestedParse(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -104,13 +328,36 @@ func TestRoundTripPropertyNestedParse(t *testing.T) {
 
 }
 
+
 // round_trip_property_nested_round_trip - function:round_trip
 func TestRoundTripPropertyNestedRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_property_complex_parse - function:parse feature:empty_keys
 func TestRoundTripPropertyComplexParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
@@ -123,11 +370,13 @@ config =
     = b
     = c
 final = end`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -136,7 +385,34 @@ final = end`
 
 }
 
+
 // round_trip_property_complex_round_trip - function:round_trip feature:empty_keys
 func TestRoundTripPropertyComplexRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+config =
+  nested =
+    deep = value
+  list =
+    = a
+    = b
+    = c
+final = end`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -2,28 +2,33 @@ package parsing_test
 
 import (
 	"testing"
-
+	
+	"github.com/tylerbutler/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/property_round_trip.json
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // round_trip_basic_parse - function:parse
 func TestRoundTripBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 nested =
   sub = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -32,23 +37,45 @@ nested =
 
 }
 
+
 // round_trip_basic_round_trip - function:round_trip
 func TestRoundTripBasicRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_whitespace_normalization_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  value  
   nested  = 
     sub  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -57,33 +84,92 @@ func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
 
 }
 
+
 // round_trip_whitespace_normalization_round_trip - function:round_trip feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_whitespace_normalization_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "nested", Value: "\n    sub  =  val"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip - function:round_trip feature:whitespace behavior:toplevel_indent_preserve
 func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_empty_keys_lists_parse - function:parse feature:empty_keys
 func TestRoundTripEmptyKeysListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
 = item2
 regular = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -92,13 +178,33 @@ regular = value`
 
 }
 
+
 // round_trip_empty_keys_lists_round_trip - function:round_trip feature:empty_keys
 func TestRoundTripEmptyKeysListsRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+regular = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_nested_structures_parse - function:parse
 func TestRoundTripNestedStructuresParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -107,11 +213,13 @@ func TestRoundTripNestedStructuresParse(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -120,24 +228,49 @@ func TestRoundTripNestedStructuresParse(t *testing.T) {
 
 }
 
+
 // round_trip_nested_structures_round_trip - function:round_trip
 func TestRoundTripNestedStructuresRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_multiline_values_parse - function:parse feature:multiline
 func TestRoundTripMultilineValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `script =
   #!/bin/bash
   echo hello
   exit 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -146,13 +279,34 @@ func TestRoundTripMultilineValuesParse(t *testing.T) {
 
 }
 
+
 // round_trip_multiline_values_round_trip - function:round_trip feature:multiline
 func TestRoundTripMultilineValuesRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `script =
+  #!/bin/bash
+  echo hello
+  exit 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_mixed_content_parse - function:parse feature:empty_keys
 func TestRoundTripMixedContentParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
@@ -161,11 +315,13 @@ config =
   port = 3000
 = second item
 final = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -174,13 +330,36 @@ final = value`
 
 }
 
+
 // round_trip_mixed_content_round_trip - function:round_trip feature:empty_keys
 func TestRoundTripMixedContentRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+= first item
+config =
+  port = 3000
+= second item
+final = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_complex_nesting_parse - function:parse feature:empty_keys
 func TestRoundTripComplexNestingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app =
@@ -191,11 +370,13 @@ func TestRoundTripComplexNestingParse(t *testing.T) {
       host = localhost
       = db_item
   = item2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -204,13 +385,38 @@ func TestRoundTripComplexNestingParse(t *testing.T) {
 
 }
 
+
 // round_trip_complex_nesting_round_trip - function:round_trip feature:empty_keys
 func TestRoundTripComplexNestingRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app =
+  = item1
+  config =
+    = nested_item
+    db =
+      host = localhost
+      = db_item
+  = item2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_deeply_nested_parse - function:parse feature:empty_keys
 func TestRoundTripDeeplyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `level1 =
@@ -219,11 +425,13 @@ func TestRoundTripDeeplyNestedParse(t *testing.T) {
       level4 =
         deep = value
         = deep_item`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -232,23 +440,48 @@ func TestRoundTripDeeplyNestedParse(t *testing.T) {
 
 }
 
+
 // round_trip_deeply_nested_round_trip - function:round_trip feature:empty_keys
 func TestRoundTripDeeplyNestedRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `level1 =
+  level2 =
+    level3 =
+      level4 =
+        deep = value
+        = deep_item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_empty_multiline_parse - function:parse feature:empty_keys feature:multiline
 func TestRoundTripEmptyMultilineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_section =
 
 other = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -257,7 +490,27 @@ other = value`
 
 }
 
+
 // round_trip_empty_multiline_round_trip - function:round_trip feature:empty_keys feature:multiline
 func TestRoundTripEmptyMultilineRoundTrip(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_section =
+
+other = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -711,23 +711,13 @@ func (g *Generator) generateFlatBuildHierarchyValidation(test types.TestCase) (s
 		}
 	}
 
-	// Handle normal case with object result
-	if object, ok := expectedMap["object"]; ok {
-		return fmt.Sprintf(`// BuildHierarchy validation
+	// Handle normal case with object result (already extracted by loader)
+	return fmt.Sprintf(`// BuildHierarchy validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
 	objectResult := ccl.BuildHierarchy(parseResult)
 	expected := %s
-	assert.Equal(t, expected, objectResult)`, formatGoValue(object)), nil
-	} else {
-		// Handle case with only count (empty result)
-		return `// BuildHierarchy validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	objectResult := ccl.BuildHierarchy(parseResult)
-	expected := map[string]interface{}{}
-	assert.Equal(t, expected, objectResult)`, nil
-	}
+	assert.Equal(t, expected, objectResult)`, formatGoValue(expectedMap)), nil
 }
 
 // generateFlatTypedAccessValidation generates typed access validation for flat format


### PR DESCRIPTION
## Summary

Removes the `behaviorFunctionMap` from the generator that was incorrectly filtering behaviors and conflicts during source-to-flat format conversion. The source test format is designed to be self-contained, with test authors explicitly declaring exactly which behaviors and conflicts apply to each test case. The filtering logic was overriding these explicit declarations and causing misattribution of behaviors to wrong tests.

## Changes

- **generator/generator.go**: Replaced `filterBehaviorsForFunction` and `filterConflictsForFunction` with simple `copyStringSlice` and `copyConflictSet` functions that preserve source test metadata exactly as authored
- **internal/generator/templates.go**: Simplified `build_hierarchy` template generation to pass the full expected map directly instead of extracting a nested "object" key
- **generated_tests/**: Regenerated all flat test files reflecting the corrected behavior/conflict propagation
- **go_tests/**: Regenerated all Go test files