### PR TITLE
feat(tests): add CRLF + comments test coverage

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -958,6 +958,446 @@
     },
     {
       "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "/",
+            "value": "this is a comment"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_normalize_comment_only_parse",
+      "source_test": "crlf_normalize_comment_only",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_normalize_comment_only_filter",
+      "source_test": "crlf_normalize_comment_only",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "/",
+            "value": "this is a comment\r"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_preserve_comment_only_parse",
+      "source_test": "crlf_preserve_comment_only",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_preserve_comment_only_filter",
+      "source_test": "crlf_preserve_comment_only",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 4,
+        "entries": [
+          {
+            "key": "/",
+            "value": "Server config"
+          },
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "/",
+            "value": "Port setting"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_normalize_comments_and_values_parse",
+      "source_test": "crlf_normalize_comments_and_values",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_normalize_comments_and_values_filter",
+      "source_test": "crlf_normalize_comments_and_values",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": "localhost",
+          "port": "8080"
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_normalize_comments_and_values_build_hierarchy",
+      "source_test": "crlf_normalize_comments_and_values",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 4,
+        "entries": [
+          {
+            "key": "/",
+            "value": "Server config\r"
+          },
+          {
+            "key": "host",
+            "value": "localhost\r"
+          },
+          {
+            "key": "/",
+            "value": "Port setting\r"
+          },
+          {
+            "key": "port",
+            "value": "8080\r"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_preserve_comments_and_values_parse",
+      "source_test": "crlf_preserve_comments_and_values",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost\r"
+          },
+          {
+            "key": "port",
+            "value": "8080\r"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_preserve_comments_and_values_filter",
+      "source_test": "crlf_preserve_comments_and_values",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": "localhost\r",
+          "port": "8080\r"
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_preserve_comments_and_values_build_hierarchy",
+      "source_test": "crlf_preserve_comments_and_values",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "/",
+            "value": "first comment"
+          },
+          {
+            "key": "/",
+            "value": "second comment"
+          },
+          {
+            "key": "/",
+            "value": "third comment"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
+      "name": "crlf_normalize_multiple_comments_parse",
+      "source_test": "crlf_normalize_multiple_comments",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
+      "name": "crlf_normalize_multiple_comments_filter",
+      "source_test": "crlf_normalize_multiple_comments",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "/",
+            "value": "first comment\r"
+          },
+          {
+            "key": "/",
+            "value": "second comment\r"
+          },
+          {
+            "key": "/",
+            "value": "third comment\r"
+          }
+        ]
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
+      "name": "crlf_preserve_multiple_comments_parse",
+      "source_test": "crlf_preserve_multiple_comments",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "filter"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
+      "name": "crlf_preserve_multiple_comments_filter",
+      "source_test": "crlf_preserve_multiple_comments",
+      "validation": "filter",
+      "variants": []
+    },
+    {
+      "behaviors": [
         "tabs_as_whitespace",
         "crlf_normalize_to_lf"
       ],

--- a/go_tests/parsing/api_advanced_processing_test.go
+++ b/go_tests/parsing/api_advanced_processing_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,19 +12,24 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // composition_stability_duplicate_keys_parse - function:parse
 func TestCompositionStabilityDuplicateKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a = 1
 b = 2
 b = 20
 c = 3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -33,18 +38,22 @@ c = 3`
 
 }
 
+
 // multiple_values_same_key_parse - function:parse
 func TestMultipleValuesSameKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 8000
 ports = 8001
 ports = 8002`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -53,18 +62,22 @@ ports = 8002`
 
 }
 
+
 // list_with_empty_keys_parse - function:parse feature:empty_keys
 func TestListWithEmptyKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= 3
 = 1
 = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -73,16 +86,20 @@ func TestListWithEmptyKeysParse(t *testing.T) {
 
 }
 
+
 // section_style_syntax_parse - function:parse feature:empty_keys
 func TestSectionStyleSyntaxParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Section 2 ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -91,19 +108,23 @@ func TestSectionStyleSyntaxParse(t *testing.T) {
 
 }
 
+
 // composition_stability_ba_parse - function:parse
 func TestCompositionStabilityBaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `b = 20
 c = 3
 a = 1
 b = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -112,19 +133,23 @@ b = 2`
 
 }
 
+
 // mixed_keys_with_duplicates_parse - function:parse feature:empty_keys
 func TestMixedKeysWithDuplicatesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = app
 ports = 8000
 name = service
 ports = 8001`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -133,18 +158,22 @@ ports = 8001`
 
 }
 
+
 // array_style_list_parse - function:parse feature:empty_keys
 func TestArrayStyleListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `1 =
 2 =
 3 =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -153,18 +182,22 @@ func TestArrayStyleListParse(t *testing.T) {
 
 }
 
+
 // section_header_double_equals_parse - function:parse feature:empty_keys
 func TestSectionHeaderDoubleEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config ==
 host = localhost
 port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -173,18 +206,22 @@ port = 5432`
 
 }
 
+
 // section_header_triple_equals_parse - function:parse feature:empty_keys
 func TestSectionHeaderTripleEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `=== Server Settings ===
 host = 0.0.0.0
 ssl = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -193,8 +230,10 @@ ssl = true`
 
 }
 
+
 // multiple_sections_with_entries_parse - function:parse feature:empty_keys
 func TestMultipleSectionsWithEntriesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database ==
@@ -205,11 +244,13 @@ redis = enabled
 
 == Logging ==
 level = info`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -218,8 +259,10 @@ level = info`
 
 }
 
+
 // section_headers_mixed_with_lists_parse - function:parse feature:empty_keys
 func TestSectionHeadersMixedWithListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Configuration ==
@@ -228,11 +271,13 @@ func TestSectionHeadersMixedWithListsParse(t *testing.T) {
 key = value
 === Next Section ===
 other = data`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -241,16 +286,20 @@ other = data`
 
 }
 
+
 // empty_section_header_only_parse - function:parse
 func TestEmptySectionHeaderOnlyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Empty Section ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -259,17 +308,21 @@ func TestEmptySectionHeaderOnlyParse(t *testing.T) {
 
 }
 
+
 // section_header_at_end_parse - function:parse feature:empty_keys
 func TestSectionHeaderAtEndParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 == Final Section ==`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -278,19 +331,23 @@ func TestSectionHeaderAtEndParse(t *testing.T) {
 
 }
 
+
 // section_headers_no_trailing_equals_parse - function:parse feature:empty_keys
 func TestSectionHeadersNoTrailingEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config
 host = localhost
 === Server Settings
 port = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -299,19 +356,23 @@ port = 8080`
 
 }
 
+
 // section_headers_with_colons_parse - function:parse feature:empty_keys
 func TestSectionHeadersWithColonsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database: Production ==
 host = db.prod.com
 === Cache: Redis Config ===
 port = 6379`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -320,19 +381,23 @@ port = 6379`
 
 }
 
+
 // spaced_equals_not_section_header_parse - function:parse feature:empty_keys
 func TestSpacedEqualsNotSectionHeaderParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= = spaced equals
 =  = wide spaces
 == Real Header ==
 key = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -341,19 +406,23 @@ key = value`
 
 }
 
+
 // consecutive_section_headers_parse - function:parse feature:empty_keys
 func TestConsecutiveSectionHeadersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== First Section ==
 === Nested Section ===
 ==== Deep Section ====
 key = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -361,3 +430,5 @@ key = value`
 	assert.Equal(t, expected, parseResult)
 
 }
+
+

--- a/go_tests/parsing/api_comments_test.go
+++ b/go_tests/parsing/api_comments_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,8 +12,11 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // comment_extension_parse - function:parse feature:comments
 func TestCommentExtensionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= This is an environment section
@@ -22,11 +25,13 @@ serve = index.html
 /= Database section
 mode = in-memory
 connections = 16`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -35,21 +40,46 @@ connections = 16`
 
 }
 
+
 // comment_extension_filter - function:filter feature:comments
 func TestCommentExtensionFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is an environment section
+port = 8080
+serve = index.html
+/= Database section
+mode = in-memory
+connections = 16`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // comment_syntax_slash_equals_parse - function:parse feature:comments
 func TestCommentSyntaxSlashEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= this is a comment`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -58,13 +88,31 @@ func TestCommentSyntaxSlashEqualsParse(t *testing.T) {
 
 }
 
+
 // comment_syntax_slash_equals_filter - function:filter feature:comments
 func TestCommentSyntaxSlashEqualsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= this is a comment`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // section_headers_with_comments_parse - function:parse feature:comments feature:empty_keys
 func TestSectionHeadersWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `== Database Config ==
@@ -73,11 +121,13 @@ host = localhost
 === Cache Config ===
 /= Redis configuration
 port = 6379`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -86,7 +136,30 @@ port = 6379`
 
 }
 
+
 // section_headers_with_comments_filter - function:filter feature:comments feature:empty_keys
 func TestSectionHeadersWithCommentsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Database Config ==
+/= Connection settings
+host = localhost
+=== Cache Config ===
+/= Redis configuration
+port = 6379`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,17 +12,22 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_object_construction_parse - function:parse
 func TestBasicObjectConstructionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,18 +36,56 @@ age = 42`
 
 }
 
+
 // basic_object_construction_build_hierarchy - function:build_hierarchy
 func TestBasicObjectConstructionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // basic_object_construction_print - function:print
 func TestBasicObjectConstructionPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deep_nested_objects_parse - function:parse
 func TestDeepNestedObjectsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `server =
@@ -51,11 +94,13 @@ func TestDeepNestedObjectsParse(t *testing.T) {
     port = 5432
   cache =
     enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -64,28 +109,76 @@ func TestDeepNestedObjectsParse(t *testing.T) {
 
 }
 
+
 // deep_nested_objects_build_hierarchy - function:build_hierarchy
 func TestDeepNestedObjectsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": map[string]interface{}{"cache": map[string]interface{}{"enabled": "true"}, "database": map[string]interface{}{"host": "localhost", "port": "5432"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // deep_nested_objects_print - function:print
 func TestDeepNestedObjectsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // duplicate_keys_to_lists_parse - function:parse
 func TestDuplicateKeysToListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = first
 item = second
 item = third`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -94,29 +187,71 @@ item = third`
 
 }
 
+
 // duplicate_keys_to_lists_build_hierarchy - function:build_hierarchy
 func TestDuplicateKeysToListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second
+item = third`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": []interface{}{"first", "second", "third"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // duplicate_keys_to_lists_print - function:print
 func TestDuplicateKeysToListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second
+item = third`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // nested_duplicate_keys_parse - function:parse
 func TestNestedDuplicateKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   server = web1
   server = web2
   port = 80`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -125,18 +260,60 @@ func TestNestedDuplicateKeysParse(t *testing.T) {
 
 }
 
+
 // nested_duplicate_keys_build_hierarchy - function:build_hierarchy
 func TestNestedDuplicateKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1
+  server = web2
+  port = 80`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_duplicate_keys_print - function:print
 func TestNestedDuplicateKeysPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1
+  server = web2
+  port = 80`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // mixed_flat_and_nested_parse - function:parse
 func TestMixedFlatAndNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
@@ -144,11 +321,13 @@ config =
   debug = true
   timeout = 30
 version = 1.0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -157,18 +336,62 @@ version = 1.0`
 
 }
 
+
 // mixed_flat_and_nested_build_hierarchy - function:build_hierarchy
 func TestMixedFlatAndNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+  debug = true
+  timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "timeout": "30"}, "name": "Alice", "version": "1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_flat_and_nested_print - function:print
 func TestMixedFlatAndNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+  debug = true
+  timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // nested_objects_with_lists_parse - function:parse
 func TestNestedObjectsWithListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `environments =
@@ -179,11 +402,13 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
   dev =
     server = localhost
     port = 3000`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -192,18 +417,68 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
 
 }
 
+
 // nested_objects_with_lists_build_hierarchy - function:build_hierarchy
 func TestNestedObjectsWithListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `environments =
+  prod =
+    server = web1
+    server = web2
+    port = 80
+  dev =
+    server = localhost
+    port = 3000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"environments": map[string]interface{}{"dev": map[string]interface{}{"port": "3000", "server": "localhost"}, "prod": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_objects_with_lists_print - function:print
 func TestNestedObjectsWithListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `environments =
+  prod =
+    server = web1
+    server = web2
+    port = 80
+  dev =
+    server = localhost
+    port = 3000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deeply_nested_list_parse - function:parse
 func TestDeeplyNestedListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -212,11 +487,13 @@ func TestDeeplyNestedListParse(t *testing.T) {
       servers = web1
       servers = web2
       servers = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -225,12 +502,64 @@ func TestDeeplyNestedListParse(t *testing.T) {
 
 }
 
+
 // deeply_nested_list_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": []interface{}{"api1", "web1", "web2"}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // deeply_nested_list_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,17 +12,22 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // complete_basic_workflow_parse - function:parse
 func TestCompleteBasicWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,29 +36,69 @@ age = 42`
 
 }
 
+
 // complete_basic_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteBasicWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_basic_workflow_print - function:print
 func TestCompleteBasicWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // complete_nested_workflow_parse - function:parse
 func TestCompleteNestedWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   host = localhost
   port = 5432
   enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -62,18 +107,60 @@ func TestCompleteNestedWorkflowParse(t *testing.T) {
 
 }
 
+
 // complete_nested_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteNestedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"enabled": "true", "host": "localhost", "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_nested_workflow_print - function:print
 func TestCompleteNestedWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // complete_mixed_workflow_parse - function:parse
 func TestCompleteMixedWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app = MyApp
@@ -83,11 +170,13 @@ config =
   features =
     feature1 = enabled
     feature2 = disabled`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -96,18 +185,66 @@ config =
 
 }
 
+
 // complete_mixed_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteMixedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app = MyApp
+version = 1.0.0
+config =
+  debug = true
+  features =
+    feature1 = enabled
+    feature2 = disabled`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"app": "MyApp", "config": map[string]interface{}{"debug": "true", "features": map[string]interface{}{"feature1": "enabled", "feature2": "disabled"}}, "version": "1.0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_mixed_workflow_print - function:print
 func TestCompleteMixedWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app = MyApp
+version = 1.0.0
+config =
+  debug = true
+  features =
+    feature1 = enabled
+    feature2 = disabled`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // complete_lists_workflow_parse - function:parse
 func TestCompleteListsWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
@@ -117,11 +254,13 @@ func TestCompleteListsWorkflowParse(t *testing.T) {
 ports =
   port = 80
   port = 443`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -129,19 +268,11 @@ ports =
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // complete_lists_workflow_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestCompleteListsWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// complete_lists_workflow_print - function:print
-func TestCompleteListsWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// complete_lists_workflow_lexicographic_parse - function:parse
-func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
@@ -151,11 +282,69 @@ func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
 ports =
   port = 80
   port = 443`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"80", "443"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// complete_lists_workflow_print - function:print
+func TestCompleteListsWorkflowPrint(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// complete_lists_workflow_lexicographic_parse - function:parse
+func TestCompleteListsWorkflowLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -164,18 +353,66 @@ ports =
 
 }
 
+
 // complete_lists_workflow_lexicographic_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestCompleteListsWorkflowLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"443", "80"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_lists_workflow_lexicographic_print - function:print
 func TestCompleteListsWorkflowLexicographicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // complete_multiline_workflow_parse - function:parse feature:multiline
 func TestCompleteMultilineWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `description = Welcome to our app
@@ -185,11 +422,13 @@ config =
   settings =
     value1 = one
     value2 = two`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -198,18 +437,66 @@ config =
 
 }
 
+
 // complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = Welcome to our app
+  This is a multi-line description
+  With several lines
+config =
+  settings =
+    value1 = one
+    value2 = two`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"settings": map[string]interface{}{"value1": "one", "value2": "two"}}, "description": "Welcome to our app\n  This is a multi-line description\n  With several lines"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complete_multiline_workflow_print - function:print feature:multiline
 func TestCompleteMultilineWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = Welcome to our app
+  This is a multi-line description
+  With several lines
+config =
+  settings =
+    value1 = one
+    value2 = two`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // real_world_complete_workflow_parse - function:parse
 func TestRealWorldCompleteWorkflowParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `service = MyMicroservice
@@ -233,11 +520,13 @@ features =
   feature_a = enabled
   feature_b = disabled
   feature_c = experimental`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -246,12 +535,88 @@ features =
 
 }
 
+
 // real_world_complete_workflow_build_hierarchy - function:build_hierarchy
 func TestRealWorldCompleteWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `service = MyMicroservice
+version = 2.1.0
+database =
+  host = db.example.com
+  port = 5432
+  credentials =
+    user = service_user
+    password = secret123
+  pools =
+    read = 5
+    write = 2
+logging =
+  level = info
+  outputs =
+    output = console
+    output = file
+    output = syslog
+features =
+  feature_a = enabled
+  feature_b = disabled
+  feature_c = experimental`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"credentials": map[string]interface{}{"password": "secret123", "user": "service_user"}, "host": "db.example.com", "pools": map[string]interface{}{"read": "5", "write": "2"}, "port": "5432"}, "features": map[string]interface{}{"feature_a": "enabled", "feature_b": "disabled", "feature_c": "experimental"}, "logging": map[string]interface{}{"level": "info", "outputs": map[string]interface{}{"output": []interface{}{"console", "file", "syslog"}}}, "service": "MyMicroservice", "version": "2.1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // real_world_complete_workflow_print - function:print
 func TestRealWorldCompleteWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `service = MyMicroservice
+version = 2.1.0
+database =
+  host = db.example.com
+  port = 5432
+  credentials =
+    user = service_user
+    password = secret123
+  pools =
+    read = 5
+    write = 2
+logging =
+  level = info
+  outputs =
+    output = console
+    output = file
+    output = syslog
+features =
+  feature_a = enabled
+  feature_b = disabled
+  feature_c = experimental`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
+

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,17 +12,22 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_key_value_pairs_parse - function:parse
 func TestBasicKeyValuePairsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
 age = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -31,22 +36,43 @@ age = 42`
 
 }
 
+
 // basic_key_value_pairs_print - function:print
 func TestBasicKeyValuePairsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // equals_in_values_parse - function:parse
 func TestEqualsInValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `msg = k=v pairs work fine
 path = /bin/app=prod`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -55,22 +81,43 @@ path = /bin/app=prod`
 
 }
 
