### PR TITLE
fix(tests): add array_order_insertion behavior to list tests

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -94,20 +94,22 @@ func AllFeatures() []CCLFeature {
 type CCLBehavior string
 
 const (
-	BehaviorCRLFNormalize          CCLBehavior = "crlf_normalize_to_lf"
-	BehaviorCRLFPreserve           CCLBehavior = "crlf_preserve_literal"
-	BehaviorTabsAsContent          CCLBehavior = "tabs_as_content"
-	BehaviorTabsAsWhitespace       CCLBehavior = "tabs_as_whitespace"
-	BehaviorIndentSpaces           CCLBehavior = "indent_spaces"
-	BehaviorIndentTabs             CCLBehavior = "indent_tabs"
-	BehaviorBooleanStrict          CCLBehavior = "boolean_strict"
-	BehaviorBooleanLenient         CCLBehavior = "boolean_lenient"
-	BehaviorListCoercionOn         CCLBehavior = "list_coercion_enabled"
-	BehaviorListCoercionOff        CCLBehavior = "list_coercion_disabled"
-	BehaviorToplevelIndentStrip    CCLBehavior = "toplevel_indent_strip"
-	BehaviorToplevelIndentPreserve CCLBehavior = "toplevel_indent_preserve"
-	BehaviorDelimiterFirstEquals   CCLBehavior = "delimiter_first_equals"
-	BehaviorDelimiterPreferSpaced  CCLBehavior = "delimiter_prefer_spaced"
+	BehaviorCRLFNormalize           CCLBehavior = "crlf_normalize_to_lf"
+	BehaviorCRLFPreserve            CCLBehavior = "crlf_preserve_literal"
+	BehaviorTabsAsContent           CCLBehavior = "tabs_as_content"
+	BehaviorTabsAsWhitespace        CCLBehavior = "tabs_as_whitespace"
+	BehaviorIndentSpaces            CCLBehavior = "indent_spaces"
+	BehaviorIndentTabs              CCLBehavior = "indent_tabs"
+	BehaviorBooleanStrict           CCLBehavior = "boolean_strict"
+	BehaviorBooleanLenient          CCLBehavior = "boolean_lenient"
+	BehaviorListCoercionOn          CCLBehavior = "list_coercion_enabled"
+	BehaviorListCoercionOff         CCLBehavior = "list_coercion_disabled"
+	BehaviorToplevelIndentStrip     CCLBehavior = "toplevel_indent_strip"
+	BehaviorToplevelIndentPreserve  CCLBehavior = "toplevel_indent_preserve"
+	BehaviorDelimiterFirstEquals    CCLBehavior = "delimiter_first_equals"
+	BehaviorDelimiterPreferSpaced   CCLBehavior = "delimiter_prefer_spaced"
+	BehaviorArrayOrderInsertion     CCLBehavior = "array_order_insertion"
+	BehaviorArrayOrderLexicographic CCLBehavior = "array_order_lexicographic"
 )
 
 // GetBehaviorConflicts returns mutually exclusive behavior groups
@@ -120,6 +122,7 @@ func GetBehaviorConflicts() map[string][]CCLBehavior {
 		"list_coercion":   {BehaviorListCoercionOn, BehaviorListCoercionOff},
 		"toplevel_indent": {BehaviorToplevelIndentStrip, BehaviorToplevelIndentPreserve},
 		"delimiter":       {BehaviorDelimiterFirstEquals, BehaviorDelimiterPreferSpaced},
+		"array_ordering":  {BehaviorArrayOrderInsertion, BehaviorArrayOrderLexicographic},
 	}
 }
 

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -90,7 +90,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -119,10 +126,12 @@
         "descriptions"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -317,7 +326,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -345,10 +361,12 @@
         "host"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -474,7 +492,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -498,10 +523,12 @@
         "empty_list"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -559,7 +586,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -588,10 +622,12 @@
         "numbers"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -652,7 +688,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -681,10 +724,12 @@
         "flags"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -747,7 +792,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -778,10 +830,12 @@
         "items"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -846,7 +900,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -877,10 +938,12 @@
         "names"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -943,7 +1006,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -972,10 +1042,12 @@
         "symbols"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -1038,7 +1110,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1069,10 +1148,12 @@
         "descriptions"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },
