### PR TITLE
docs: fix Go version reference in CLAUDE.md

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -135,7 +135,7 @@ Tests are organized by the CCL functions they validate. Implement the functions 
 ## Build System
 
 - **Build tool**: `just` (justfile)
-- **Go version**: 1.25.1
+- **Go version**: See go.mod for current version
 - **Module**: `github.com/catconflang/ccl-test-data`
 
 ## Changelog Generation


### PR DESCRIPTION
## Summary
- Replace hardcoded Go version 1.25.1 (which doesn't exist) with reference to go.mod

## Test plan
- [x] Verify CLAUDE.md is accurate