### PR TITLE
chore: update repository URLs to catconflang org

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -136,7 +136,7 @@ Tests are organized by the CCL functions they validate. Implement the functions 
 
 - **Build tool**: `just` (justfile)
 - **Go version**: 1.25.1
-- **Module**: `github.com/tylerbutler/ccl-test-data`
+- **Module**: `github.com/catconflang/ccl-test-data`
 
 ## Shared Test Infrastructure
 
@@ -153,9 +153,9 @@ types/      # Unified data structures for test suites
 
 ```go
 import (
-    "github.com/tylerbutler/ccl-test-data/config"
-    "github.com/tylerbutler/ccl-test-data/loader"
-    "github.com/tylerbutler/ccl-test-data/types"
+    "github.com/catconflang/ccl-test-data/config"
+    "github.com/catconflang/ccl-test-data/loader"
+    "github.com/catconflang/ccl-test-data/types"
 )
 
 // Declare capabilities
@@ -179,7 +179,7 @@ tests, _ := testLoader.LoadAllTests(loader.LoadOptions{
 
 **Note:** These packages were consolidated from the deprecated `ccl-test-lib` repository. For local development, use a `replace` directive in your `go.mod`:
 ```
-replace github.com/tylerbutler/ccl-test-data => ../ccl-test-data
+replace github.com/catconflang/ccl-test-data => ../ccl-test-data
 ```
 
 ## Before Committing

--- a/README.md
+++ b/README.md
@@ -6,11 +6,11 @@ Language-agnostic JSON test suite for [CCL (Categorical Configuration Language)]
 
 ## Quick Start
 
-Download test files from [GitHub Releases](https://github.com/tylerbutler/ccl-test-data/releases) or use the generated flat format directly.
+Download test files from [GitHub Releases](https://github.com/catconflang/ccl-test-data/releases) or use the generated flat format directly.
 
 ```bash
 # Clone for development