@@ -1162,7 +1243,14 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "array_order_lexicographic"
+        ]
+      },
       "expected": {
         "count": 1,
         "object": {
@@ -1204,10 +1292,12 @@
         "features"
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "conflicts": {
         "behaviors": [
+          "array_order_lexicographic",
           "list_coercion_disabled"
         ]
       },

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -27,12 +27,12 @@ func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline
+// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled
+// indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -95,12 +95,12 @@ host = localhost`
 
 }
 
-// mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy
+// mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled
+// mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -154,12 +154,12 @@ func TestEmptyListParse(t *testing.T) {
 
 }
 
-// empty_list_build_hierarchy - function:build_hierarchy
+// empty_list_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestEmptyListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// empty_list_get_list - function:get_list behavior:list_coercion_enabled
+// empty_list_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestEmptyListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -185,12 +185,12 @@ numbers = 0`
 
 }
 
-// list_with_numbers_build_hierarchy - function:build_hierarchy
+// list_with_numbers_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled
+// list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithNumbersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -216,12 +216,12 @@ flags = no`
 
 }
 
-// list_with_booleans_build_hierarchy - function:build_hierarchy
+// list_with_booleans_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled
+// list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithBooleansGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -247,12 +247,12 @@ items =   `
 
 }
 
-// list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace
+// list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_insertion
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled
+// list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithWhitespaceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -278,12 +278,12 @@ names = العربية`
 
 }
 
-// list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode
+// list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_insertion
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled
+// list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithUnicodeGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -309,12 +309,12 @@ symbols = <>=+`
 
 }
 
-// list_with_special_characters_build_hierarchy - function:build_hierarchy
+// list_with_special_characters_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled
+// list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithSpecialCharactersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -324,12 +324,12 @@ func TestListMultilineValuesParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline
+// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled
+// list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListMultilineValuesGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -339,12 +339,12 @@ func TestComplexMixedListScenariosParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy
+// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// complex_mixed_list_scenarios_get_list - function:get_list behavior:list_coercion_enabled
+// complex_mixed_list_scenarios_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestComplexMixedListScenariosGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -87,7 +87,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "features": [
         "multiline"
@@ -225,7 +226,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "ports = 80\nports = 443\nhost = localhost"
@@ -313,7 +315,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "empty_list ="
@@ -368,7 +371,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
@@ -423,7 +427,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "flags = true\nflags = false\nflags = yes\nflags = no"
@@ -478,7 +483,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "features": [
         "whitespace"
@@ -536,7 +542,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "features": [
         "unicode"
@@ -594,7 +601,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "symbols = @#$%\nsymbols = !^&*()\nsymbols = []{}|\nsymbols = <>=+"
@@ -648,7 +656,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "features": [
         "multiline"
@@ -779,7 +788,8 @@
         }
       ],
       "behaviors": [
-        "list_coercion_enabled"
+        "list_coercion_enabled",
+        "array_order_insertion"
       ],
       "inputs": [
         "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"


### PR DESCRIPTION
## Summary

Closes #92.

- Added `array_order_insertion` to `behaviors` array of 10 source tests in `api_proposed_behavior.json` that have insertion-order list expectations but no `array_order_*` tag
- Added `BehaviorArrayOrderInsertion`/`BehaviorArrayOrderLexicographic` constants and `array_ordering` conflict group to `config.go`

Implementations using lexicographic ordering (e.g., OCaml's `Map.Make(String)`) declare `array_order_lexicographic` but could not skip these tests because they were untagged.

## Affected tests

- `indented_line_is_continuation`
- `mixed_duplicate_single_keys`
- `empty_list`
- `list_with_numbers`
- `list_with_booleans`
- `list_with_whitespace`
- `list_with_unicode`
- `list_with_special_characters`
- `list_multiline_values`
- `complex_mixed_list_scenarios`

## Test plan

- [x] `just lint` passes
- [x] `just validate` passes
- [x] `just reset` passes (873 tests, 454 skipped)