+
 // equals_in_values_print - function:print
 func TestEqualsInValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `msg = k=v pairs work fine
+path = /bin/app=prod`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // whitespace_trimming_parse - function:parse feature:whitespace
 func TestWhitespaceTrimmingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key   =    value with spaces   
 other = normal`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -79,19 +126,23 @@ other = normal`
 
 }
 
+
 // multiline_values_parse - function:parse feature:multiline
 func TestMultilineValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `description = First line
   Second line
   Third line
 done = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -100,22 +151,45 @@ done = yes`
 
 }
 
+
 // multiline_values_print - function:print feature:multiline
 func TestMultilineValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = First line
+  Second line
+  Third line
+done = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // empty_values_parse - function:parse feature:empty_keys
 func TestEmptyValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty =
 other = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -124,23 +198,44 @@ other = value`
 
 }
 
+
 // empty_values_print - function:print feature:empty_keys
 func TestEmptyValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty =
+other = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // nested_structure_parsing_parse - function:parse
 func TestNestedStructureParsingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   host = localhost
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -149,22 +244,44 @@ func TestNestedStructureParsingParse(t *testing.T) {
 
 }
 
+
 // nested_structure_parsing_print - function:print
 func TestNestedStructureParsingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // unicode_parsing_parse - function:parse feature:unicode
 func TestUnicodeParsingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `emoji = 😀😃😄
 配置 = config`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -173,21 +290,42 @@ func TestUnicodeParsingParse(t *testing.T) {
 
 }
 
+
 // unicode_parsing_print - function:print feature:unicode
 func TestUnicodeParsingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `emoji = 😀😃😄
+配置 = config`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // empty_input_parse - function:parse
 func TestEmptyInputParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ""
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -196,22 +334,42 @@ func TestEmptyInputParse(t *testing.T) {
 
 }
 
+
 // empty_input_print - function:print
 func TestEmptyInputPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // leading_whitespace_baseline_zero_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
 func TestLeadingWhitespaceBaselineZeroParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key = value
   second`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -220,17 +378,21 @@ func TestLeadingWhitespaceBaselineZeroParse(t *testing.T) {
 
 }
 
+
 // leading_whitespace_multiple_entries_parse - function:parse feature:whitespace
 func TestLeadingWhitespaceMultipleEntriesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key1 = value1
 key2 = value2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -239,7 +401,27 @@ key2 = value2`
 
 }
 
+
 // leading_whitespace_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestLeadingWhitespaceToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key = value
+  second = entry`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "second", Value: "entry"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
+

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_single_no_spaces_parse - function:parse
 func TestBasicSingleNoSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key=val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -29,17 +34,21 @@ func TestBasicSingleNoSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // basic_with_spaces_parse - function:parse feature:whitespace
 func TestBasicWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -47,22 +56,42 @@ func TestBasicWithSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // indented_key_parse_indented - function:parse_indented feature:whitespace
 func TestIndentedKeyParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  key = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // value_trailing_spaces_parse - function:parse feature:whitespace
 func TestValueTrailingSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -70,17 +99,21 @@ func TestValueTrailingSpacesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // key_value_surrounded_spaces_parse - function:parse feature:whitespace
 func TestKeyValueSurroundedSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -89,18 +122,22 @@ func TestKeyValueSurroundedSpacesParse(t *testing.T) {
 
 }
 
+
 // surrounded_by_newlines_parse - function:parse
 func TestSurroundedByNewlinesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
 key = val
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -109,16 +146,20 @@ key = val
 
 }
 
+
 // key_empty_value_parse - function:parse feature:empty_keys
 func TestKeyEmptyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -127,17 +168,21 @@ func TestKeyEmptyValueParse(t *testing.T) {
 
 }
 
+
 // empty_value_with_newline_parse - function:parse feature:empty_keys
 func TestEmptyValueWithNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -145,17 +190,21 @@ func TestEmptyValueWithNewlineParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // empty_value_with_spaces_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -164,22 +213,42 @@ func TestEmptyValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // empty_key_indented_parse_indented - function:parse_indented feature:empty_keys
 func TestEmptyKeyIndentedParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // empty_key_with_newline_parse - function:parse feature:empty_keys
 func TestEmptyKeyWithNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
   = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -188,16 +257,20 @@ func TestEmptyKeyWithNewlineParse(t *testing.T) {
 
 }
 
+
 // empty_key_value_with_spaces_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyKeyValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  =  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -206,16 +279,20 @@ func TestEmptyKeyValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // equals_in_value_no_spaces_parse - function:parse
 func TestEqualsInValueNoSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a=b=c`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -224,16 +301,20 @@ func TestEqualsInValueNoSpacesParse(t *testing.T) {
 
 }
 
+
 // equals_in_value_with_spaces_parse - function:parse feature:whitespace
 func TestEqualsInValueWithSpacesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `a = b = c`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -242,17 +323,21 @@ func TestEqualsInValueWithSpacesParse(t *testing.T) {
 
 }
 
+
 // multiple_key_value_pairs_parse - function:parse
 func TestMultipleKeyValuePairsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key1 = val1
 key2 = val2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -261,26 +346,64 @@ key2 = val2`
 
 }
 
+
 // key_with_tabs_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestKeyWithTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // key_with_tabs_ocaml_reference_parse - function:parse feature:whitespace behavior:tabs_as_content variant:reference_compliant
 func TestKeyWithTabsOcamlReferenceParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // whitespace_only_value_parse - function:parse feature:empty_keys feature:whitespace
 func TestWhitespaceOnlyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `onlyspaces =     `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -289,26 +412,66 @@ func TestWhitespaceOnlyValueParse(t *testing.T) {
 
 }
 
+
 // spaces_vs_tabs_continuation_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // spaces_vs_tabs_continuation_ocaml_reference_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationOcamlReferenceParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // multiple_empty_equality_parse - function:parse feature:empty_keys feature:whitespace
 func TestMultipleEmptyEqualityParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ` =  = `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -317,18 +480,22 @@ func TestMultipleEmptyEqualityParse(t *testing.T) {
 
 }
 
+
 // key_with_newline_before_equals_parse - function:parse feature:empty_keys feature:whitespace
 func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key 
 = val
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -337,19 +504,23 @@ func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 
 }
 
+
 // complex_multi_newline_whitespace_parse - function:parse feature:empty_keys feature:whitespace
 func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  
  key  
 =  val  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -358,17 +529,21 @@ func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
 
 }
 
+
 // empty_value_with_trailing_spaces_newline_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyValueWithTrailingSpacesNewlineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -377,18 +552,22 @@ func TestEmptyValueWithTrailingSpacesNewlineParse(t *testing.T) {
 
 }
 
+
 // empty_key_value_with_surrounding_newlines_parse - function:parse feature:empty_keys feature:whitespace
 func TestEmptyKeyValueWithSurroundingNewlinesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
   =  
 `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -397,16 +576,20 @@ func TestEmptyKeyValueWithSurroundingNewlinesParse(t *testing.T) {
 
 }
 
+
 // quotes_treated_as_literal_unquoted_parse - function:parse
 func TestQuotesTreatedAsLiteralUnquotedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -415,16 +598,20 @@ func TestQuotesTreatedAsLiteralUnquotedParse(t *testing.T) {
 
 }
 
+
 // quotes_treated_as_literal_quoted_parse - function:parse
 func TestQuotesTreatedAsLiteralQuotedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = "localhost"`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -433,17 +620,21 @@ func TestQuotesTreatedAsLiteralQuotedParse(t *testing.T) {
 
 }
 
+
 // nested_single_line_parse - function:parse
 func TestNestedSingleLineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
   val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -452,18 +643,22 @@ func TestNestedSingleLineParse(t *testing.T) {
 
 }
 
+
 // nested_multi_line_parse - function:parse feature:multiline
 func TestNestedMultiLineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key =
   line1
   line2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -472,29 +667,72 @@ func TestNestedMultiLineParse(t *testing.T) {
 
 }
 
+
 // nested_with_blank_line_parse_indented - function:parse_indented feature:multiline
 func TestNestedWithBlankLineParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  line1
+
+  line2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // deep_nested_structure_parse_indented - function:parse_indented
 func TestDeepNestedStructureParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  field1 = value1
+  field2 =
+    subfield = x
+    another = y`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // realistic_stress_test_parse - function:parse
 func TestRealisticStressTestParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Dmitrii Kovanikov
 login = chshersh
 language = OCaml
 date = 2024-05-25`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -503,8 +741,10 @@ date = 2024-05-25`
 
 }
 
+
 // ocaml_stress_test_original_parse - function:parse feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/= This is a CCL document
@@ -526,11 +766,13 @@ user =
 user =
   login = chshersh
   createdAt = 2024-12-31`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -539,28 +781,105 @@ user =
 
 }
 
+
 // ocaml_stress_test_original_build_hierarchy - function:build_hierarchy feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": "This is a CCL document", "database": map[string]interface{}{"enabled": "true", "limits": map[string]interface{}{"cpu": "1500mi", "memory": "10Gb"}, "ports": map[string]interface{}{"": []interface{}{"8000", "8001", "8002"}}}, "title": "CCL Example", "user": map[string]interface{}{"createdAt": "2024-12-31", "guestId": "42", "login": "chshersh"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // ocaml_stress_test_original_get_string - function:get_string feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"title"})
+	require.NoError(t, err)
+	assert.Equal(t, "CCL Example", result)
+
 }
+
 
 // forward_slashes_in_map_keys_parse - function:parse
 func TestForwardSlashesInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `mappings =
   config/settings.json = .vscode/settings.json
   src/template.env = .env`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -569,28 +888,73 @@ func TestForwardSlashesInMapKeysParse(t *testing.T) {
 
 }
 
+
 // forward_slashes_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestForwardSlashesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  config/settings.json = .vscode/settings.json
+  src/template.env = .env`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mappings": map[string]interface{}{"config/settings.json": ".vscode/settings.json", "src/template.env": ".env"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // forward_slashes_in_map_keys_get_string - function:get_string
 func TestForwardSlashesInMapKeysGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  config/settings.json = .vscode/settings.json
+  src/template.env = .env`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mappings", "config/settings.json"})
+	require.NoError(t, err)
+	assert.Equal(t, ".vscode/settings.json", result)
+
 }
+
 
 // backslashes_in_map_keys_parse - function:parse
 func TestBackslashesInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `paths =
   C:\Users\config = user_settings
   D:\data\file.txt = backup`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -599,23 +963,47 @@ func TestBackslashesInMapKeysParse(t *testing.T) {
 
 }
 
+
 // backslashes_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestBackslashesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `paths =
+  C:\Users\config = user_settings
+  D:\data\file.txt = backup`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"paths": map[string]interface{}{"C:\\Users\\config": "user_settings", "D:\\data\\file.txt": "backup"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // colons_in_map_keys_parse - function:parse
 func TestColonsInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `timestamps =
   12:30:45 = morning
   23:59:59 = midnight`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -624,23 +1012,47 @@ func TestColonsInMapKeysParse(t *testing.T) {
 
 }
 
+
 // colons_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestColonsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `timestamps =
+  12:30:45 = morning
+  23:59:59 = midnight`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"timestamps": map[string]interface{}{"12:30:45": "morning", "23:59:59": "midnight"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // hyphens_in_map_keys_parse - function:parse
 func TestHyphensInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `packages =
   my-package-name = 1.0.0
   another-lib = 2.3.4`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -649,23 +1061,47 @@ func TestHyphensInMapKeysParse(t *testing.T) {
 
 }
 
+
 // hyphens_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestHyphensInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `packages =
+  my-package-name = 1.0.0
+  another-lib = 2.3.4`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"packages": map[string]interface{}{"another-lib": "2.3.4", "my-package-name": "1.0.0"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // at_signs_in_map_keys_parse - function:parse
 func TestAtSignsInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `emails =
   user@example.com = primary
   admin@test.org = secondary`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -674,23 +1110,47 @@ func TestAtSignsInMapKeysParse(t *testing.T) {
 
 }
 
+
 // at_signs_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestAtSignsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `emails =
+  user@example.com = primary
+  admin@test.org = secondary`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"emails": map[string]interface{}{"admin@test.org": "secondary", "user@example.com": "primary"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // hash_in_map_keys_parse - function:parse
 func TestHashInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `issues =
   issue#123 = open
   bug#456 = closed`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -699,23 +1159,47 @@ func TestHashInMapKeysParse(t *testing.T) {
 
 }
 
+
 // hash_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestHashInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `issues =
+  issue#123 = open
+  bug#456 = closed`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"issues": map[string]interface{}{"bug#456": "closed", "issue#123": "open"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // brackets_in_map_keys_parse - function:parse
 func TestBracketsInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `arrays =
   items[0] = first
   items[1] = second`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -724,23 +1208,47 @@ func TestBracketsInMapKeysParse(t *testing.T) {
 
 }
 
+
 // brackets_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestBracketsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `arrays =
+  items[0] = first
+  items[1] = second`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"arrays": map[string]interface{}{"items[0]": "first", "items[1]": "second"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parentheses_in_map_keys_parse - function:parse
 func TestParenthesesInMapKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `functions =
   init() = setup
   run(args) = execute`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -749,24 +1257,48 @@ func TestParenthesesInMapKeysParse(t *testing.T) {
 
 }
 
+
 // parentheses_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestParenthesesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `functions =
+  init() = setup
+  run(args) = execute`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"functions": map[string]interface{}{"init()": "setup", "run(args)": "execute"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_special_chars_in_keys_parse - function:parse
 func TestMixedSpecialCharsInKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `complex =
   user@host:8080/api = endpoint
   file#v1.2.3 = release
   path\to\[item] = location`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -775,23 +1307,48 @@ func TestMixedSpecialCharsInKeysParse(t *testing.T) {
 
 }
 
+
 // mixed_special_chars_in_keys_build_hierarchy - function:build_hierarchy
 func TestMixedSpecialCharsInKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `complex =
+  user@host:8080/api = endpoint
+  file#v1.2.3 = release
+  path\to\[item] = location`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"complex": map[string]interface{}{"file#v1.2.3": "release", "path\\to\\[item]": "location", "user@host:8080/api": "endpoint"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // url_like_keys_parse - function:parse
 func TestUrlLikeKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `endpoints =
   https://api.example.com/v1 = production
   http://localhost:3000/test = development`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -800,7 +1357,29 @@ func TestUrlLikeKeysParse(t *testing.T) {
 
 }
 
+
 // url_like_keys_build_hierarchy - function:build_hierarchy
 func TestUrlLikeKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `endpoints =
+  https://api.example.com/v1 = production
+  http://localhost:3000/test = development`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"endpoints": map[string]interface{}{"http://localhost:3000/test": "development", "https://api.example.com/v1": "production"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
+

--- a/go_tests/parsing/api_errors_test.go
+++ b/go_tests/parsing/api_errors_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // just_key_error_parse - function:parse
 func TestJustKeyErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -29,17 +34,21 @@ func TestJustKeyErrorParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // whitespace_only_error_parse - function:parse feature:whitespace
 func TestWhitespaceOnlyErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -47,17 +56,21 @@ func TestWhitespaceOnlyErrorParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // whitespace_only_error_ocaml_reference_parse - function:parse feature:whitespace
 func TestWhitespaceOnlyErrorOcamlReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -65,17 +78,21 @@ func TestWhitespaceOnlyErrorOcamlReferenceParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // just_string_error_parse - function:parse
 func TestJustStringErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,17 +101,21 @@ func TestJustStringErrorParse(t *testing.T) {
 
 }
 
+
 // multiline_plain_error_parse - function:parse feature:multiline
 func TestMultilinePlainErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `val
   next`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -103,18 +124,22 @@ func TestMultilinePlainErrorParse(t *testing.T) {
 
 }
 
+
 // multiline_plain_nested_error_parse - function:parse feature:multiline
 func TestMultilinePlainNestedErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `
 val
   next`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -122,3 +147,5 @@ val
 	assert.Equal(t, expected, parseResult)
 
 }
+
+