-git clone https://github.com/tylerbutler/ccl-test-data.git
+git clone https://github.com/catconflang/ccl-test-data.git
 cd ccl-test-data
 ```
 
@@ -81,8 +81,8 @@ For Go implementations, import the test infrastructure directly:
 
 ```go
 import (
-    "github.com/tylerbutler/ccl-test-data/config"
-    "github.com/tylerbutler/ccl-test-data/loader"
+    "github.com/catconflang/ccl-test-data/config"
+    "github.com/catconflang/ccl-test-data/loader"
 )
 
 cfg := config.ImplementationConfig{

--- a/ccl.go
+++ b/ccl.go
@@ -3,9 +3,9 @@
 package ccl_test_data
 
 import (
-	"github.com/tylerbutler/ccl-test-data/config"
-	"github.com/tylerbutler/ccl-test-data/loader"
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/loader"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // Version of the package

--- a/cmd/ccl-test-runner/generate_flat.go
+++ b/cmd/ccl-test-runner/generate_flat.go
@@ -6,8 +6,8 @@ import (
 	"fmt"
 	"path/filepath"
 
-	"github.com/tylerbutler/ccl-test-data/generator"
-	"github.com/tylerbutler/ccl-test-data/internal/styles"
+	"github.com/catconflang/ccl-test-data/generator"
+	"github.com/catconflang/ccl-test-data/internal/styles"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/ccl-test-runner/main.go
+++ b/cmd/ccl-test-runner/main.go
@@ -8,11 +8,11 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/internal/benchmark"
-	"github.com/tylerbutler/ccl-test-data/internal/config"
-	"github.com/tylerbutler/ccl-test-data/internal/generator"
-	"github.com/tylerbutler/ccl-test-data/internal/stats"
-	"github.com/tylerbutler/ccl-test-data/internal/styles"
+	"github.com/catconflang/ccl-test-data/internal/benchmark"
+	"github.com/catconflang/ccl-test-data/internal/config"
+	"github.com/catconflang/ccl-test-data/internal/generator"
+	"github.com/catconflang/ccl-test-data/internal/stats"
+	"github.com/catconflang/ccl-test-data/internal/styles"
 	"github.com/urfave/cli/v2"
 )
 

--- a/cmd/test-reader/main.go
+++ b/cmd/test-reader/main.go
@@ -18,9 +18,9 @@ import (
 
 	tea "github.com/charmbracelet/bubbletea"
 	"github.com/charmbracelet/lipgloss"
-	"github.com/tylerbutler/ccl-test-data/config"
-	"github.com/tylerbutler/ccl-test-data/loader"
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/loader"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // Configuration constants

--- a/cmd/validate-config/main.go
+++ b/cmd/validate-config/main.go
@@ -5,7 +5,7 @@ import (
 	"fmt"
 	"os"
 
-	"github.com/tylerbutler/ccl-test-data/internal/config"
+	"github.com/catconflang/ccl-test-data/internal/config"
 )
 
 func main() {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -10,10 +10,10 @@ import (
 	"reflect"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/config"
-	"github.com/tylerbutler/ccl-test-data/loader"
-	"github.com/tylerbutler/ccl-test-data/types"
-	"github.com/tylerbutler/ccl-test-data/types/generated"
+	"github.com/catconflang/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/loader"
+	"github.com/catconflang/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/types/generated"
 )
 
 // Export format constants for convenience

--- a/go.mod
+++ b/go.mod
@@ -1,4 +1,4 @@
-module github.com/tylerbutler/ccl-test-data
+module github.com/catconflang/ccl-test-data
 
 go 1.25.1
 

--- a/go_tests/parsing/api_advanced_processing_test.go
+++ b/go_tests/parsing/api_advanced_processing_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_advanced_processing.json

--- a/go_tests/parsing/api_comments_test.go
+++ b/go_tests/parsing/api_comments_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_comments.json

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_hierarchy.json

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_integration.json

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_core_ccl_parsing.json

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_edge_cases.json

--- a/go_tests/parsing/api_errors_test.go
+++ b/go_tests/parsing/api_errors_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_errors.json

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_list_access.json

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_proposed_behavior.json

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_reference_compliant.json

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_typed_access.json

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/api_whitespace_behaviors.json

--- a/go_tests/parsing/property_algebraic_test.go
+++ b/go_tests/parsing/property_algebraic_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/property_algebraic.json

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -5,7 +5,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
-	"github.com/tylerbutler/ccl-test-data/internal/mock"
+	"github.com/catconflang/ccl-test-data/internal/mock"
 )
 
 // Generated from generated_tests/property_round_trip.json

--- a/internal/config/runner_config.go
+++ b/internal/config/runner_config.go
@@ -6,7 +6,7 @@ import (
 	"fmt"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/config"
 )
 
 // RunnerConfig centralizes all behavioral choices, feature selections, and implementation capabilities

--- a/internal/config/simple_config.go
+++ b/internal/config/simple_config.go
@@ -7,7 +7,7 @@ import (
 	"slices"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/config"
 	"gopkg.in/yaml.v3"
 )
 

--- a/internal/generator/generator.go
+++ b/internal/generator/generator.go
@@ -29,10 +29,10 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/internal/config"
-	"github.com/tylerbutler/ccl-test-data/internal/styles"
-	"github.com/tylerbutler/ccl-test-data/loader"
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/internal/config"
+	"github.com/catconflang/ccl-test-data/internal/styles"
+	"github.com/catconflang/ccl-test-data/loader"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // Options configures test generation behavior

--- a/internal/generator/pool.go
+++ b/internal/generator/pool.go
@@ -4,7 +4,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // Pool manages reusable objects to reduce memory allocations

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -8,7 +8,7 @@ import (
 	"strings"
 	"text/template"
 
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 const testFileTemplate = `package {{.PackageName}}_test
@@ -16,7 +16,7 @@ const testFileTemplate = `package {{.PackageName}}_test
 import (
 	"testing"
 	{{if .HasActiveTests}}
-	"github.com/tylerbutler/ccl-test-data/internal/mock"{{if .HasAssertions}}
+	"github.com/catconflang/ccl-test-data/internal/mock"{{if .HasAssertions}}
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"{{end}}{{end}}
 )

--- a/internal/stats/collector.go
+++ b/internal/stats/collector.go
@@ -8,7 +8,7 @@ import (
 	"path/filepath"
 	"strings"
 
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // FeatureCategories maps feature names to categories

--- a/internal/stats/enhanced.go
+++ b/internal/stats/enhanced.go
@@ -37,7 +37,7 @@ import (
 	"strings"
 	"sync"
 
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // String slice pool for reducing allocations during stats collection

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -8,8 +8,8 @@ import (
 	"os"
 	"path/filepath"
 
-	"github.com/tylerbutler/ccl-test-data/config"
-	"github.com/tylerbutler/ccl-test-data/types"
+	"github.com/catconflang/ccl-test-data/config"
+	"github.com/catconflang/ccl-test-data/types"
 )
 
 // TestLoader handles both source and flat format loading with type-safe filtering

--- a/package.json
+++ b/package.json
@@ -9,13 +9,13 @@
   },
   "repository": {
     "type": "git",
-    "url": "git+https://github.com/tylerbutler/ccl-test-data.git"
+    "url": "git+https://github.com/catconflang/ccl-test-data.git"
   },
   "license": "ISC",
   "bugs": {
-    "url": "https://github.com/tylerbutler/ccl-test-data/issues"
+    "url": "https://github.com/catconflang/ccl-test-data/issues"
   },
-  "homepage": "https://github.com/tylerbutler/ccl-test-data#readme",
+  "homepage": "https://github.com/catconflang/ccl-test-data#readme",
   "dependencies": {
     "remark-gfm": "^4.0.1",
     "remark-parse": "^11.0.0",

--- a/types/structured.go
+++ b/types/structured.go
@@ -1,7 +1,7 @@
 package types
 
 import (
-	"github.com/tylerbutler/ccl-test-data/types/generated"
+	"github.com/catconflang/ccl-test-data/types/generated"
 )
 
 // Convenient type aliases for the generated structs with better naming


### PR DESCRIPTION
## Summary

Updates all repository references from `tylerbutler/ccl-test-data` to `catconflang/ccl-test-data` following the repository transfer to the CatConfLang organization.

## Changes

- **Go module path**: Updated `go.mod` module declaration
- **Import statements**: Updated all Go source files with new import paths
- **Documentation**: Updated README.md and CLAUDE.md with new GitHub URLs and Go import examples
- **Package metadata**: Updated package.json repository, bugs, and homepage URLs