--- a/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // s1_fuzz_single_squote_parse - function:parse
 func TestS1FuzzSingleSquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `' = val406`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,16 +35,20 @@ func TestS1FuzzSingleSquoteParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_asterisk_parse - function:parse
 func TestS1FuzzSingleAsteriskParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `* = val236`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -48,16 +57,20 @@ func TestS1FuzzSingleAsteriskParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_backslash_parse - function:parse
 func TestS1FuzzSingleBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `\ = val775`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -66,16 +79,20 @@ func TestS1FuzzSingleBackslashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_rbrace_parse - function:parse
 func TestS1FuzzSingleRbraceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `} = val221`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,16 +101,20 @@ func TestS1FuzzSingleRbraceParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_tilde_parse - function:parse
 func TestS1FuzzSingleTildeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~ = val416`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -102,16 +123,20 @@ func TestS1FuzzSingleTildeParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_semicolon_parse - function:parse
 func TestS1FuzzSingleSemicolonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `; = val155`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -120,16 +145,20 @@ func TestS1FuzzSingleSemicolonParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_plus_parse - function:parse
 func TestS1FuzzSinglePlusParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `+ = val794`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -138,16 +167,20 @@ func TestS1FuzzSinglePlusParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_dollar_parse - function:parse
 func TestS1FuzzSingleDollarParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$ = val665`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -156,16 +189,20 @@ func TestS1FuzzSingleDollarParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_percent_parse - function:parse
 func TestS1FuzzSinglePercentParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `% = val973`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -174,16 +211,20 @@ func TestS1FuzzSinglePercentParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_at_parse - function:parse
 func TestS1FuzzSingleAtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@ = val410`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -192,16 +233,20 @@ func TestS1FuzzSingleAtParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_dquote_parse - function:parse
 func TestS1FuzzSingleDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `" = val797`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -210,16 +255,20 @@ func TestS1FuzzSingleDquoteParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_lparen_parse - function:parse
 func TestS1FuzzSingleLparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `( = val364`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,16 +277,20 @@ func TestS1FuzzSingleLparenParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_lt_parse - function:parse
 func TestS1FuzzSingleLtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `< = val789`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -246,16 +299,20 @@ func TestS1FuzzSingleLtParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_lbracket_parse - function:parse
 func TestS1FuzzSingleLbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `[ = val216`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -264,16 +321,20 @@ func TestS1FuzzSingleLbracketParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_single_rparen_parse - function:parse
 func TestS1FuzzSingleRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `) = val374`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -282,16 +343,20 @@ func TestS1FuzzSingleRparenParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_at_lt_slash_parse - function:parse
 func TestS1FuzzComboAtLtSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@</ = combo594`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -300,16 +365,20 @@ func TestS1FuzzComboAtLtSlashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_slash_lparen_semicolon_backslash_parse - function:parse
 func TestS1FuzzComboSlashLparenSemicolonBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/(;\ = combo220`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,16 +387,20 @@ func TestS1FuzzComboSlashLparenSemicolonBackslashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_lt_hash_parse - function:parse
 func TestS1FuzzComboLtHashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `<# = combo31`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -336,16 +409,20 @@ func TestS1FuzzComboLtHashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_lparen_dquote_bang_parse - function:parse
 func TestS1FuzzComboLparenDquoteBangParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `("! = combo359`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -354,16 +431,20 @@ func TestS1FuzzComboLparenDquoteBangParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_slash_hash_backslash_dquote_parse - function:parse
 func TestS1FuzzComboSlashHashBackslashDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/#\" = combo87`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -372,16 +453,20 @@ func TestS1FuzzComboSlashHashBackslashDquoteParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_slash_percent_pipe_parse - function:parse
 func TestS1FuzzComboSlashPercentPipeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/%| = combo957`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -390,16 +475,20 @@ func TestS1FuzzComboSlashPercentPipeParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_lbrace_pipe_backslash_parse - function:parse
 func TestS1FuzzComboLbracePipeBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{|\ = combo828`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -408,16 +497,20 @@ func TestS1FuzzComboLbracePipeBackslashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_bang_percent_slash_parse - function:parse
 func TestS1FuzzComboBangPercentSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `!%/ = combo382`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -426,16 +519,20 @@ func TestS1FuzzComboBangPercentSlashParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_lbrace_pipe_rparen_parse - function:parse
 func TestS1FuzzComboLbracePipeRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{|) = combo608`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -444,16 +541,20 @@ func TestS1FuzzComboLbracePipeRparenParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_combo_colon_semicolon_squote_lt_parse - function:parse
 func TestS1FuzzComboColonSemicolonSquoteLtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `:;'< = combo488`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -462,16 +563,20 @@ func TestS1FuzzComboColonSemicolonSquoteLtParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_start_lbracket_host_parse - function:parse
 func TestS1FuzzPosStartLbracketHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `[host = pos428`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -480,16 +585,20 @@ func TestS1FuzzPosStartLbracketHostParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_middle_dollar_gamma_parse - function:parse
 func TestS1FuzzPosMiddleDollarGammaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ga$mma = pos138`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -498,16 +607,20 @@ func TestS1FuzzPosMiddleDollarGammaParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_end_pipe_name_parse - function:parse
 func TestS1FuzzPosEndPipeNameParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name| = pos691`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,16 +629,20 @@ func TestS1FuzzPosEndPipeNameParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_start_asterisk_server_parse - function:parse
 func TestS1FuzzPosStartAsteriskServerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `*server = pos50`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -534,16 +651,20 @@ func TestS1FuzzPosStartAsteriskServerParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_middle_gt_alpha_parse - function:parse
 func TestS1FuzzPosMiddleGtAlphaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `al>pha = pos153`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -552,16 +673,20 @@ func TestS1FuzzPosMiddleGtAlphaParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_end_squote_item_parse - function:parse
 func TestS1FuzzPosEndSquoteItemParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item' = pos133`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -570,16 +695,20 @@ func TestS1FuzzPosEndSquoteItemParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_start_dquote_mode_parse - function:parse
 func TestS1FuzzPosStartDquoteModeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"mode = pos155`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -588,16 +717,20 @@ func TestS1FuzzPosStartDquoteModeParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_middle_ampersand_port_parse - function:parse
 func TestS1FuzzPosMiddleAmpersandPortParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `po&rt = pos601`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -606,16 +739,20 @@ func TestS1FuzzPosMiddleAmpersandPortParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_end_hash_host_parse - function:parse
 func TestS1FuzzPosEndHashHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host# = pos976`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -624,16 +761,20 @@ func TestS1FuzzPosEndHashHostParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_pos_start_dollar_path_parse - function:parse
 func TestS1FuzzPosStartDollarPathParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$path = pos556`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -642,16 +783,20 @@ func TestS1FuzzPosStartDollarPathParse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_name_0_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzValName0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = data?x77]x88`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,26 +805,67 @@ func TestS1FuzzValName0Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_name_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data?x77]x88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data?x77]x88"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_val_name_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data?x77]x88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data?x77]x88", result)
+
 }
+
 
 // s1_fuzz_val_data_1_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzValData1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `data = data'x23!x22`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -688,26 +874,67 @@ func TestS1FuzzValData1Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_data_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValData1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data'x23!x22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"data": "data'x23!x22"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_val_data_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValData1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data'x23!x22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"data"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x23!x22", result)
+
 }
+
 
 // s1_fuzz_val_mode_2_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzValMode2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `mode = data?x30"x15~x73`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -716,26 +943,67 @@ func TestS1FuzzValMode2Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_mode_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValMode2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data?x30"x15~x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mode": "data?x30\"x15~x73"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_val_mode_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValMode2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data?x30"x15~x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mode"})
+	require.NoError(t, err)
+	assert.Equal(t, "data?x30\"x15~x73", result)
+
 }
+
 
 // s1_fuzz_val_name_3_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzValName3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = data$x23~x81@x41`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -744,26 +1012,67 @@ func TestS1FuzzValName3Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_name_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data$x23~x81@x41`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data$x23~x81@x41"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_val_name_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data$x23~x81@x41`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data$x23~x81@x41", result)
+
 }
+
 
 // s1_fuzz_val_user_4_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzValUser4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `user = data}x85$x2$x43`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -772,27 +1081,68 @@ func TestS1FuzzValUser4Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_val_user_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValUser4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `user = data}x85$x2$x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"user": "data}x85$x2$x43"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_val_user_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValUser4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `user = data}x85$x2$x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"user"})
+	require.NoError(t, err)
+	assert.Equal(t, "data}x85$x2$x43", result)
+
 }
+
 
 // s1_fuzz_nested_ampersand_rbrace_0_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&alpha = nested297
 }gamma = deep715`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -801,27 +1151,70 @@ func TestS1FuzzNestedAmpersandRbrace0Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_ampersand_rbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&alpha = nested297
+}gamma = deep715`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&alpha": "nested297", "}gamma": "deep715"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_ampersand_rbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&alpha = nested297
+}gamma = deep715`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested297", result)
+
 }
+
 
 // s1_fuzz_nested_question_rbracket_1_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `?port = nested105
 ]name = deep997`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -830,27 +1223,70 @@ func TestS1FuzzNestedQuestionRbracket1Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_question_rbracket_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?port = nested105
+]name = deep997`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"?port": "nested105", "]name": "deep997"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_question_rbracket_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?port = nested105
+]name = deep997`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested105", result)
+
 }
+
 
 // s1_fuzz_nested_plus_slash_2_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `+config = nested427
 /server = deep329`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -859,27 +1295,70 @@ func TestS1FuzzNestedPlusSlash2Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_plus_slash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+config = nested427
+/server = deep329`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"+config": "nested427", "/server": "deep329"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_plus_slash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+config = nested427
+/server = deep329`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"+config"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested427", result)
+
 }
+
 
 // s1_fuzz_nested_ampersand_dollar_3_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&name = nested41
 $port = deep486`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -888,27 +1367,70 @@ $port = deep486`
 
 }
 
+
 // s1_fuzz_nested_ampersand_dollar_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&name = nested41
+$port = deep486`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$port": "deep486", "&name": "nested41"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_ampersand_dollar_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&name = nested41
+$port = deep486`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested41", result)
+
 }
+
 
 // s1_fuzz_nested_tilde_squote_4_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~beta = nested332
 'beta = deep158`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -917,27 +1439,70 @@ func TestS1FuzzNestedTildeSquote4Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_tilde_squote_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested332
+'beta = deep158`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"'beta": "deep158", "~beta": "nested332"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_tilde_squote_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested332
+'beta = deep158`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"~beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested332", result)
+
 }
+
 
 // s1_fuzz_nested_hyphen_ampersand_5_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `-config = nested723
 &epsilon = deep891`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -946,27 +1511,70 @@ func TestS1FuzzNestedHyphenAmpersand5Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `-config = nested723
+&epsilon = deep891`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&epsilon": "deep891", "-config": "nested723"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_hyphen_ampersand_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `-config = nested723
+&epsilon = deep891`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"-config"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested723", result)
+
 }
+
 
 // s1_fuzz_nested_dollar_asterisk_6_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$path = nested884
 *mode = deep88`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -975,27 +1583,70 @@ func TestS1FuzzNestedDollarAsterisk6Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_dollar_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$path = nested884
+*mode = deep88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$path": "nested884", "*mode": "deep88"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_dollar_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$path = nested884
+*mode = deep88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"$path"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested884", result)
+
 }
+
 
 // s1_fuzz_nested_underscore_semicolon_7_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `_path = nested515
 ;alpha = deep519`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1004,27 +1655,70 @@ func TestS1FuzzNestedUnderscoreSemicolon7Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_underscore_semicolon_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `_path = nested515
+;alpha = deep519`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{";alpha": "deep519", "_path": "nested515"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_underscore_semicolon_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `_path = nested515
+;alpha = deep519`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"_path"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested515", result)
+
 }
+
 
 // s1_fuzz_nested_at_rparen_8_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@server = nested286
 )gamma = deep475`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1033,27 +1727,70 @@ func TestS1FuzzNestedAtRparen8Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_at_rparen_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@server = nested286
+)gamma = deep475`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")gamma": "deep475", "@server": "nested286"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_at_rparen_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@server = nested286
+)gamma = deep475`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"@server"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested286", result)
+
 }
+
 
 // s1_fuzz_nested_rbrace_tilde_9_parse - function:parse feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `}beta = nested295
 ~alpha = deep415`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1062,12 +1799,53 @@ func TestS1FuzzNestedRbraceTilde9Parse(t *testing.T) {
 
 }
 
+
 // s1_fuzz_nested_rbrace_tilde_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}beta = nested295
+~alpha = deep415`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"}beta": "nested295", "~alpha": "deep415"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s1_fuzz_nested_rbrace_tilde_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}beta = nested295
+~alpha = deep415`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested295", result)
+
 }
+
+

--- a/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // s42_fuzz_single_lparen_parse - function:parse
 func TestS42FuzzSingleLparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `( = val620`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,16 +35,20 @@ func TestS42FuzzSingleLparenParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_hyphen_parse - function:parse
 func TestS42FuzzSingleHyphenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `- = val619`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -48,16 +57,20 @@ func TestS42FuzzSingleHyphenParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_rbracket_parse - function:parse
 func TestS42FuzzSingleRbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `] = val334`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -66,16 +79,20 @@ func TestS42FuzzSingleRbracketParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_backslash_parse - function:parse
 func TestS42FuzzSingleBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `\ = val595`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,16 +101,20 @@ func TestS42FuzzSingleBackslashParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_slash_parse - function:parse
 func TestS42FuzzSingleSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/ = val509`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -102,16 +123,20 @@ func TestS42FuzzSingleSlashParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_dollar_parse - function:parse
 func TestS42FuzzSingleDollarParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$ = val877`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -120,16 +145,20 @@ func TestS42FuzzSingleDollarParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_rbrace_parse - function:parse
 func TestS42FuzzSingleRbraceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `} = val644`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -138,16 +167,20 @@ func TestS42FuzzSingleRbraceParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_plus_parse - function:parse
 func TestS42FuzzSinglePlusParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `+ = val412`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -156,16 +189,20 @@ func TestS42FuzzSinglePlusParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_dquote_parse - function:parse
 func TestS42FuzzSingleDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `" = val691`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -174,16 +211,20 @@ func TestS42FuzzSingleDquoteParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_bang_parse - function:parse
 func TestS42FuzzSingleBangParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `! = val528`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -192,16 +233,20 @@ func TestS42FuzzSingleBangParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_hash_parse - function:parse
 func TestS42FuzzSingleHashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `# = val238`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -210,16 +255,20 @@ func TestS42FuzzSingleHashParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_gt_parse - function:parse
 func TestS42FuzzSingleGtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `> = val318`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,16 +277,20 @@ func TestS42FuzzSingleGtParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_lbracket_parse - function:parse
 func TestS42FuzzSingleLbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `[ = val72`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -246,16 +299,20 @@ func TestS42FuzzSingleLbracketParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_rparen_parse - function:parse
 func TestS42FuzzSingleRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `) = val688`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -264,16 +321,20 @@ func TestS42FuzzSingleRparenParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_single_question_parse - function:parse
 func TestS42FuzzSingleQuestionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `? = val825`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -282,16 +343,20 @@ func TestS42FuzzSingleQuestionParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_pipe_lt_semicolon_parse - function:parse
 func TestS42FuzzComboPipeLtSemicolonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `|<; = combo808`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -300,16 +365,20 @@ func TestS42FuzzComboPipeLtSemicolonParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_rbracket_dquote_asterisk_parse - function:parse
 func TestS42FuzzComboRbracketDquoteAsteriskParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `]"* = combo591`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,16 +387,20 @@ func TestS42FuzzComboRbracketDquoteAsteriskParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_rbrace_squote_plus_parse - function:parse
 func TestS42FuzzComboRbraceSquotePlusParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `}'+ = combo440`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -336,16 +409,20 @@ func TestS42FuzzComboRbraceSquotePlusParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_ampersand_dquote_rparen_parse - function:parse
 func TestS42FuzzComboAmpersandDquoteRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&") = combo488`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -354,16 +431,20 @@ func TestS42FuzzComboAmpersandDquoteRparenParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_hyphen_tilde_parse - function:parse
 func TestS42FuzzComboHyphenTildeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `-~ = combo135`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -372,16 +453,20 @@ func TestS42FuzzComboHyphenTildeParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_at_lt_semicolon_lbracket_parse - function:parse
 func TestS42FuzzComboAtLtSemicolonLbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@<;[ = combo491`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -390,16 +475,20 @@ func TestS42FuzzComboAtLtSemicolonLbracketParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_squote_underscore_parse - function:parse
 func TestS42FuzzComboSquoteUnderscoreParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `'_ = combo768`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -408,16 +497,20 @@ func TestS42FuzzComboSquoteUnderscoreParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_lt_colon_parse - function:parse
 func TestS42FuzzComboLtColonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `<: = combo590`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -426,16 +519,20 @@ func TestS42FuzzComboLtColonParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_at_slash_asterisk_parse - function:parse
 func TestS42FuzzComboAtSlashAsteriskParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@/* = combo681`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -444,16 +541,20 @@ func TestS42FuzzComboAtSlashAsteriskParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_combo_dquote_pipe_slash_parse - function:parse
 func TestS42FuzzComboDquotePipeSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"|/ = combo76`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -462,16 +563,20 @@ func TestS42FuzzComboDquotePipeSlashParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_start_bang_port_parse - function:parse
 func TestS42FuzzPosStartBangPortParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `!port = pos235`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -480,16 +585,20 @@ func TestS42FuzzPosStartBangPortParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_middle_squote_data_parse - function:parse
 func TestS42FuzzPosMiddleSquoteDataParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `da'ta = pos941`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -498,16 +607,20 @@ func TestS42FuzzPosMiddleSquoteDataParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_end_gt_data_parse - function:parse
 func TestS42FuzzPosEndGtDataParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `data> = pos187`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,16 +629,20 @@ func TestS42FuzzPosEndGtDataParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_start_slash_host_parse - function:parse
 func TestS42FuzzPosStartSlashHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/host = pos306`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -534,16 +651,20 @@ func TestS42FuzzPosStartSlashHostParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_middle_hash_name_parse - function:parse
 func TestS42FuzzPosMiddleHashNameParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `na#me = pos189`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -552,16 +673,20 @@ func TestS42FuzzPosMiddleHashNameParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_end_plus_delta_parse - function:parse
 func TestS42FuzzPosEndPlusDeltaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `delta+ = pos397`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -570,16 +695,20 @@ func TestS42FuzzPosEndPlusDeltaParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_start_squote_path_parse - function:parse
 func TestS42FuzzPosStartSquotePathParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `'path = pos238`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -588,16 +717,20 @@ func TestS42FuzzPosStartSquotePathParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_middle_lparen_port_parse - function:parse
 func TestS42FuzzPosMiddleLparenPortParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `po(rt = pos139`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -606,16 +739,20 @@ func TestS42FuzzPosMiddleLparenPortParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_end_semicolon_gamma_parse - function:parse
 func TestS42FuzzPosEndSemicolonGammaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `gamma; = pos404`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -624,16 +761,20 @@ func TestS42FuzzPosEndSemicolonGammaParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_pos_start_gt_alpha_parse - function:parse
 func TestS42FuzzPosStartGtAlphaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `>alpha = pos196`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -642,16 +783,20 @@ func TestS42FuzzPosStartGtAlphaParse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_data_0_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzValData0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `data = data|x58`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,26 +805,67 @@ func TestS42FuzzValData0Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_data_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValData0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data|x58`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"data": "data|x58"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_val_data_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValData0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data|x58`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"data"})
+	require.NoError(t, err)
+	assert.Equal(t, "data|x58", result)
+
 }
+
 
 // s42_fuzz_val_beta_1_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzValBeta1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `beta = data\x12`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -688,26 +874,67 @@ func TestS42FuzzValBeta1Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_beta_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValBeta1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `beta = data\x12`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"beta": "data\\x12"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_val_beta_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValBeta1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `beta = data\x12`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "data\\x12", result)
+
 }
+
 
 // s42_fuzz_val_name_2_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzValName2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = data\x77"x95_x85`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -716,26 +943,67 @@ func TestS42FuzzValName2Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data\x77"x95_x85`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data\\x77\"x95_x85"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValName2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data\x77"x95_x85`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data\\x77\"x95_x85", result)
+
 }
+
 
 // s42_fuzz_val_path_3_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzValPath3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `path = data-x45`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -744,26 +1012,67 @@ func TestS42FuzzValPath3Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValPath3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data-x45`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data-x45"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValPath3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data-x45`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data-x45", result)
+
 }
+
 
 // s42_fuzz_val_name_4_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzValName4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = data{x49"x55`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -772,27 +1081,68 @@ func TestS42FuzzValName4Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_val_name_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data{x49"x55`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data{x49\"x55"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_val_name_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValName4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data{x49"x55`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data{x49\"x55", result)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbracket_0_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{host = nested259
 ]name = deep985`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -801,27 +1151,70 @@ func TestS42FuzzNestedLbraceRbracket0Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_lbrace_rbracket_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested259
+]name = deep985`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"]name": "deep985", "{host": "nested259"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbracket_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested259
+]name = deep985`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested259", result)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbrace_1_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{port = nested169
 }mode = deep270`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -830,27 +1223,70 @@ func TestS42FuzzNestedLbraceRbrace1Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{port = nested169
+}mode = deep270`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"{port": "nested169", "}mode": "deep270"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbrace_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{port = nested169
+}mode = deep270`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested169", result)
+
 }
+
 
 // s42_fuzz_nested_ampersand_percent_2_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&delta = nested56
 %data = deep952`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -859,27 +1295,70 @@ func TestS42FuzzNestedAmpersandPercent2Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_ampersand_percent_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&delta = nested56
+%data = deep952`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%data": "deep952", "&delta": "nested56"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_ampersand_percent_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&delta = nested56
+%data = deep952`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested56", result)
+
 }
+
 
 // s42_fuzz_nested_dquote_gt_3_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"epsilon = nested885
 >user = deep168`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -888,27 +1367,70 @@ func TestS42FuzzNestedDquoteGt3Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_dquote_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"epsilon = nested885
+>user = deep168`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"epsilon": "nested885", ">user": "deep168"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_dquote_gt_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"epsilon = nested885
+>user = deep168`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested885", result)
+
 }
+
 
 // s42_fuzz_nested_percent_dollar_4_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `%alpha = nested438
 $path = deep65`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -917,27 +1439,70 @@ $path = deep65`
 
 }
 
+
 // s42_fuzz_nested_percent_dollar_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%alpha = nested438
+$path = deep65`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$path": "deep65", "%alpha": "nested438"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_percent_dollar_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%alpha = nested438
+$path = deep65`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"%alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested438", result)
+
 }
+
 
 // s42_fuzz_nested_dquote_rbracket_5_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"gamma = nested524
 ]mode = deep57`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -946,27 +1511,70 @@ func TestS42FuzzNestedDquoteRbracket5Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_dquote_rbracket_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"gamma = nested524
+]mode = deep57`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"gamma": "nested524", "]mode": "deep57"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_dquote_rbracket_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"gamma = nested524
+]mode = deep57`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"gamma"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested524", result)
+
 }
+
 
 // s42_fuzz_nested_lbrace_ampersand_6_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{data = nested474
 &port = deep22`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -975,27 +1583,70 @@ func TestS42FuzzNestedLbraceAmpersand6Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_lbrace_ampersand_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{data = nested474
+&port = deep22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&port": "deep22", "{data": "nested474"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_lbrace_ampersand_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{data = nested474
+&port = deep22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested474", result)
+
 }
+
 
 // s42_fuzz_nested_semicolon_hyphen_7_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `;data = nested239
 -server = deep284`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1004,27 +1655,70 @@ func TestS42FuzzNestedSemicolonHyphen7Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;data = nested239
+-server = deep284`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"-server": "deep284", ";data": "nested239"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_semicolon_hyphen_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;data = nested239
+-server = deep284`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{";data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested239", result)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbrace_8_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `{host = nested125
 }user = deep615`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1033,27 +1727,70 @@ func TestS42FuzzNestedLbraceRbrace8Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_lbrace_rbrace_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested125
+}user = deep615`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"{host": "nested125", "}user": "deep615"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_lbrace_rbrace_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested125
+}user = deep615`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested125", result)
+
 }
+
 
 // s42_fuzz_nested_tilde_ampersand_9_parse - function:parse feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~beta = nested835
 &gamma = deep966`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1062,12 +1799,53 @@ func TestS42FuzzNestedTildeAmpersand9Parse(t *testing.T) {
 
 }
 
+
 // s42_fuzz_nested_tilde_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested835
+&gamma = deep966`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&gamma": "deep966", "~beta": "nested835"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s42_fuzz_nested_tilde_ampersand_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested835
+&gamma = deep966`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"~beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested835", result)
+
 }
+
+

--- a/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // s49_fuzz_single_lparen_parse - function:parse
 func TestS49FuzzSingleLparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `( = val911`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,16 +35,20 @@ func TestS49FuzzSingleLparenParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_pipe_parse - function:parse
 func TestS49FuzzSinglePipeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `| = val79`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -48,16 +57,20 @@ func TestS49FuzzSinglePipeParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_percent_parse - function:parse
 func TestS49FuzzSinglePercentParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `% = val935`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -66,16 +79,20 @@ func TestS49FuzzSinglePercentParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_asterisk_parse - function:parse
 func TestS49FuzzSingleAsteriskParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `* = val545`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,16 +101,20 @@ func TestS49FuzzSingleAsteriskParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_backslash_parse - function:parse
 func TestS49FuzzSingleBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `\ = val748`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -102,16 +123,20 @@ func TestS49FuzzSingleBackslashParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_slash_parse - function:parse
 func TestS49FuzzSingleSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/ = val718`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -120,16 +145,20 @@ func TestS49FuzzSingleSlashParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_rbracket_parse - function:parse
 func TestS49FuzzSingleRbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `] = val858`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -138,16 +167,20 @@ func TestS49FuzzSingleRbracketParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_ampersand_parse - function:parse
 func TestS49FuzzSingleAmpersandParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `& = val116`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -156,16 +189,20 @@ func TestS49FuzzSingleAmpersandParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_at_parse - function:parse
 func TestS49FuzzSingleAtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@ = val518`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -174,16 +211,20 @@ func TestS49FuzzSingleAtParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_dquote_parse - function:parse
 func TestS49FuzzSingleDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `" = val757`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -192,16 +233,20 @@ func TestS49FuzzSingleDquoteParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_dollar_parse - function:parse
 func TestS49FuzzSingleDollarParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$ = val874`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -210,16 +255,20 @@ func TestS49FuzzSingleDollarParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_bang_parse - function:parse
 func TestS49FuzzSingleBangParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `! = val221`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,16 +277,20 @@ func TestS49FuzzSingleBangParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_rparen_parse - function:parse
 func TestS49FuzzSingleRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `) = val331`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -246,16 +299,20 @@ func TestS49FuzzSingleRparenParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_rbrace_parse - function:parse
 func TestS49FuzzSingleRbraceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `} = val9`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -264,16 +321,20 @@ func TestS49FuzzSingleRbraceParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_single_tilde_parse - function:parse
 func TestS49FuzzSingleTildeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~ = val714`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -282,16 +343,20 @@ func TestS49FuzzSingleTildeParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_lparen_hash_asterisk_parse - function:parse
 func TestS49FuzzComboLparenHashAsteriskParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `(#* = combo926`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -300,16 +365,20 @@ func TestS49FuzzComboLparenHashAsteriskParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_rbrace_slash_underscore_rbrace_parse - function:parse
 func TestS49FuzzComboRbraceSlashUnderscoreRbraceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `}/_} = combo173`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,16 +387,20 @@ func TestS49FuzzComboRbraceSlashUnderscoreRbraceParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_rbracket_backslash_percent_at_parse - function:parse
 func TestS49FuzzComboRbracketBackslashPercentAtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `]\%@ = combo764`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -336,16 +409,20 @@ func TestS49FuzzComboRbracketBackslashPercentAtParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_rbracket_lbrace_squote_lbracket_parse - function:parse
 func TestS49FuzzComboRbracketLbraceSquoteLbracketParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `]{'[ = combo827`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -354,16 +431,20 @@ func TestS49FuzzComboRbracketLbraceSquoteLbracketParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_colon_rparen_parse - function:parse
 func TestS49FuzzComboColonRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `:) = combo140`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -372,16 +453,20 @@ func TestS49FuzzComboColonRparenParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_gt_tilde_rparen_parse - function:parse
 func TestS49FuzzComboGtTildeRparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `>~) = combo274`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -390,16 +475,20 @@ func TestS49FuzzComboGtTildeRparenParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_semicolon_gt_colon_parse - function:parse
 func TestS49FuzzComboSemicolonGtColonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `;>: = combo111`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -408,16 +497,20 @@ func TestS49FuzzComboSemicolonGtColonParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_question_plus_backslash_parse - function:parse
 func TestS49FuzzComboQuestionPlusBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `?+\ = combo711`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -426,16 +519,20 @@ func TestS49FuzzComboQuestionPlusBackslashParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_ampersand_ampersand_parse - function:parse
 func TestS49FuzzComboAmpersandAmpersandParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&& = combo102`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -444,16 +541,20 @@ func TestS49FuzzComboAmpersandAmpersandParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_combo_tilde_ampersand_tilde_parse - function:parse
 func TestS49FuzzComboTildeAmpersandTildeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~&~ = combo549`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -462,16 +563,20 @@ func TestS49FuzzComboTildeAmpersandTildeParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_start_hash_host_parse - function:parse
 func TestS49FuzzPosStartHashHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `#host = pos568`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -480,16 +585,20 @@ func TestS49FuzzPosStartHashHostParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_middle_slash_beta_parse - function:parse
 func TestS49FuzzPosMiddleSlashBetaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `be/ta = pos975`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -498,16 +607,20 @@ func TestS49FuzzPosMiddleSlashBetaParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_end_lparen_config_parse - function:parse
 func TestS49FuzzPosEndLparenConfigParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config( = pos258`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,16 +629,20 @@ func TestS49FuzzPosEndLparenConfigParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_start_squote_data_parse - function:parse
 func TestS49FuzzPosStartSquoteDataParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `'data = pos985`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -534,16 +651,20 @@ func TestS49FuzzPosStartSquoteDataParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_middle_rbracket_alpha_parse - function:parse
 func TestS49FuzzPosMiddleRbracketAlphaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `al]pha = pos844`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -552,16 +673,20 @@ func TestS49FuzzPosMiddleRbracketAlphaParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_end_percent_name_parse - function:parse
 func TestS49FuzzPosEndPercentNameParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name% = pos392`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -570,16 +695,20 @@ func TestS49FuzzPosEndPercentNameParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_start_rparen_user_parse - function:parse
 func TestS49FuzzPosStartRparenUserParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `)user = pos217`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -588,16 +717,20 @@ func TestS49FuzzPosStartRparenUserParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_middle_lbracket_host_parse - function:parse
 func TestS49FuzzPosMiddleLbracketHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ho[st = pos439`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -606,16 +739,20 @@ func TestS49FuzzPosMiddleLbracketHostParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_end_tilde_beta_parse - function:parse
 func TestS49FuzzPosEndTildeBetaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `beta~ = pos557`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -624,16 +761,20 @@ func TestS49FuzzPosEndTildeBetaParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_pos_start_dollar_config_parse - function:parse
 func TestS49FuzzPosStartDollarConfigParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$config = pos46`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -642,16 +783,20 @@ func TestS49FuzzPosStartDollarConfigParse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_epsilon_0_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `epsilon = data;x5&x96?x73`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,26 +805,67 @@ func TestS49FuzzValEpsilon0Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_epsilon_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `epsilon = data;x5&x96?x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"epsilon": "data;x5&x96?x73"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_val_epsilon_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `epsilon = data;x5&x96?x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "data;x5&x96?x73", result)
+
 }
+
 
 // s49_fuzz_val_config_1_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzValConfig1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config = data'x33`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -688,26 +874,67 @@ func TestS49FuzzValConfig1Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_config_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValConfig1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config = data'x33`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": "data'x33"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_val_config_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValConfig1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config = data'x33`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"config"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x33", result)
+
 }
+
 
 // s49_fuzz_val_name_2_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzValName2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = data<x71`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -716,26 +943,67 @@ func TestS49FuzzValName2Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValName2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data<x71`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data<x71"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValName2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data<x71`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data<x71", result)
+
 }
+
 
 // s49_fuzz_val_mode_3_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzValMode3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `mode = data+x19`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -744,26 +1012,67 @@ func TestS49FuzzValMode3Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_mode_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValMode3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data+x19`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mode": "data+x19"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_val_mode_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValMode3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data+x19`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mode"})
+	require.NoError(t, err)
+	assert.Equal(t, "data+x19", result)
+
 }
+
 
 // s49_fuzz_val_server_4_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzValServer4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `server = data#x70-x10`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -772,27 +1081,68 @@ func TestS49FuzzValServer4Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_val_server_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValServer4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data#x70-x10`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": "data#x70-x10"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_val_server_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValServer4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data#x70-x10`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"server"})
+	require.NoError(t, err)
+	assert.Equal(t, "data#x70-x10", result)
+
 }
+
 
 // s49_fuzz_nested_squote_lbrace_0_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `'name = nested330
 {user = deep34`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -801,27 +1151,70 @@ func TestS49FuzzNestedSquoteLbrace0Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_squote_lbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `'name = nested330
+{user = deep34`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"'name": "nested330", "{user": "deep34"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_squote_lbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `'name = nested330
+{user = deep34`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"'name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested330", result)
+
 }
+
 
 // s49_fuzz_nested_at_underscore_1_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `@name = nested517
 _user = deep650`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -830,27 +1223,70 @@ _user = deep650`
 
 }
 
+
 // s49_fuzz_nested_at_underscore_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@name = nested517
+_user = deep650`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"@name": "nested517", "_user": "deep650"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_at_underscore_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@name = nested517
+_user = deep650`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"@name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested517", result)
+
 }
+
 
 // s49_fuzz_nested_rparen_backslash_2_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `)epsilon = nested451
 \delta = deep648`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -859,27 +1295,70 @@ func TestS49FuzzNestedRparenBackslash2Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_rparen_backslash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)epsilon = nested451
+\delta = deep648`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")epsilon": "nested451", "\\delta": "deep648"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_rparen_backslash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)epsilon = nested451
+\delta = deep648`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{")epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested451", result)
+
 }
+
 
 // s49_fuzz_nested_dollar_gt_3_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$port = nested76
 >host = deep444`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -888,27 +1367,70 @@ func TestS49FuzzNestedDollarGt3Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_dollar_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$port = nested76
+>host = deep444`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$port": "nested76", ">host": "deep444"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_dollar_gt_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$port = nested76
+>host = deep444`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"$port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested76", result)
+
 }
+
 
 // s49_fuzz_nested_dquote_lbrace_4_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"host = nested587
 {gamma = deep774`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -917,27 +1439,70 @@ func TestS49FuzzNestedDquoteLbrace4Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_dquote_lbrace_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested587
+{gamma = deep774`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"host": "nested587", "{gamma": "deep774"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_dquote_lbrace_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested587
+{gamma = deep774`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested587", result)
+
 }
+
 
 // s49_fuzz_nested_semicolon_asterisk_5_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `;host = nested246
 *item = deep424`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -946,27 +1511,70 @@ func TestS49FuzzNestedSemicolonAsterisk5Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;host = nested246
+*item = deep424`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"*item": "deep424", ";host": "nested246"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_semicolon_asterisk_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;host = nested246
+*item = deep424`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{";host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested246", result)
+
 }
+
 
 // s49_fuzz_nested_question_asterisk_6_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `?epsilon = nested334
 *delta = deep689`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -975,27 +1583,70 @@ func TestS49FuzzNestedQuestionAsterisk6Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_question_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?epsilon = nested334
+*delta = deep689`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"*delta": "deep689", "?epsilon": "nested334"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_question_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?epsilon = nested334
+*delta = deep689`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested334", result)
+
 }
+
 
 // s49_fuzz_nested_plus_ampersand_7_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `+server = nested496
 &gamma = deep440`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1004,27 +1655,70 @@ func TestS49FuzzNestedPlusAmpersand7Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_plus_ampersand_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+server = nested496
+&gamma = deep440`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&gamma": "deep440", "+server": "nested496"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_plus_ampersand_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+server = nested496
+&gamma = deep440`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"+server"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested496", result)
+
 }
+
 
 // s49_fuzz_nested_asterisk_dquote_8_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `*item = nested578
 "delta = deep232`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1033,27 +1727,70 @@ func TestS49FuzzNestedAsteriskDquote8Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_asterisk_dquote_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `*item = nested578
+"delta = deep232`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"delta": "deep232", "*item": "nested578"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_asterisk_dquote_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `*item = nested578
+"delta = deep232`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"*item"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested578", result)
+
 }
+
 
 // s49_fuzz_nested_rbrace_slash_9_parse - function:parse feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `}host = nested668
 /delta = deep756`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1062,12 +1799,53 @@ func TestS49FuzzNestedRbraceSlash9Parse(t *testing.T) {
 
 }
 
+
 // s49_fuzz_nested_rbrace_slash_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}host = nested668
+/delta = deep756`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/delta": "deep756", "}host": "nested668"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s49_fuzz_nested_rbrace_slash_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}host = nested668
+/delta = deep756`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested668", result)
+
 }
+
+

--- a/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // s99_fuzz_single_underscore_parse - function:parse
 func TestS99FuzzSingleUnderscoreParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `_ = val35`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,16 +35,20 @@ func TestS99FuzzSingleUnderscoreParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_backslash_parse - function:parse
 func TestS99FuzzSingleBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `\ = val524`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -48,16 +57,20 @@ func TestS99FuzzSingleBackslashParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_percent_parse - function:parse
 func TestS99FuzzSinglePercentParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `% = val196`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -66,16 +79,20 @@ func TestS99FuzzSinglePercentParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_dquote_parse - function:parse
 func TestS99FuzzSingleDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `" = val52`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -84,16 +101,20 @@ func TestS99FuzzSingleDquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_pipe_parse - function:parse
 func TestS99FuzzSinglePipeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `| = val653`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -102,16 +123,20 @@ func TestS99FuzzSinglePipeParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_question_parse - function:parse
 func TestS99FuzzSingleQuestionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `? = val143`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -120,16 +145,20 @@ func TestS99FuzzSingleQuestionParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_rbrace_parse - function:parse
 func TestS99FuzzSingleRbraceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `} = val623`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -138,16 +167,20 @@ func TestS99FuzzSingleRbraceParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_hyphen_parse - function:parse
 func TestS99FuzzSingleHyphenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `- = val645`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -156,16 +189,20 @@ func TestS99FuzzSingleHyphenParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_lparen_parse - function:parse
 func TestS99FuzzSingleLparenParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `( = val220`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -174,16 +211,20 @@ func TestS99FuzzSingleLparenParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_slash_parse - function:parse
 func TestS99FuzzSingleSlashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/ = val115`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -192,16 +233,20 @@ func TestS99FuzzSingleSlashParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_bang_parse - function:parse
 func TestS99FuzzSingleBangParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `! = val103`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -210,16 +255,20 @@ func TestS99FuzzSingleBangParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_hash_parse - function:parse
 func TestS99FuzzSingleHashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `# = val874`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,16 +277,20 @@ func TestS99FuzzSingleHashParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_ampersand_parse - function:parse
 func TestS99FuzzSingleAmpersandParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `& = val520`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -246,16 +299,20 @@ func TestS99FuzzSingleAmpersandParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_dollar_parse - function:parse
 func TestS99FuzzSingleDollarParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `$ = val921`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -264,16 +321,20 @@ func TestS99FuzzSingleDollarParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_single_colon_parse - function:parse
 func TestS99FuzzSingleColonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `: = val671`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -282,16 +343,20 @@ func TestS99FuzzSingleColonParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_lbracket_asterisk_gt_parse - function:parse
 func TestS99FuzzComboLbracketAsteriskGtParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `[*> = combo828`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -300,16 +365,20 @@ func TestS99FuzzComboLbracketAsteriskGtParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_percent_semicolon_squote_parse - function:parse
 func TestS99FuzzComboPercentSemicolonSquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `%;' = combo983`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,16 +387,20 @@ func TestS99FuzzComboPercentSemicolonSquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_squote_underscore_rparen_squote_parse - function:parse
 func TestS99FuzzComboSquoteUnderscoreRparenSquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `'_)' = combo857`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -336,16 +409,20 @@ func TestS99FuzzComboSquoteUnderscoreRparenSquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_underscore_lbracket_lt_backslash_parse - function:parse
 func TestS99FuzzComboUnderscoreLbracketLtBackslashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `_[<\ = combo602`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -354,16 +431,20 @@ func TestS99FuzzComboUnderscoreLbracketLtBackslashParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_ampersand_lparen_dquote_parse - function:parse
 func TestS99FuzzComboAmpersandLparenDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `&(" = combo48`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -372,16 +453,20 @@ func TestS99FuzzComboAmpersandLparenDquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_rparen_pipe_lparen_hash_parse - function:parse
 func TestS99FuzzComboRparenPipeLparenHashParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `)|(# = combo531`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -390,16 +475,20 @@ func TestS99FuzzComboRparenPipeLparenHashParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_tilde_asterisk_at_question_parse - function:parse
 func TestS99FuzzComboTildeAsteriskAtQuestionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `~*@? = combo716`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -408,16 +497,20 @@ func TestS99FuzzComboTildeAsteriskAtQuestionParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_underscore_asterisk_question_parse - function:parse
 func TestS99FuzzComboUnderscoreAsteriskQuestionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `_*? = combo909`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -426,16 +519,20 @@ func TestS99FuzzComboUnderscoreAsteriskQuestionParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_bang_squote_parse - function:parse
 func TestS99FuzzComboBangSquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `!' = combo182`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -444,16 +541,20 @@ func TestS99FuzzComboBangSquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_combo_question_underscore_dquote_parse - function:parse
 func TestS99FuzzComboQuestionUnderscoreDquoteParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `?_" = combo211`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -462,16 +563,20 @@ func TestS99FuzzComboQuestionUnderscoreDquoteParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_start_percent_item_parse - function:parse
 func TestS99FuzzPosStartPercentItemParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `%item = pos832`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -480,16 +585,20 @@ func TestS99FuzzPosStartPercentItemParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_middle_rbracket_data_parse - function:parse
 func TestS99FuzzPosMiddleRbracketDataParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `da]ta = pos418`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -498,16 +607,20 @@ func TestS99FuzzPosMiddleRbracketDataParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_end_gt_delta_parse - function:parse
 func TestS99FuzzPosEndGtDeltaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `delta> = pos239`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,16 +629,20 @@ func TestS99FuzzPosEndGtDeltaParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_start_rparen_port_parse - function:parse
 func TestS99FuzzPosStartRparenPortParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `)port = pos895`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -534,16 +651,20 @@ func TestS99FuzzPosStartRparenPortParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_middle_underscore_alpha_parse - function:parse
 func TestS99FuzzPosMiddleUnderscoreAlphaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `al_pha = pos195`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -552,16 +673,20 @@ func TestS99FuzzPosMiddleUnderscoreAlphaParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_end_lbrace_epsilon_parse - function:parse
 func TestS99FuzzPosEndLbraceEpsilonParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `epsilon{ = pos824`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -570,16 +695,20 @@ func TestS99FuzzPosEndLbraceEpsilonParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_start_lt_alpha_parse - function:parse
 func TestS99FuzzPosStartLtAlphaParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `<alpha = pos633`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -588,16 +717,20 @@ func TestS99FuzzPosStartLtAlphaParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_middle_percent_host_parse - function:parse
 func TestS99FuzzPosMiddlePercentHostParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ho%st = pos14`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -606,16 +739,20 @@ func TestS99FuzzPosMiddlePercentHostParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_end_pipe_item_parse - function:parse
 func TestS99FuzzPosEndPipeItemParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item| = pos19`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -624,16 +761,20 @@ func TestS99FuzzPosEndPipeItemParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_pos_start_percent_server_parse - function:parse
 func TestS99FuzzPosStartPercentServerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `%server = pos981`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -642,16 +783,20 @@ func TestS99FuzzPosStartPercentServerParse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_path_0_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzValPath0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `path = data'x66`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,26 +805,67 @@ func TestS99FuzzValPath0Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_path_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data'x66`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data'x66"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_val_path_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data'x66`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x66", result)
+
 }
+
 
 // s99_fuzz_val_item_1_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzValItem1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = data]x41!x78`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -688,26 +874,67 @@ func TestS99FuzzValItem1Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_item_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValItem1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = data]x41!x78`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "data]x41!x78"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_val_item_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValItem1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = data]x41!x78`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"item"})
+	require.NoError(t, err)
+	assert.Equal(t, "data]x41!x78", result)
+
 }
+
 
 // s99_fuzz_val_server_2_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzValServer2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `server = data[x73;x54!x24`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -716,26 +943,67 @@ func TestS99FuzzValServer2Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_server_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValServer2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data[x73;x54!x24`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": "data[x73;x54!x24"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_val_server_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValServer2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data[x73;x54!x24`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"server"})
+	require.NoError(t, err)
+	assert.Equal(t, "data[x73;x54!x24", result)
+
 }
+
 
 // s99_fuzz_val_path_3_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzValPath3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `path = data~x4>x82~x46`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -744,26 +1012,67 @@ func TestS99FuzzValPath3Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data~x4>x82~x46`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data~x4>x82~x46"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data~x4>x82~x46`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data~x4>x82~x46", result)
+
 }
+
 
 // s99_fuzz_val_alpha_4_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzValAlpha4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `alpha = data<x11[x43`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -772,27 +1081,68 @@ func TestS99FuzzValAlpha4Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_val_alpha_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValAlpha4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `alpha = data<x11[x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"alpha": "data<x11[x43"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_val_alpha_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValAlpha4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `alpha = data<x11[x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "data<x11[x43", result)
+
 }
+
 
 // s99_fuzz_nested_slash_rparen_0_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/data = nested929
 )item = deep37`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -801,27 +1151,70 @@ func TestS99FuzzNestedSlashRparen0Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_slash_rparen_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/data = nested929
+)item = deep37`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")item": "deep37", "/data": "nested929"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_slash_rparen_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/data = nested929
+)item = deep37`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"/data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested929", result)
+
 }
+
 
 // s99_fuzz_nested_lt_percent_1_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `<port = nested722
 %config = deep795`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -830,27 +1223,70 @@ func TestS99FuzzNestedLtPercent1Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_lt_percent_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `<port = nested722
+%config = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%config": "deep795", "<port": "nested722"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_lt_percent_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `<port = nested722
+%config = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"<port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested722", result)
+
 }
+
 
 // s99_fuzz_nested_slash_lbrace_2_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `/epsilon = nested268
 {server = deep795`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -859,27 +1295,70 @@ func TestS99FuzzNestedSlashLbrace2Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_slash_lbrace_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/epsilon = nested268
+{server = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/epsilon": "nested268", "{server": "deep795"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_slash_lbrace_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/epsilon = nested268
+{server = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"/epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested268", result)
+
 }
+
 
 // s99_fuzz_nested_dquote_lbracket_3_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"host = nested435
 [server = deep479`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -888,27 +1367,70 @@ func TestS99FuzzNestedDquoteLbracket3Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_dquote_lbracket_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested435
+[server = deep479`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"host": "nested435", "[server": "deep479"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_dquote_lbracket_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested435
+[server = deep479`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested435", result)
+
 }
+
 
 // s99_fuzz_nested_backslash_backslash_4_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `\item = nested708
 \name = deep133`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -917,27 +1439,70 @@ func TestS99FuzzNestedBackslashBackslash4Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_backslash_backslash_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `\item = nested708
+\name = deep133`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\\item": "nested708", "\\name": "deep133"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_backslash_backslash_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `\item = nested708
+\name = deep133`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\\item"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested708", result)
+
 }
+
 
 // s99_fuzz_nested_question_dquote_5_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `?delta = nested18
 "item = deep576`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -946,27 +1511,70 @@ func TestS99FuzzNestedQuestionDquote5Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_question_dquote_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?delta = nested18
+"item = deep576`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"item": "deep576", "?delta": "nested18"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_question_dquote_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?delta = nested18
+"item = deep576`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested18", result)
+
 }
+
 
 // s99_fuzz_nested_dquote_backslash_6_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `"user = nested759
 \data = deep718`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -975,27 +1583,70 @@ func TestS99FuzzNestedDquoteBackslash6Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_dquote_backslash_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"user = nested759
+\data = deep718`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"user": "nested759", "\\data": "deep718"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_dquote_backslash_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"user = nested759
+\data = deep718`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"user"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested759", result)
+
 }
+
 
 // s99_fuzz_nested_rparen_backslash_7_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `)port = nested292
 \server = deep527`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1004,27 +1655,70 @@ func TestS99FuzzNestedRparenBackslash7Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_rparen_backslash_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)port = nested292
+\server = deep527`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")port": "nested292", "\\server": "deep527"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_rparen_backslash_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)port = nested292
+\server = deep527`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{")port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested292", result)
+
 }
+
 
 // s99_fuzz_nested_rbrace_dollar_8_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `}delta = nested591
 $gamma = deep225`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1033,27 +1727,70 @@ $gamma = deep225`
 
 }
 
+
 // s99_fuzz_nested_rbrace_dollar_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}delta = nested591
+$gamma = deep225`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$gamma": "deep225", "}delta": "nested591"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_rbrace_dollar_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}delta = nested591
+$gamma = deep225`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested591", result)
+
 }
+
 
 // s99_fuzz_nested_percent_ampersand_9_parse - function:parse feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9Parse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `%epsilon = nested761
 &port = deep211`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -1062,12 +1799,53 @@ func TestS99FuzzNestedPercentAmpersand9Parse(t *testing.T) {
 
 }
 
+
 // s99_fuzz_nested_percent_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%epsilon = nested761
+&port = deep211`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%epsilon": "nested761", "&port": "deep211"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // s99_fuzz_nested_percent_ampersand_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%epsilon = nested761
+&port = deep211`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"%epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested761", result)
+
 }
+
+

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,18 +12,23 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // basic_list_from_duplicates_parse - function:parse
 func TestBasicListFromDuplicatesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
 servers = web2
 servers = web3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -32,18 +37,61 @@ servers = web3`
 
 }
 
+
 // basic_list_from_duplicates_build_hierarchy - function:build_hierarchy
 func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // basic_list_from_duplicates_get_list - function:get_list behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
+
 
 // large_list_parse - function:parse
 func TestLargeListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items = item01
@@ -66,11 +114,13 @@ items = item17
 items = item18
 items = item19
 items = item20`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -79,18 +129,95 @@ items = item20`
 
 }
 
+
 // large_list_build_hierarchy - function:build_hierarchy
 func TestLargeListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // large_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestLargeListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}, result)
+
 }
+
 
 // list_with_comments_parse - function:parse feature:comments
 func TestListWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
@@ -98,11 +225,13 @@ func TestListWithCommentsParse(t *testing.T) {
 servers = web2
 servers = web3
 /= End of list`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -110,19 +239,11 @@ servers = web3
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_insertion
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// list_with_comments_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
-func TestListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// list_with_comments_lexicographic_parse - function:parse feature:comments
-func TestListWithCommentsLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers = web1
@@ -130,11 +251,68 @@ func TestListWithCommentsLexicographicParse(t *testing.T) {
 servers = web2
 servers = web3
 /= End of list`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"Production servers", "End of list"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// list_with_comments_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
+func TestListWithCommentsGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
+}
+
+
+// list_with_comments_lexicographic_parse - function:parse feature:comments
+func TestListWithCommentsLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -143,26 +321,75 @@ servers = web3
 
 }
 
+
 // list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"End of list", "Production servers"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_comments_lexicographic_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
+
 
 // list_error_missing_key_parse - function:parse
 func TestListErrorMissingKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `existing = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -171,27 +398,71 @@ func TestListErrorMissingKeyParse(t *testing.T) {
 
 }
 
+
 // list_error_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_missing_key_get_list - function:get_list
 func TestListErrorMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_error_nested_missing_key_parse - function:parse
 func TestListErrorNestedMissingKeyParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   server = web1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -200,26 +471,72 @@ func TestListErrorNestedMissingKeyParse(t *testing.T) {
 
 }
 
+
 // list_error_nested_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorNestedMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"server": "web1"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_nested_missing_key_get_list - function:get_list
 func TestListErrorNestedMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_error_non_object_path_parse - function:parse
 func TestListErrorNonObjectPathParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `value = simple`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -228,26 +545,70 @@ func TestListErrorNonObjectPathParse(t *testing.T) {
 
 }
 
+
 // list_error_non_object_path_build_hierarchy - function:build_hierarchy
 func TestListErrorNonObjectPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"value": "simple"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_error_non_object_path_get_list - function:get_list
 func TestListErrorNonObjectPathGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"value", "nested"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_edge_case_zero_length_parse - function:parse
 func TestListEdgeCaseZeroLengthParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := ""
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -256,29 +617,73 @@ func TestListEdgeCaseZeroLengthParse(t *testing.T) {
 
 }
 
+
 // list_edge_case_zero_length_build_hierarchy - function:build_hierarchy
 func TestListEdgeCaseZeroLengthBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_edge_case_zero_length_get_list - function:get_list
 func TestListEdgeCaseZeroLengthGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"nonexistent"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // bare_list_basic_parse - function:parse feature:empty_keys
 func TestBareListBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `servers =
   = web1
   = web2
   = web3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -287,18 +692,63 @@ func TestBareListBasicParse(t *testing.T) {
 
 }
 
+
 // bare_list_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_basic_get_list - function:get_list feature:empty_keys
 func TestBareListBasicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
+
 
 // bare_list_nested_parse - function:parse feature:empty_keys
 func TestBareListNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `network =
@@ -306,11 +756,13 @@ func TestBareListNestedParse(t *testing.T) {
     = 80
     = 443
     = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -318,19 +770,11 @@ func TestBareListNestedParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
-func TestBareListNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys
-func TestBareListNestedLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `network =
@@ -338,11 +782,68 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
     = 80
     = 443
     = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"80", "443", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+func TestBareListNestedGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"80", "443", "8080"}, result)
+
+}
+
+
+// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys
+func TestBareListNestedLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -351,18 +852,65 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"443", "80", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"443", "80", "8080"}, result)
+
 }
+
 
 // bare_list_with_comments_parse - function:parse feature:empty_keys feature:comments
 func TestBareListWithCommentsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `allowed_hosts =
@@ -370,11 +918,13 @@ func TestBareListWithCommentsParse(t *testing.T) {
   = localhost
   = 127.0.0.1
   = example.com`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -382,19 +932,11 @@ func TestBareListWithCommentsParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_with_comments_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
-func TestBareListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_with_comments_lexicographic_parse - function:parse feature:empty_keys feature:comments
-func TestBareListWithCommentsLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `allowed_hosts =
@@ -402,11 +944,68 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
   = localhost
   = 127.0.0.1
   = example.com`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"localhost", "127.0.0.1", "example.com"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
+func TestBareListWithCommentsGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost", "127.0.0.1", "example.com"}, result)
+
+}
+
+
+// bare_list_with_comments_lexicographic_parse - function:parse feature:empty_keys feature:comments
+func TestBareListWithCommentsLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -415,18 +1014,65 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"127.0.0.1", "example.com", "localhost"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_with_comments_lexicographic_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"127.0.0.1", "example.com", "localhost"}, result)
+
 }
+
 
 // bare_list_deeply_nested_parse - function:parse feature:empty_keys
 func TestBareListDeeplyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -436,11 +1082,13 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
         = web1
         = web2
         = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -448,19 +1096,11 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
-func TestBareListDeeplyNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys
-func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -470,11 +1110,72 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
         = web1
         = web2
         = api1`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "api1"}}}}}}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+func TestBareListDeeplyNestedGetList(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "api1"}, result)
+
+}
+
+
+// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys
+func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -483,18 +1184,69 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 
 }
 
+
 // bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"api1", "web1", "web2"}}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_deeply_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"api1", "web1", "web2"}, result)
+
 }
+
 
 // bare_list_mixed_with_other_keys_parse - function:parse feature:empty_keys
 func TestBareListMixedWithOtherKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
@@ -503,11 +1255,13 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
   replicas =
     = replica1
     = replica2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -516,27 +1270,78 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 
 }
 
+
 // bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"host": "localhost", "port": "5432", "replicas": map[string]interface{}{"": []interface{}{"replica1", "replica2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys
 func TestBareListMixedWithOtherKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "replicas"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"replica1", "replica2"}, result)
+
 }
+
 
 // bare_list_error_not_a_list_parse - function:parse
 func TestBareListErrorNotAListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
   setting = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -545,18 +1350,62 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 
 }
 
+
 // bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"setting": "value"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_error_not_a_list_get_list - function:get_list behavior:list_coercion_disabled
 func TestBareListErrorNotAListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "setting"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // bare_list_nested_objects_basic_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -566,11 +1415,13 @@ func TestBareListNestedObjectsBasicParse(t *testing.T) {
   =
     name = second
     value = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -579,29 +1430,82 @@ func TestBareListNestedObjectsBasicParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "first", "value": "1"}, map[string]interface{}{"name": "second", "value": "2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_objects_basic_get_list - function:get_list feature:empty_keys
 func TestBareListNestedObjectsBasicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{map[string]interface {}{"name":"first", "value":"1"}, map[string]interface {}{"name":"second", "value":"2"}}, result)
+
 }
+
 
 // bare_list_nested_objects_single_item_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsSingleItemParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
   =
     name = only
     value = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -610,18 +1514,63 @@ func TestBareListNestedObjectsSingleItemParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_single_item_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsSingleItemBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = only
+    value = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "only", "value": "42"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_objects_single_item_get_list - function:get_list feature:empty_keys
 func TestBareListNestedObjectsSingleItemGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = only
+    value = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{map[string]interface {}{"name":"only", "value":"42"}}, result)
+
 }
+
 
 // bare_list_nested_objects_minimal_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsMinimalParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -629,11 +1578,13 @@ func TestBareListNestedObjectsMinimalParse(t *testing.T) {
     name = first
   =
     name = second`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -642,13 +1593,37 @@ func TestBareListNestedObjectsMinimalParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_minimal_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsMinimalBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+  =
+    name = second`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "first"}, map[string]interface{}{"name": "second"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_objects_deeply_nested_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsDeeplyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -660,11 +1635,13 @@ func TestBareListNestedObjectsDeeplyNestedParse(t *testing.T) {
     config =
       host = example.com
       port = 443`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -673,13 +1650,41 @@ func TestBareListNestedObjectsDeeplyNestedParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    config =
+      host = localhost
+      port = 8080
+  =
+    config =
+      host = example.com
+      port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"config": map[string]interface{}{"host": "localhost", "port": "8080"}}, map[string]interface{}{"config": map[string]interface{}{"host": "example.com", "port": "443"}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_objects_mixed_with_strings_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsMixedWithStringsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -688,11 +1693,13 @@ func TestBareListNestedObjectsMixedWithStringsParse(t *testing.T) {
     name = nested
     value = obj
   = another_string`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -701,13 +1708,38 @@ func TestBareListNestedObjectsMixedWithStringsParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_mixed_with_strings_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedObjectsMixedWithStringsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  = simple_string
+  =
+    name = nested
+    value = obj
+  = another_string`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{"simple_string", map[string]interface{}{"name": "nested", "value": "obj"}, "another_string"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // bare_list_nested_objects_round_trip_parse - function:parse feature:empty_keys
 func TestBareListNestedObjectsRoundTripParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -717,11 +1749,13 @@ func TestBareListNestedObjectsRoundTripParse(t *testing.T) {
   =
     name = second
     value = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -730,13 +1764,10 @@ func TestBareListNestedObjectsRoundTripParse(t *testing.T) {
 
 }
 
+
 // bare_list_nested_objects_round_trip_print - function:print feature:empty_keys
 func TestBareListNestedObjectsRoundTripPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// bare_list_nested_objects_round_trip_round_trip - function:parse function:print feature:empty_keys
-func TestBareListNestedObjectsRoundTripRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =
@@ -746,14 +1777,45 @@ func TestBareListNestedObjectsRoundTripRoundTrip(t *testing.T) {
   =
     name = second
     value = 2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
+
+// bare_list_nested_objects_round_trip_round_trip - function:parse function:print feature:empty_keys
+func TestBareListNestedObjectsRoundTripRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,51 +12,193 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // multiline_section_header_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline variant:proposed_behavior
 func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+  This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // unindented_multiline_becomes_continuation_parse_indented - function:parse_indented feature:empty_keys variant:proposed_behavior
 func TestUnindentedMultilineBecomesContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline variant:proposed_behavior
 func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline variant:proposed_behavior
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line\n  second line", "Another item"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line\n  second line", "Another item"}, result)
+
 }
+
 
 // mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline feature:empty_keys variant:proposed_behavior
 func TestMixedIndentationLevelsParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline feature:empty_keys variant:proposed_behavior
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1\n  indented continuation", "key2": "value2", "not indented key": map[string]interface{}{"indented for not indented": ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // single_item_as_list_parse - function:parse variant:proposed_behavior
 func TestSingleItemAsListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = single`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -65,28 +207,69 @@ func TestSingleItemAsListParse(t *testing.T) {
 
 }
 
+
 // single_item_as_list_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestSingleItemAsListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // single_item_as_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestSingleItemAsListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"single"}, result)
+
 }
+
 
 // mixed_duplicate_single_keys_parse - function:parse variant:proposed_behavior
 func TestMixedDuplicateSingleKeysParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 80
 ports = 443
 host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -95,29 +278,74 @@ host = localhost`
 
 }
 
+
 // mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"80", "443"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost"}, result)
+
 }
+
 
 // nested_list_access_parse - function:parse variant:proposed_behavior
 func TestNestedListAccessParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   hosts = primary
   hosts = secondary
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -126,26 +354,73 @@ func TestNestedListAccessParse(t *testing.T) {
 
 }
 
+
 // nested_list_access_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestNestedListAccessBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_list_access_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestNestedListAccessGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"5432"}, result)
+
 }
+
 
 // empty_list_parse - function:parse variant:proposed_behavior
 func TestEmptyListParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_list =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -154,29 +429,70 @@ func TestEmptyListParse(t *testing.T) {
 
 }
 
+
 // empty_list_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestEmptyListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // empty_list_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestEmptyListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{""}, result)
+
 }
+
 
 // list_with_numbers_parse - function:parse variant:proposed_behavior
 func TestListWithNumbersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `numbers = 1
 numbers = 42
 numbers = -17
 numbers = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -185,29 +501,76 @@ numbers = 0`
 
 }
 
+
 // list_with_numbers_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"1", "42", "-17", "0"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithNumbersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"1", "42", "-17", "0"}, result)
+
 }
+
 
 // list_with_booleans_parse - function:parse variant:proposed_behavior
 func TestListWithBooleansParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flags = true
 flags = false
 flags = yes
 flags = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -216,29 +579,76 @@ flags = no`
 
 }
 
+
 // list_with_booleans_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"true", "false", "yes", "no"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithBooleansGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"true", "false", "yes", "no"}, result)
+
 }
+
 
 // list_with_whitespace_parse - function:parse feature:whitespace variant:proposed_behavior
 func TestListWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =   spaced   
 items = normal
 items =
 items =   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -247,29 +657,76 @@ items =   `
 
 }
 
+
 // list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace variant:proposed_behavior
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"spaced", "normal", "", ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithWhitespaceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"spaced", "normal", "", ""}, result)
+
 }
+
 
 // list_with_unicode_parse - function:parse feature:unicode variant:proposed_behavior
 func TestListWithUnicodeParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `names = 张三
 names = José
 names = François
 names = العربية`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -278,29 +735,76 @@ names = العربية`
 
 }
 
+
 // list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode variant:proposed_behavior
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"张三", "José", "François", "العربية"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithUnicodeGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"张三", "José", "François", "العربية"}, result)
+
 }
+
 
 // list_with_special_characters_parse - function:parse variant:proposed_behavior
 func TestListWithSpecialCharactersParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `symbols = @#$%
 symbols = !^&*()
 symbols = []{}|
 symbols = <>=+`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -309,56 +813,248 @@ symbols = <>=+`
 
 }
 
+
 // list_with_special_characters_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"@#$%", "!^&*()", "[]{}|", "<>=+"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListWithSpecialCharactersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"@#$%", "!^&*()", "[]{}|", "<>=+"}, result)
+
 }
+
 
 // list_multiline_values_parse_indented - function:parse_indented feature:multiline variant:proposed_behavior
 func TestListMultilineValuesParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline variant:proposed_behavior
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line", "Another item", "Third item"}, "second line": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled variant:proposed_behavior
 func TestListMultilineValuesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line", "Another item", "Third item"}, result)
+
 }
+
 
 // complex_mixed_list_scenarios_parse_indented - function:parse_indented variant:proposed_behavior
 func TestComplexMixedListScenariosParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"primary", "backup"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"auth", "api", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complex_mixed_list_scenarios_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestComplexMixedListScenariosGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"auth", "api", "ui"}, result)
+
 }
+
 
 // list_path_traversal_protection_parse - function:parse variant:proposed_behavior
 func TestListPathTraversalProtectionParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `safe = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -367,26 +1063,67 @@ func TestListPathTraversalProtectionParse(t *testing.T) {
 
 }
 
+
 // list_path_traversal_protection_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestListPathTraversalProtectionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_path_traversal_protection_get_list - function:get_list behavior:list_coercion_enabled variant:proposed_behavior
 func TestListPathTraversalProtectionGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"value"}, result)
+
 }
+
 
 // parse_empty_value_parse - function:parse variant:proposed_behavior
 func TestParseEmptyValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -395,12 +1132,51 @@ func TestParseEmptyValueParse(t *testing.T) {
 
 }
 
+
 // parse_empty_value_build_hierarchy - function:build_hierarchy variant:proposed_behavior
 func TestParseEmptyValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_empty_value_get_string - function:get_string variant:proposed_behavior
 func TestParseEmptyValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"empty_key"})
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+
 }
+
+

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // single_item_as_list_reference_parse - function:parse variant:reference_compliant
 func TestSingleItemAsListReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `item = single`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,28 +35,72 @@ func TestSingleItemAsListReferenceParse(t *testing.T) {
 
 }
 
+
 // single_item_as_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestSingleItemAsListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // single_item_as_list_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // mixed_duplicate_single_keys_reference_parse - function:parse
 func TestMixedDuplicateSingleKeysReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `ports = 80
 ports = 443
 host = localhost`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -60,29 +109,77 @@ host = localhost`
 
 }
 
+
 // mixed_duplicate_single_keys_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"443", "80"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // mixed_duplicate_single_keys_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // nested_list_access_reference_parse - function:parse variant:reference_compliant
 func TestNestedListAccessReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `database =
   hosts = primary
   hosts = secondary
   port = 5432`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -91,26 +188,76 @@ func TestNestedListAccessReferenceParse(t *testing.T) {
 
 }
 
+
 // nested_list_access_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // nested_list_access_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // empty_list_reference_parse - function:parse variant:reference_compliant
 func TestEmptyListReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_list =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -119,29 +266,73 @@ func TestEmptyListReferenceParse(t *testing.T) {
 
 }
 
+
 // empty_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // empty_list_reference_get_list - function:get_list variant:reference_compliant
 func TestEmptyListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_with_numbers_reference_parse - function:parse
 func TestListWithNumbersReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `numbers = 1
 numbers = 42
 numbers = -17
 numbers = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -150,29 +341,79 @@ numbers = 0`
 
 }
 
+
 // list_with_numbers_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithNumbersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"-17", "0", "1", "42"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_numbers_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_with_booleans_reference_parse - function:parse
 func TestListWithBooleansReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flags = true
 flags = false
 flags = yes
 flags = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -181,29 +422,79 @@ flags = no`
 
 }
 
+
 // list_with_booleans_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithBooleansReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"false", "no", "true", "yes"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_booleans_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithBooleansReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_with_whitespace_reference_parse - function:parse feature:whitespace
 func TestListWithWhitespaceReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `items =   spaced   
 items = normal
 items =
 items =   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -212,29 +503,79 @@ items =   `
 
 }
 
+
 // list_with_whitespace_reference_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"normal", "spaced"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_whitespace_reference_get_list - function:get_list feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_with_unicode_reference_parse - function:parse feature:unicode
 func TestListWithUnicodeReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `names = 张三
 names = José
 names = François
 names = العربية`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -243,28 +584,78 @@ names = العربية`
 
 }
 
+
 // list_with_unicode_reference_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"François", "José", "العربية", "张三"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_unicode_reference_get_list - function:get_list feature:unicode behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_with_special_characters_reference_parse - function:parse
 func TestListWithSpecialCharactersReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `symbols = @#$%
 symbols = !^&*()
 symbols = []{}|`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -273,36 +664,144 @@ symbols = []{}|`
 
 }
 
+
 // list_with_special_characters_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"!^&*()", "@#$%", "[]{}|"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_with_special_characters_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"backup", "primary"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"api", "auth", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // complex_mixed_list_scenarios_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // list_path_traversal_protection_reference_parse - function:parse variant:reference_compliant
 func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `safe = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -311,26 +810,70 @@ func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
 
 }
 
+
 // list_path_traversal_protection_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestListPathTraversalProtectionReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // list_path_traversal_protection_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
+
 
 // empty_value_reference_behavior_parse - function:parse variant:reference_compliant
 func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -339,95 +882,180 @@ func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
 
 }
 
+
 // empty_value_reference_behavior_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyValueReferenceBehaviorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// canonical_format_empty_values_ocaml_reference_canonical_format - function:parse function:print variant:reference_compliant
-func TestCanonicalFormatEmptyValuesOcamlReferenceCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_key =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
 
 }
+
+
+// canonical_format_empty_values_ocaml_reference_canonical_format - function:parse function:print variant:reference_compliant
+func TestCanonicalFormatEmptyValuesOcamlReferenceCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
 
 // canonical_format_tab_preservation_ocaml_reference_canonical_format - function:parse function:print behavior:tabs_as_content variant:reference_compliant
 func TestCanonicalFormatTabPreservationOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `value_with_tabs = text		with	tabs	`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_unicode_ocaml_reference_canonical_format - function:parse function:print feature:unicode variant:reference_compliant
 func TestCanonicalFormatUnicodeOcamlReferenceCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `unicode = 你好世界
 emo = 🌟✨`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
 
 // canonical_format_line_endings_reference_behavior_parse - function:parse behavior:crlf_preserve_literal variant:reference_compliant
 func TestCanonicalFormatLineEndingsReferenceBehaviorParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // canonical_format_line_endings_reference_behavior_canonical_format - function:parse function:print behavior:crlf_preserve_literal variant:reference_compliant
 func TestCanonicalFormatLineEndingsReferenceBehaviorCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // canonical_format_consistent_spacing_ocaml_reference_canonical_format - function:parse function:print variant:reference_compliant
 func TestCanonicalFormatConsistentSpacingOcamlReferenceCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key1=value1
 key2  =  value2
 key3	=	value3`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
 // deterministic_output_ocaml_reference_canonical_format - function:parse function:print variant:reference_compliant
 func TestDeterministicOutputOcamlReferenceCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `z = last
 a = first
 m = middle`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
+

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,16 +12,21 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // parse_basic_integer_parse - function:parse feature:optional_typed_accessors
 func TestParseBasicIntegerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `port = 8080`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -30,26 +35,67 @@ func TestParseBasicIntegerParse(t *testing.T) {
 
 }
 
+
 // parse_basic_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "8080"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_basic_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBasicIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
+
 
 // parse_basic_float_parse - function:parse feature:optional_typed_accessors
 func TestParseBasicFloatParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `temperature = 98.6`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -58,26 +104,67 @@ func TestParseBasicFloatParse(t *testing.T) {
 
 }
 
+
 // parse_basic_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicFloatBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "98.6"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_basic_float_get_float - function:get_float feature:optional_typed_accessors
 func TestParseBasicFloatGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	require.NoError(t, err)
+	assert.Equal(t, 98.6, result)
+
 }
+
 
 // parse_boolean_true_parse - function:parse feature:optional_typed_accessors
 func TestParseBooleanTrueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `enabled = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -86,26 +173,67 @@ func TestParseBooleanTrueParse(t *testing.T) {
 
 }
 
+
 // parse_boolean_true_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanTrueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "true"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_true_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // parse_boolean_yes_parse - function:parse feature:optional_typed_accessors
 func TestParseBooleanYesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `active = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -113,27 +241,68 @@ func TestParseBooleanYesParse(t *testing.T) {
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // parse_boolean_yes_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_yes_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
-func TestParseBooleanYesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_yes_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `active = yes`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// parse_boolean_yes_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseBooleanYesGetBool(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
+}
+
+
+// parse_boolean_yes_strict_literal_parse - function:parse feature:optional_typed_accessors
+func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -142,26 +311,70 @@ func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
 
 }
 
+
 // parse_boolean_yes_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_yes_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanYesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // parse_boolean_false_parse - function:parse feature:optional_typed_accessors
 func TestParseBooleanFalseParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `disabled = false`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -170,26 +383,67 @@ func TestParseBooleanFalseParse(t *testing.T) {
 
 }
 
+
 // parse_boolean_false_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanFalseBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"disabled": "false"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_false_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanFalseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
+
 
 // parse_string_fallback_parse - function:parse
 func TestParseStringFallbackParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -198,26 +452,67 @@ func TestParseStringFallbackParse(t *testing.T) {
 
 }
 
+
 // parse_string_fallback_build_hierarchy - function:build_hierarchy
 func TestParseStringFallbackBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_string_fallback_get_string - function:get_string
 func TestParseStringFallbackGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", result)
+
 }
+
 
 // parse_negative_integer_parse - function:parse feature:optional_typed_accessors
 func TestParseNegativeIntegerParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `offset = -42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -226,28 +521,69 @@ func TestParseNegativeIntegerParse(t *testing.T) {
 
 }
 
+
 // parse_negative_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseNegativeIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"offset": "-42"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_negative_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseNegativeIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"offset"})
+	require.NoError(t, err)
+	assert.Equal(t, -42, result)
+
 }
+
 
 // parse_zero_values_parse - function:parse feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `count = 0
 distance = 0.0
 disabled = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -255,39 +591,126 @@ disabled = no`
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // parse_zero_values_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
-func TestParseZeroValuesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
-func TestParseZeroValuesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
-func TestParseZeroValuesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_zero_values_strict_literal_parse - function:parse feature:empty_keys feature:optional_typed_accessors
-func TestParseZeroValuesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `count = 0
 distance = 0.0
 disabled = no`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// parse_zero_values_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
+func TestParseZeroValuesGetInt(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
+}
+
+
+// parse_zero_values_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseZeroValuesGetBool(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
+}
+
+
+// parse_zero_values_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
+func TestParseZeroValuesGetFloat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
+}
+
+
+// parse_zero_values_strict_literal_parse - function:parse feature:empty_keys feature:optional_typed_accessors
+func TestParseZeroValuesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -296,28 +719,116 @@ disabled = no`
 
 }
 
+
 // parse_zero_values_strict_literal_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_zero_values_strict_literal_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
+
 
 // parse_zero_values_strict_literal_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // parse_zero_values_strict_literal_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
+
 
 // parse_boolean_variants_parse - function:parse feature:optional_typed_accessors
 func TestParseBooleanVariantsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag1 = yes
@@ -327,11 +838,13 @@ flag4 = false
 flag5 = no
 flag6 = off
 flag7 = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -339,24 +852,11 @@ flag7 = 0`
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // parse_boolean_variants_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors
-func TestParseBooleanVariantsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_variants_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
-func TestParseBooleanVariantsGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_boolean_variants_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseBooleanVariantsStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag1 = yes
@@ -366,11 +866,102 @@ flag4 = false
 flag5 = no
 flag6 = off
 flag7 = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors
+func TestParseBooleanVariantsGetInt(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
+}
+
+
+// parse_boolean_variants_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseBooleanVariantsGetBool(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
+}
+
+
+// parse_boolean_variants_strict_literal_parse - function:parse feature:optional_typed_accessors
+func TestParseBooleanVariantsStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -379,23 +970,102 @@ flag7 = 0`
 
 }
 
+
 // parse_boolean_variants_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_variants_strict_literal_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
+
 
 // parse_boolean_variants_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanVariantsStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // parse_mixed_types_parse - function:parse feature:optional_typed_accessors
 func TestParseMixedTypesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost
@@ -403,11 +1073,13 @@ port = 8080
 ssl = true
 timeout = 30.5
 debug = off`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -415,34 +1087,11 @@ debug = off`
 	assert.Equal(t, expected, parseResult)
 
 }
+
 
 // parse_mixed_types_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_get_string - function:get_string feature:optional_typed_accessors
-func TestParseMixedTypesGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_get_int - function:get_int feature:optional_typed_accessors
-func TestParseMixedTypesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
-func TestParseMixedTypesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_get_float - function:get_float feature:optional_typed_accessors
-func TestParseMixedTypesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// parse_mixed_types_strict_literal_parse - function:parse feature:optional_typed_accessors
-func TestParseMixedTypesStrictLiteralParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `host = localhost
@@ -450,11 +1099,152 @@ port = 8080
 ssl = true
 timeout = 30.5
 debug = off`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
 
+}
+
+
+// parse_mixed_types_get_string - function:get_string feature:optional_typed_accessors
+func TestParseMixedTypesGetString(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
+}
+
+
+// parse_mixed_types_get_int - function:get_int feature:optional_typed_accessors
+func TestParseMixedTypesGetInt(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
+}
+
+
+// parse_mixed_types_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
+func TestParseMixedTypesGetBool(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
+}
+
+
+// parse_mixed_types_get_float - function:get_float feature:optional_typed_accessors
+func TestParseMixedTypesGetFloat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
+}
+
+
+// parse_mixed_types_strict_literal_parse - function:parse feature:optional_typed_accessors
+func TestParseMixedTypesStrictLiteralParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -463,42 +1253,160 @@ debug = off`
 
 }
 
+
 // parse_mixed_types_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_mixed_types_strict_literal_get_string - function:get_string feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
 }
+
 
 // parse_mixed_types_strict_literal_get_int - function:get_int feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
+
 
 // parse_mixed_types_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // parse_mixed_types_strict_literal_get_float - function:get_float feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
 }
+
 
 // parse_with_whitespace_parse - function:parse feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number =   42   
 flag =  true  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -507,34 +1415,97 @@ flag =  true  `
 
 }
 
+
 // parse_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag": "true", "number": "42"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_with_whitespace_get_int - function:get_int feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
+
 
 // parse_with_whitespace_get_bool - function:get_bool feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // parse_with_conservative_options_parse - function:parse feature:optional_typed_accessors
 func TestParseWithConservativeOptionsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number = 42
 decimal = 3.14
 flag = true
 text = hello`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -543,31 +1514,100 @@ text = hello`
 
 }
 
+
 // parse_with_conservative_options_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseWithConservativeOptionsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"decimal": "3.14", "flag": "true", "number": "42", "text": "hello"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_with_conservative_options_get_string - function:get_string feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"decimal"})
+	require.NoError(t, err)
+	assert.Equal(t, "3.14", result)
+
 }
+
 
 // parse_with_conservative_options_get_int - function:get_int feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
+
 
 // parse_integer_error_parse - function:parse feature:optional_typed_accessors
 func TestParseIntegerErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `port = not_a_number`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -576,26 +1616,70 @@ func TestParseIntegerErrorParse(t *testing.T) {
 
 }
 
+
 // parse_integer_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseIntegerErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "not_a_number"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_integer_error_get_int - function:get_int feature:optional_typed_accessors
 func TestParseIntegerErrorGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
+
 
 // parse_float_error_parse - function:parse feature:optional_typed_accessors
 func TestParseFloatErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `temperature = invalid`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -604,26 +1688,70 @@ func TestParseFloatErrorParse(t *testing.T) {
 
 }
 
+
 // parse_float_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseFloatErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "invalid"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_float_error_get_float - function:get_float feature:optional_typed_accessors
 func TestParseFloatErrorGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
+
 
 // parse_boolean_error_parse - function:parse feature:optional_typed_accessors
 func TestParseBooleanErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `enabled = maybe`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -632,26 +1760,70 @@ func TestParseBooleanErrorParse(t *testing.T) {
 
 }
 
+
 // parse_boolean_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "maybe"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_boolean_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // parse_missing_path_error_parse - function:parse
 func TestParseMissingPathErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `existing = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -660,27 +1832,71 @@ func TestParseMissingPathErrorParse(t *testing.T) {
 
 }
 
+
 // parse_missing_path_error_build_hierarchy - function:build_hierarchy
 func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // parse_missing_path_error_get_string - function:get_string
 func TestParseMissingPathErrorGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, "", result)
+	}
+
 }
+
 
 // boolean_case_sensitivity_uppercase_parse - function:parse feature:optional_typed_accessors
 func TestBooleanCaseSensitivityUppercaseParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `upper_true = TRUE
 upper_false = FALSE`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -689,22 +1905,49 @@ upper_false = FALSE`
 
 }
 
+
 // boolean_case_sensitivity_uppercase_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityUppercaseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_true = TRUE
+upper_false = FALSE`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // boolean_case_sensitivity_mixed_parse - function:parse feature:optional_typed_accessors
 func TestBooleanCaseSensitivityMixedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `mixed_true = True
 mixed_false = False`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -713,22 +1956,49 @@ mixed_false = False`
 
 }
 
+
 // boolean_case_sensitivity_mixed_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityMixedGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mixed_true = True
+mixed_false = False`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"mixed_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // boolean_lenient_uppercase_yes_no_parse - function:parse feature:optional_typed_accessors
 func TestBooleanLenientUppercaseYesNoParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `upper_yes = YES
 upper_no = NO`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -737,22 +2007,49 @@ upper_no = NO`
 
 }
 
+
 // boolean_lenient_uppercase_yes_no_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestBooleanLenientUppercaseYesNoGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_yes = YES
+upper_no = NO`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_yes"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // boolean_numeric_one_zero_strict_parse - function:parse feature:optional_typed_accessors
 func TestBooleanNumericOneZeroStrictParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `one = 1
 zero = 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -761,26 +2058,73 @@ zero = 0`
 
 }
 
+
 // boolean_numeric_one_zero_strict_get_int - function:get_int feature:optional_typed_accessors
 func TestBooleanNumericOneZeroStrictGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
+
 
 // boolean_numeric_one_zero_strict_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanNumericOneZeroStrictGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"one"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // boolean_with_whitespace_parse - function:parse feature:optional_typed_accessors feature:whitespace
 func TestBooleanWithWhitespaceParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `padded =   true   `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -789,26 +2133,70 @@ func TestBooleanWithWhitespaceParse(t *testing.T) {
 
 }
 
+
 // boolean_with_whitespace_get_bool - function:get_bool feature:optional_typed_accessors feature:whitespace behavior:boolean_strict
 func TestBooleanWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `padded =   true   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"padded"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
+
 
 // boolean_nested_object_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  debug = true
+  verbose = false
+  experimental = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "experimental": "yes", "verbose": "false"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // type_mismatch_get_int_on_bool_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag = true`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -817,21 +2205,47 @@ func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_int_on_bool_get_int - function:get_int feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
+
 
 // type_mismatch_get_bool_on_int_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `number = 42`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -840,21 +2254,47 @@ func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_bool_on_int_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestTypeMismatchGetBoolOnIntGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"number"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
 
 // type_mismatch_get_float_on_bool_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `flag = false`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -863,26 +2303,72 @@ func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
 
 }
 
+
 // type_mismatch_get_float_on_bool_get_float - function:get_float feature:optional_typed_accessors
 func TestTypeMismatchGetFloatOnBoolGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
+
 
 // type_mismatch_nested_path_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  name = test
+  count = abc`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"count": "abc", "name": "test"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // boolean_empty_value_error_parse - function:parse feature:optional_typed_accessors
 func TestBooleanEmptyValueErrorParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty =`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -891,7 +2377,31 @@ func TestBooleanEmptyValueErrorParse(t *testing.T) {
 
 }
 
+
 // boolean_empty_value_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanEmptyValueErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"empty"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
+
+

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,130 +12,445 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // tabs_as_content_in_value_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-// tabs_as_content_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_content_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_content_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-// tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_whitespace_in_value_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace
-func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_whitespace_leading_tab_get_string - function:get_string feature:whitespace
-func TestTabsAsWhitespaceLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_content
-func TestTabsAsContentMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
-func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_canonical_format_as_content_canonical_format - function:parse function:print feature:whitespace behavior:tabs_as_content
-func TestTabsCanonicalFormatAsContentCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-// tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print feature:whitespace behavior:tabs_as_whitespace
-func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_spaces
-func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
-
-// tabs_as_whitespace_round_trip_round_trip - function:parse function:print feature:whitespace
-func TestTabsAsWhitespaceRoundTripRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = 	value	with	tabs`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
 
 }
 
+
+// tabs_as_content_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_content
+func TestTabsAsContentInValueBuildHierarchy(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "\tvalue\twith\ttabs"}
+	assert.Equal(t, expected, objectResult)
+
+}
+
+
+// tabs_as_content_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_content
+func TestTabsAsContentInValueGetString(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tvalue\twith\ttabs", result)
+
+}
+
+
+// tabs_as_content_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_content
+func TestTabsAsContentLeadingTabParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tindented"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_content
+func TestTabsAsContentLeadingTabGetString(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tindented", result)
+
+}
+
+
+// tabs_as_whitespace_in_value_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceInValueParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value with tabs"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "value with tabs"}
+	assert.Equal(t, expected, objectResult)
+
+}
+
+
+// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace
+func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "value with tabs", result)
+
+}
+
+
+// tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceLeadingTabParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "indented"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_whitespace_leading_tab_get_string - function:get_string feature:whitespace
+func TestTabsAsWhitespaceLeadingTabGetString(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "indented", result)
+
+}
+
+
+// tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 			three_tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "three_tabs"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_content
+func TestTabsAsContentMultilineParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	indented_with_tabs
+ 	another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\n \tindented_with_tabs\n \tanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented_with_tabs
+		another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nindented_with_tabs\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
+func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	mixed_indent
+	 another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nmixed_indent\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// tabs_canonical_format_as_content_canonical_format - function:parse function:print feature:whitespace behavior:tabs_as_content
+func TestTabsCanonicalFormatAsContentCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print feature:whitespace behavior:tabs_as_whitespace
+func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_spaces
+func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented
+		another`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// tabs_as_whitespace_round_trip_round_trip - function:parse function:print feature:whitespace
+func TestTabsAsWhitespaceRoundTripRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // nested_bare_list_indentation_canonical_format - function:parse function:print feature:empty_keys feature:whitespace behavior:indent_spaces
 func TestNestedBareListIndentationCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `package =
   = brew
   = scoop
   = nix`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
 // deeply_nested_bare_list_indentation_canonical_format - function:parse function:print feature:empty_keys feature:whitespace behavior:indent_spaces
 func TestDeeplyNestedBareListIndentationCanonicalFormat(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app =
@@ -147,28 +462,34 @@ func TestDeeplyNestedBareListIndentationCanonicalFormat(t *testing.T) {
       = level3a
       = level3b
   = item2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement canonical_format validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
 // crlf_normalize_to_lf_basic_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "key1 = value1\r\nkey2 = value2\r\n"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -177,31 +498,88 @@ func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
 
 }
 
+
 // crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1", "key2": "value2"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // crlf_preserve_literal_basic_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // crlf_preserve_literal_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1\r", "key2": "value2\r"}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // crlf_normalize_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "multiline =\r\n  line1\r\n  line2"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -210,21 +588,42 @@ func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
 
 }
 
+
 // crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_preserve_literal
 func TestCrlfPreserveMultilineValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "multiline =\r\n  line1\r\n  line2"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "multiline", Value: "\r\n  line1\r\n  line2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // crlf_mixed_line_endings_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfMixedLineEndingsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -233,16 +632,20 @@ func TestCrlfMixedLineEndingsParse(t *testing.T) {
 
 }
 
+
 // crlf_nested_structure_parse - function:parse feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := "config =\r\n  host = localhost\r\n  port = 8080"
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -251,27 +654,420 @@ func TestCrlfNestedStructureParse(t *testing.T) {
 
 }
 
+
 // crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"host": "localhost", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
 
 // crlf_preserve_nested_structure_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "config", Value: "\r\n  host = localhost\r\n  port = 8080"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // crlf_preserve_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"host": "localhost\r", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
+
+
+// crlf_normalize_comment_only_parse - function:parse feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeCommentOnlyParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "this is a comment"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_normalize_comment_only_filter - function:filter feature:comments feature:whitespace
+func TestCrlfNormalizeCommentOnlyFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// crlf_preserve_comment_only_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveCommentOnlyParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "this is a comment\r"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_preserve_comment_only_filter - function:filter feature:comments feature:whitespace
+func TestCrlfPreserveCommentOnlyFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// crlf_normalize_comments_and_values_parse - function:parse feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeCommentsAndValuesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "Server config"}, mock.Entry{Key: "host", Value: "localhost"}, mock.Entry{Key: "/", Value: "Port setting"}, mock.Entry{Key: "port", Value: "8080"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_normalize_comments_and_values_filter - function:filter feature:comments feature:whitespace
+func TestCrlfNormalizeCommentsAndValuesFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// crlf_normalize_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeCommentsAndValuesBuildHierarchy(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "port": "8080"}
+	assert.Equal(t, expected, objectResult)
+
+}
+
+
+// crlf_preserve_comments_and_values_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveCommentsAndValuesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "Server config\r"}, mock.Entry{Key: "host", Value: "localhost\r"}, mock.Entry{Key: "/", Value: "Port setting\r"}, mock.Entry{Key: "port", Value: "8080\r"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_preserve_comments_and_values_filter - function:filter feature:comments feature:whitespace
+func TestCrlfPreserveCommentsAndValuesFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// crlf_preserve_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveCommentsAndValuesBuildHierarchy(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost\r", "port": "8080\r"}
+	assert.Equal(t, expected, objectResult)
+
+}
+
+
+// crlf_normalize_multiple_comments_parse - function:parse feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeMultipleCommentsParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "first comment"}, mock.Entry{Key: "/", Value: "second comment"}, mock.Entry{Key: "/", Value: "third comment"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_normalize_multiple_comments_filter - function:filter feature:comments feature:whitespace
+func TestCrlfNormalizeMultipleCommentsFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// crlf_preserve_multiple_comments_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveMultipleCommentsParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "first comment\r"}, mock.Entry{Key: "/", Value: "second comment\r"}, mock.Entry{Key: "/", Value: "third comment\r"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// crlf_preserve_multiple_comments_filter - function:filter feature:comments feature:whitespace
+func TestCrlfPreserveMultipleCommentsFilter(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
 
 // behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_as_whitespace behavior:crlf_normalize_to_lf
 func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := "key = \tvalue\twith\ttabs\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value with tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
 
 // behavior_combo_content_tabs_crlf_parse - function:parse feature:whitespace behavior:tabs_as_content behavior:crlf_normalize_to_lf
 func TestBehaviorComboContentTabsCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "\tvalue1"}, mock.Entry{Key: "key2", Value: "\tvalue2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
+
+

--- a/go_tests/parsing/property_algebraic_test.go
+++ b/go_tests/parsing/property_algebraic_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,62 +12,265 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // semigroup_associativity_basic_compose_associative - function:compose_associative
 func TestSemigroupAssociativityBasicComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `a = 1`
+	input1 := `b = 2`
+	input2 := `c = 3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // semigroup_associativity_nested_compose_associative - function:compose_associative
 func TestSemigroupAssociativityNestedComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  host = localhost`
+	input1 := `config =
+  port = 8080`
+	input2 := `db =
+  name = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // semigroup_associativity_lists_compose_associative - function:compose_associative feature:empty_keys
 func TestSemigroupAssociativityListsComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1`
+	input1 := `= item2`
+	input2 := `= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_basic_identity_left - function:identity_left
 func TestMonoidLeftIdentityBasicIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_basic_identity_right - function:identity_right
 func TestMonoidRightIdentityBasicIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `key = value
+nested =
+  sub = val`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_nested_identity_left - function:identity_left
 func TestMonoidLeftIdentityNestedIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_nested_identity_right - function:identity_right
 func TestMonoidRightIdentityNestedIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_left_identity_lists_identity_left - function:identity_left feature:empty_keys
 func TestMonoidLeftIdentityListsIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `= item1
+= item2
+= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // monoid_right_identity_lists_identity_right - function:identity_right feature:empty_keys
 func TestMonoidRightIdentityListsIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1
+= item2
+= item3`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
+
 
 // round_trip_property_basic_parse - function:parse
 func TestRoundTripPropertyBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 another = test`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -76,31 +279,54 @@ another = test`
 
 }
 
+
 // round_trip_property_basic_print - function:print
 func TestRoundTripPropertyBasicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_property_basic_round_trip - function:parse function:print
-func TestRoundTripPropertyBasicRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 another = test`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_property_basic_round_trip - function:parse function:print
+func TestRoundTripPropertyBasicRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = value
+another = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_property_nested_parse - function:parse
 func TestRoundTripPropertyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -109,11 +335,13 @@ func TestRoundTripPropertyNestedParse(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -122,13 +350,10 @@ func TestRoundTripPropertyNestedParse(t *testing.T) {
 
 }
 
+
 // round_trip_property_nested_print - function:print
 func TestRoundTripPropertyNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_property_nested_round_trip - function:parse function:print
-func TestRoundTripPropertyNestedRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -137,20 +362,50 @@ func TestRoundTripPropertyNestedRoundTrip(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_property_nested_round_trip - function:parse function:print
+func TestRoundTripPropertyNestedRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_property_complex_parse - function:parse feature:empty_keys
 func TestRoundTripPropertyComplexParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
@@ -163,11 +418,13 @@ config =
     = b
     = c
 final = end`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -176,13 +433,10 @@ final = end`
 
 }
 
+
 // round_trip_property_complex_print - function:print feature:empty_keys
 func TestRoundTripPropertyComplexPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_property_complex_round_trip - function:parse function:print feature:empty_keys
-func TestRoundTripPropertyComplexRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
@@ -195,14 +449,48 @@ config =
     = b
     = c
 final = end`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
+
+// round_trip_property_complex_round_trip - function:parse function:print feature:empty_keys
+func TestRoundTripPropertyComplexRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+config =
+  nested =
+    deep = value
+  list =
+    = a
+    = b
+    = c
+final = end`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -2,7 +2,7 @@ package parsing_test
 
 import (
 	"testing"
-
+	
 	"github.com/catconflang/ccl-test-data/internal/mock"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,18 +12,23 @@ import (
 // Suite: Flat Format
 // Version: 1.0
 
+
+
 // round_trip_basic_parse - function:parse
 func TestRoundTripBasicParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 nested =
   sub = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -32,42 +37,68 @@ nested =
 
 }
 
+
 // round_trip_basic_print - function:print
 func TestRoundTripBasicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_basic_round_trip - function:parse function:print
-func TestRoundTripBasicRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `key = value
 nested =
   sub = val`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_basic_round_trip - function:parse function:print
+func TestRoundTripBasicRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_whitespace_normalization_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  value  
   nested  = 
     sub  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -76,61 +107,92 @@ func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
 
 }
 
+
 // round_trip_whitespace_normalization_round_trip - function:parse function:print feature:whitespace variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  value  
   nested  = 
     sub  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
 
 // round_trip_whitespace_normalization_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
-}
-
-// round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip - function:parse function:print feature:whitespace
-func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `  key  =  value  
   nested  = 
     sub  =  val  `
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "nested", Value: "\n    sub  =  val"}}
+	assert.Equal(t, expected, parseResult)
 
 }
 
+
+// round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip - function:parse function:print feature:whitespace
+func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_empty_keys_lists_parse - function:parse feature:empty_keys
 func TestRoundTripEmptyKeysListsParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
 = item2
 regular = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -139,32 +201,56 @@ regular = value`
 
 }
 
+
 // round_trip_empty_keys_lists_print - function:print feature:empty_keys
 func TestRoundTripEmptyKeysListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_empty_keys_lists_round_trip - function:parse function:print feature:empty_keys
-func TestRoundTripEmptyKeysListsRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `= item1
 = item2
 regular = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_empty_keys_lists_round_trip - function:parse function:print feature:empty_keys
+func TestRoundTripEmptyKeysListsRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+regular = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_nested_structures_parse - function:parse
 func TestRoundTripNestedStructuresParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -173,11 +259,13 @@ func TestRoundTripNestedStructuresParse(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -186,13 +274,10 @@ func TestRoundTripNestedStructuresParse(t *testing.T) {
 
 }
 
+
 // round_trip_nested_structures_print - function:print
 func TestRoundTripNestedStructuresPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_nested_structures_round_trip - function:parse function:print
-func TestRoundTripNestedStructuresRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `config =
@@ -201,31 +286,63 @@ func TestRoundTripNestedStructuresRoundTrip(t *testing.T) {
   db =
     name = mydb
     user = admin`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_nested_structures_round_trip - function:parse function:print
+func TestRoundTripNestedStructuresRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_multiline_values_parse - function:parse feature:multiline
 func TestRoundTripMultilineValuesParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `script =
   #!/bin/bash
   echo hello
   exit 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -234,33 +351,58 @@ func TestRoundTripMultilineValuesParse(t *testing.T) {
 
 }
 
+
 // round_trip_multiline_values_print - function:print feature:multiline
 func TestRoundTripMultilineValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_multiline_values_round_trip - function:parse function:print feature:multiline
-func TestRoundTripMultilineValuesRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `script =
   #!/bin/bash
   echo hello
   exit 0`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_multiline_values_round_trip - function:parse function:print feature:multiline
+func TestRoundTripMultilineValuesRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `script =
+  #!/bin/bash
+  echo hello
+  exit 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_mixed_content_parse - function:parse feature:empty_keys
 func TestRoundTripMixedContentParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
@@ -269,11 +411,13 @@ config =
   port = 3000
 = second item
 final = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -282,13 +426,10 @@ final = value`
 
 }
 
+
 // round_trip_mixed_content_print - function:print feature:empty_keys
 func TestRoundTripMixedContentPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_mixed_content_round_trip - function:parse function:print feature:empty_keys
-func TestRoundTripMixedContentRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `name = Alice
@@ -297,20 +438,50 @@ config =
   port = 3000
 = second item
 final = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_mixed_content_round_trip - function:parse function:print feature:empty_keys
+func TestRoundTripMixedContentRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+= first item
+config =
+  port = 3000
+= second item
+final = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_complex_nesting_parse - function:parse feature:empty_keys
 func TestRoundTripComplexNestingParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app =
@@ -321,11 +492,13 @@ func TestRoundTripComplexNestingParse(t *testing.T) {
       host = localhost
       = db_item
   = item2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -334,13 +507,10 @@ func TestRoundTripComplexNestingParse(t *testing.T) {
 
 }
 
+
 // round_trip_complex_nesting_print - function:print feature:empty_keys
 func TestRoundTripComplexNestingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_complex_nesting_round_trip - function:parse function:print feature:empty_keys
-func TestRoundTripComplexNestingRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `app =
@@ -351,20 +521,52 @@ func TestRoundTripComplexNestingRoundTrip(t *testing.T) {
       host = localhost
       = db_item
   = item2`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_complex_nesting_round_trip - function:parse function:print feature:empty_keys
+func TestRoundTripComplexNestingRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `app =
+  = item1
+  config =
+    = nested_item
+    db =
+      host = localhost
+      = db_item
+  = item2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_deeply_nested_parse - function:parse feature:empty_keys
 func TestRoundTripDeeplyNestedParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `level1 =
@@ -373,11 +575,13 @@ func TestRoundTripDeeplyNestedParse(t *testing.T) {
       level4 =
         deep = value
         = deep_item`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -386,13 +590,10 @@ func TestRoundTripDeeplyNestedParse(t *testing.T) {
 
 }
 
+
 // round_trip_deeply_nested_print - function:print feature:empty_keys
 func TestRoundTripDeeplyNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_deeply_nested_round_trip - function:parse function:print feature:empty_keys
-func TestRoundTripDeeplyNestedRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `level1 =
@@ -401,30 +602,62 @@ func TestRoundTripDeeplyNestedRoundTrip(t *testing.T) {
       level4 =
         deep = value
         = deep_item`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
 
+
+// round_trip_deeply_nested_round_trip - function:parse function:print feature:empty_keys
+func TestRoundTripDeeplyNestedRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `level1 =
+  level2 =
+    level3 =
+      level4 =
+        deep = value
+        = deep_item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
 // round_trip_empty_multiline_parse - function:parse feature:empty_keys feature:multiline
 func TestRoundTripEmptyMultilineParse(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_section =
 
 other = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
+	
 	// Parse validation
 	parseResult, err := ccl.Parse(input)
 	require.NoError(t, err)
@@ -433,26 +666,50 @@ other = value`
 
 }
 
+
 // round_trip_empty_multiline_print - function:print feature:empty_keys feature:multiline
 func TestRoundTripEmptyMultilinePrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-// round_trip_empty_multiline_round_trip - function:parse function:print feature:empty_keys feature:multiline
-func TestRoundTripEmptyMultilineRoundTrip(t *testing.T) {
+	
 
 	ccl := mock.New()
 	input := `empty_section =
 
 other = value`
-
+	
 	// Declare variables for reuse across validations
-
+	
+	
+	
 	var err error
-
-	// TODO: Implement round_trip validation
-	_ = ccl   // Prevent unused variable warning
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
 	_ = input // Prevent unused variable warning
-	_ = err   // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
 
 }
+
+
+// round_trip_empty_multiline_round_trip - function:parse function:print feature:empty_keys feature:multiline
+func TestRoundTripEmptyMultilineRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `empty_section =
+
+other = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -552,6 +552,246 @@
       ]
     },
     {
+      "name": "crlf_normalize_comment_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "this is a comment"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": []
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ]
+    },
+    {
+      "name": "crlf_preserve_comment_only",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "this is a comment\r"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": []
+        }
+      ],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ]
+    },
+    {
+      "name": "crlf_normalize_comments_and_values",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "Server config"
+            },
+            {
+              "key": "host",
+              "value": "localhost"
+            },
+            {
+              "key": "/",
+              "value": "Port setting"
+            },
+            {
+              "key": "port",
+              "value": "8080"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": [
+            {
+              "key": "host",
+              "value": "localhost"
+            },
+            {
+              "key": "port",
+              "value": "8080"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "host": "localhost",
+            "port": "8080"
+          }
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ]
+    },
+    {
+      "name": "crlf_preserve_comments_and_values",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "Server config\r"
+            },
+            {
+              "key": "host",
+              "value": "localhost\r"
+            },
+            {
+              "key": "/",
+              "value": "Port setting\r"
+            },
+            {
+              "key": "port",
+              "value": "8080\r"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": [
+            {
+              "key": "host",
+              "value": "localhost\r"
+            },
+            {
+              "key": "port",
+              "value": "8080\r"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "host": "localhost\r",
+            "port": "8080\r"
+          }
+        }
+      ],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ]
+    },
+    {
+      "name": "crlf_normalize_multiple_comments",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "first comment"
+            },
+            {
+              "key": "/",
+              "value": "second comment"
+            },
+            {
+              "key": "/",
+              "value": "third comment"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": []
+        }
+      ],
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ]
+    },
+    {
+      "name": "crlf_preserve_multiple_comments",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "/",
+              "value": "first comment\r"
+            },
+            {
+              "key": "/",
+              "value": "second comment\r"
+            },
+            {
+              "key": "/",
+              "value": "third comment\r"
+            }
+          ]
+        },
+        {
+          "function": "filter",
+          "expect": []
+        }
+      ],
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ]
+    },
+    {
       "name": "behavior_combo_tabs_and_crlf",
       "tests": [
         {


### PR DESCRIPTION
## Summary

Add test cases for CRLF line endings combined with `/=` comment syntax, addressing the gap identified in #68.

## New Tests

| Test Name | Behavior | Description |
|-----------|----------|-------------|
| `crlf_normalize_comment_only` | `crlf_normalize_to_lf` | Single comment with CRLF ending; parse recognizes comment, filter removes it |
| `crlf_preserve_comment_only` | `crlf_preserve_literal` | Single comment with CRLF; `\r` preserved in value, filter still removes it |
| `crlf_normalize_comments_and_values` | `crlf_normalize_to_lf` | Mixed comments and key-value pairs with CRLF |
| `crlf_preserve_comments_and_values` | `crlf_preserve_literal` | Mixed comments and key-value pairs with CRLF; `\r` preserved |
| `crlf_normalize_multiple_comments` | `crlf_normalize_to_lf` | Three consecutive comments with CRLF |
| `crlf_preserve_multiple_comments` | `crlf_preserve_literal` | Three consecutive comments with CRLF; `\r` preserved |

These 6 source tests generate **14 flat test assertions** covering `parse`, `filter`, and `build_hierarchy` functions.

Closes #68