### PR TITLE
feat(tests): add path_traversal feature tag for multi-component args

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -74,6 +74,7 @@ const (
 	FeatureExperimentalDottedKeys CCLFeature = "experimental_dotted_keys"
 	FeatureEmptyKeys              CCLFeature = "empty_keys"
 	FeatureMultiline              CCLFeature = "multiline"
+	FeaturePathTraversal          CCLFeature = "path_traversal"
 	FeatureUnicode                CCLFeature = "unicode"
 	FeatureWhitespace             CCLFeature = "whitespace"
 )
@@ -85,6 +86,7 @@ func AllFeatures() []CCLFeature {
 		FeatureExperimentalDottedKeys,
 		FeatureEmptyKeys,
 		FeatureMultiline,
+		FeaturePathTraversal,
 		FeatureUnicode,
 		FeatureWhitespace,
 	}

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -108,6 +108,7 @@ func TestAllFeatures_Completeness(t *testing.T) {
 		FeatureExperimentalDottedKeys,
 		FeatureEmptyKeys,
 		FeatureMultiline,
+		FeaturePathTraversal,
 		FeatureUnicode,
 		FeatureWhitespace,
 	}
@@ -516,6 +517,7 @@ func TestCCLFeature_StringValues(t *testing.T) {
 		{FeatureExperimentalDottedKeys, "experimental_dotted_keys"},
 		{FeatureEmptyKeys, "empty_keys"},
 		{FeatureMultiline, "multiline"},
+		{FeaturePathTraversal, "path_traversal"},
 		{FeatureUnicode, "unicode"},
 		{FeatureWhitespace, "whitespace"},
 	}

--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -434,7 +434,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -471,7 +473,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -503,7 +507,9 @@
       "expected": {
         "count": 0
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -957,7 +957,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -980,7 +982,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1002,7 +1006,9 @@
         "count": 1,
         "value": ".vscode/settings.json"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -1676,7 +1682,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -1699,7 +1707,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1721,7 +1731,9 @@
         "count": 1,
         "value": "../bar"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -1790,7 +1802,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -1815,7 +1829,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1838,7 +1854,9 @@
         "count": 1,
         "value": "../.cache"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -1861,7 +1879,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -1886,7 +1906,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1909,7 +1931,9 @@
         "count": 1,
         "value": "../src/main"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -1932,7 +1956,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -1960,7 +1986,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1983,7 +2011,9 @@
         "count": 1,
         "value": "../../"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -2006,7 +2036,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -2034,7 +2066,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -2057,7 +2091,9 @@
         "count": 1,
         "value": "//api.example.com"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -2294,7 +2330,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -2317,7 +2355,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -2339,7 +2379,9 @@
         "count": 1,
         "value": "https://prod.example.com"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],
@@ -2362,7 +2404,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -2392,7 +2436,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -2416,7 +2462,9 @@
         "count": 1,
         "value": "https://api.example.com"
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_string"
       ],

--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -845,7 +845,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "parse"
@@ -882,7 +883,8 @@
         }
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "build_hierarchy"
@@ -917,7 +919,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "get_list"
@@ -942,7 +945,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "parse"
@@ -979,7 +983,8 @@
         }
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "build_hierarchy"
@@ -1014,7 +1019,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "get_list"
@@ -1235,7 +1241,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "parse"
@@ -1276,7 +1283,8 @@
         }
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "build_hierarchy"
@@ -1313,7 +1321,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "get_list"
@@ -1338,7 +1347,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "parse"
@@ -1379,7 +1389,8 @@
         }
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "build_hierarchy"
@@ -1416,7 +1427,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "get_list"
@@ -1441,7 +1453,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "parse"
@@ -1472,7 +1485,8 @@
         }
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "build_hierarchy"
@@ -1499,7 +1513,8 @@
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "functions": [
         "get_list"
@@ -1523,7 +1538,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -1545,7 +1562,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1573,7 +1592,9 @@
       "expected": {
         "count": 0
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -399,7 +399,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -425,7 +427,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -456,7 +460,9 @@
           "5432"
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],
@@ -1230,7 +1236,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse_indented"
       ],
@@ -1275,7 +1283,9 @@
           ]
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -1309,7 +1319,9 @@
           "ui"
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -179,7 +179,9 @@
           }
         ]
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "parse"
       ],
@@ -207,7 +209,9 @@
           }
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -237,7 +241,9 @@
       "expected": {
         "count": 0
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],
@@ -838,7 +844,9 @@
           ]
         }
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "build_hierarchy"
       ],
@@ -867,7 +875,9 @@
       "expected": {
         "count": 0
       },
-      "features": [],
+      "features": [
+        "path_traversal"
+      ],
       "functions": [
         "get_list"
       ],

--- a/generated_tests/api_typed_access.json
+++ b/generated_tests/api_typed_access.json
@@ -2503,6 +2503,741 @@
       "source_test": "boolean_empty_value_error",
       "validation": "get_bool",
       "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "server",
+            "value": "\n  port = 8080\n  max_connections = 1000"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_parse",
+      "source_test": "nested_get_int",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "max_connections": "1000",
+            "port": "8080"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_build_hierarchy",
+      "source_test": "nested_get_int",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "max_connections"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 1000
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_get_int",
+      "source_test": "nested_get_int",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "config",
+            "value": "\n  database =\n    pool =\n      min = 5\n      max = 50"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_parse",
+      "source_test": "deeply_nested_get_int",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "database": {
+              "pool": {
+                "max": "50",
+                "min": "5"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_build_hierarchy",
+      "source_test": "deeply_nested_get_int",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "config",
+        "database",
+        "pool",
+        "max"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 50
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_get_int",
+      "source_test": "deeply_nested_get_int",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "metrics",
+            "value": "\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_parse",
+      "source_test": "nested_get_float",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "metrics": {
+            "cpu_threshold": "0.85",
+            "memory_limit": "2.5"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_build_hierarchy",
+      "source_test": "nested_get_float",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "metrics",
+        "memory_limit"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 2.5
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_get_float",
+      "source_test": "nested_get_float",
+      "validation": "get_float",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "app",
+            "value": "\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_parse",
+      "source_test": "deeply_nested_get_float",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "app": {
+            "scoring": {
+              "weights": {
+                "freshness": "0.4",
+                "relevance": "0.6"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_build_hierarchy",
+      "source_test": "deeply_nested_get_float",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "app",
+        "scoring",
+        "weights",
+        "freshness"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 0.4
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_get_float",
+      "source_test": "deeply_nested_get_float",
+      "validation": "get_float",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "feature_flags",
+            "value": "\n  dark_mode = true\n  beta_access = false"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_parse",
+      "source_test": "nested_get_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "feature_flags": {
+            "beta_access": "false",
+            "dark_mode": "true"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_build_hierarchy",
+      "source_test": "nested_get_bool",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "feature_flags",
+        "beta_access"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": false
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_get_bool",
+      "source_test": "nested_get_bool",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "services",
+            "value": "\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_parse",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "services": {
+            "auth": {
+              "settings": {
+                "allow_anonymous": "false",
+                "require_mfa": "true"
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_build_hierarchy",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "services",
+        "auth",
+        "settings",
+        "allow_anonymous"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": false
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_get_bool",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "database",
+            "value": "\n  host = localhost\n  name = mydb"
+          }
+        ]
+      },
+      "features": [
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_parse",
+      "source_test": "nested_get_string_basic",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": "localhost",
+            "name": "mydb"
+          }
+        }
+      },
+      "features": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_build_hierarchy",
+      "source_test": "nested_get_string_basic",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "database",
+        "name"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "mydb"
+      },
+      "features": [
+        "path_traversal"
+      ],
+      "functions": [
+        "get_string"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_get_string",
+      "source_test": "nested_get_string_basic",
+      "validation": "get_string",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "server",
+            "value": "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+          }
+        ]
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_parse",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "debug": "true",
+            "host": "0.0.0.0",
+            "port": "3000",
+            "rate_limit": "1.5"
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_build_hierarchy",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "host"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": "0.0.0.0"
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_string"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_string",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_string",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "port"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 3000
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_int"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_int",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_int",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "debug"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "boolean_lenient",
+          "boolean_strict"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": true
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_bool"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_bool",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_bool",
+      "variants": []
+    },
+    {
+      "args": [
+        "server",
+        "rate_limit"
+      ],
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "value": 1.5
+      },
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "functions": [
+        "get_float"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_get_float",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "get_float",
+      "variants": []
     }
   ]
 }

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -240,7 +240,7 @@ func TestNestedObjectsWithListsPrint(t *testing.T) {
 }
 
 
-// deeply_nested_list_parse - function:parse
+// deeply_nested_list_parse - function:parse feature:path_traversal
 func TestDeeplyNestedListParse(t *testing.T) {
 	
 
@@ -267,13 +267,13 @@ func TestDeeplyNestedListParse(t *testing.T) {
 }
 
 
-// deeply_nested_list_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// deeply_nested_list_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// deeply_nested_list_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
+// deeply_nested_list_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -661,7 +661,7 @@ func TestOcamlStressTestOriginalGetString(t *testing.T) {
 }
 
 
-// forward_slashes_in_map_keys_parse - function:parse
+// forward_slashes_in_map_keys_parse - function:parse feature:path_traversal
 func TestForwardSlashesInMapKeysParse(t *testing.T) {
 	
 
@@ -685,13 +685,13 @@ func TestForwardSlashesInMapKeysParse(t *testing.T) {
 }
 
 
-// forward_slashes_in_map_keys_build_hierarchy - function:build_hierarchy
+// forward_slashes_in_map_keys_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestForwardSlashesInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// forward_slashes_in_map_keys_get_string - function:get_string
+// forward_slashes_in_map_keys_get_string - function:get_string feature:path_traversal
 func TestForwardSlashesInMapKeysGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1114,7 +1114,7 @@ func TestRelativePathInValueGetString(t *testing.T) {
 }
 
 
-// relative_path_in_nested_value_parse - function:parse
+// relative_path_in_nested_value_parse - function:parse feature:path_traversal
 func TestRelativePathInNestedValueParse(t *testing.T) {
 	
 
@@ -1138,13 +1138,13 @@ func TestRelativePathInNestedValueParse(t *testing.T) {
 }
 
 
-// relative_path_in_nested_value_build_hierarchy - function:build_hierarchy
+// relative_path_in_nested_value_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathInNestedValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// relative_path_in_nested_value_get_string - function:get_string
+// relative_path_in_nested_value_get_string - function:get_string feature:path_traversal
 func TestRelativePathInNestedValueGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1180,7 +1180,7 @@ func TestDoubleSlashInNestedBuildHierarchy(t *testing.T) {
 }
 
 
-// relative_paths_deeply_nested_parse - function:parse
+// relative_paths_deeply_nested_parse - function:parse feature:path_traversal
 func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 	
 
@@ -1205,19 +1205,19 @@ func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 }
 
 
-// relative_paths_deeply_nested_build_hierarchy - function:build_hierarchy
+// relative_paths_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathsDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// relative_paths_deeply_nested_get_string - function:get_string
+// relative_paths_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestRelativePathsDeeplyNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// relative_paths_as_nested_keys_parse - function:parse
+// relative_paths_as_nested_keys_parse - function:parse feature:path_traversal
 func TestRelativePathsAsNestedKeysParse(t *testing.T) {
 	
 
@@ -1242,19 +1242,19 @@ func TestRelativePathsAsNestedKeysParse(t *testing.T) {
 }
 
 
-// relative_paths_as_nested_keys_build_hierarchy - function:build_hierarchy
+// relative_paths_as_nested_keys_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathsAsNestedKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// relative_paths_as_nested_keys_get_string - function:get_string
+// relative_paths_as_nested_keys_get_string - function:get_string feature:path_traversal
 func TestRelativePathsAsNestedKeysGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// mixed_relative_and_absolute_nested_parse - function:parse
+// mixed_relative_and_absolute_nested_parse - function:parse feature:path_traversal
 func TestMixedRelativeAndAbsoluteNestedParse(t *testing.T) {
 	
 
@@ -1281,19 +1281,19 @@ func TestMixedRelativeAndAbsoluteNestedParse(t *testing.T) {
 }
 
 
-// mixed_relative_and_absolute_nested_build_hierarchy - function:build_hierarchy
+// mixed_relative_and_absolute_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestMixedRelativeAndAbsoluteNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// mixed_relative_and_absolute_nested_get_string - function:get_string
+// mixed_relative_and_absolute_nested_get_string - function:get_string feature:path_traversal
 func TestMixedRelativeAndAbsoluteNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// double_slash_deeply_nested_parse - function:parse
+// double_slash_deeply_nested_parse - function:parse feature:path_traversal
 func TestDoubleSlashDeeplyNestedParse(t *testing.T) {
 	
 
@@ -1320,13 +1320,13 @@ func TestDoubleSlashDeeplyNestedParse(t *testing.T) {
 }
 
 
-// double_slash_deeply_nested_build_hierarchy - function:build_hierarchy
+// double_slash_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestDoubleSlashDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// double_slash_deeply_nested_get_string - function:get_string
+// double_slash_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestDoubleSlashDeeplyNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1456,7 +1456,7 @@ func TestUrlInValueGetString(t *testing.T) {
 }
 
 
-// urls_as_nested_keys_and_values_parse - function:parse
+// urls_as_nested_keys_and_values_parse - function:parse feature:path_traversal
 func TestUrlsAsNestedKeysAndValuesParse(t *testing.T) {
 	
 
@@ -1480,19 +1480,19 @@ func TestUrlsAsNestedKeysAndValuesParse(t *testing.T) {
 }
 
 
-// urls_as_nested_keys_and_values_build_hierarchy - function:build_hierarchy
+// urls_as_nested_keys_and_values_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestUrlsAsNestedKeysAndValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// urls_as_nested_keys_and_values_get_string - function:get_string
+// urls_as_nested_keys_and_values_get_string - function:get_string feature:path_traversal
 func TestUrlsAsNestedKeysAndValuesGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// urls_deeply_nested_parse - function:parse
+// urls_deeply_nested_parse - function:parse feature:path_traversal
 func TestUrlsDeeplyNestedParse(t *testing.T) {
 	
 
@@ -1520,13 +1520,13 @@ func TestUrlsDeeplyNestedParse(t *testing.T) {
 }
 
 
-// urls_deeply_nested_build_hierarchy - function:build_hierarchy
+// urls_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestUrlsDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// urls_deeply_nested_get_string - function:get_string
+// urls_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestUrlsDeeplyNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -353,7 +353,7 @@ func TestBareListBasicGetList(t *testing.T) {
 }
 
 
-// bare_list_nested_parse - function:parse feature:empty_keys
+// bare_list_nested_parse - function:parse feature:empty_keys feature:path_traversal
 func TestBareListNestedParse(t *testing.T) {
 	
 
@@ -379,19 +379,19 @@ func TestBareListNestedParse(t *testing.T) {
 }
 
 
-// bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
+// bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+// bare_list_nested_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListNestedGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys
+// bare_list_nested_lexicographic_parse - function:parse feature:empty_keys feature:path_traversal
 func TestBareListNestedLexicographicParse(t *testing.T) {
 	
 
@@ -417,13 +417,13 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 }
 
 
-// bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
+// bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
+// bare_list_nested_lexicographic_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListNestedLexicographicGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -505,7 +505,7 @@ func TestBareListWithCommentsLexicographicGetList(t *testing.T) {
 }
 
 
-// bare_list_deeply_nested_parse - function:parse feature:empty_keys
+// bare_list_deeply_nested_parse - function:parse feature:empty_keys feature:path_traversal
 func TestBareListDeeplyNestedParse(t *testing.T) {
 	
 
@@ -533,19 +533,19 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
 }
 
 
-// bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
+// bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion
+// bare_list_deeply_nested_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListDeeplyNestedGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys
+// bare_list_deeply_nested_lexicographic_parse - function:parse feature:empty_keys feature:path_traversal
 func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 	
 
@@ -573,19 +573,19 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 }
 
 
-// bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
+// bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_deeply_nested_lexicographic_get_list - function:get_list feature:empty_keys behavior:array_order_lexicographic
+// bare_list_deeply_nested_lexicographic_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_mixed_with_other_keys_parse - function:parse feature:empty_keys
+// bare_list_mixed_with_other_keys_parse - function:parse feature:empty_keys feature:path_traversal
 func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 	
 
@@ -612,19 +612,19 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 }
 
 
-// bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal
 func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys
+// bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys feature:path_traversal
 func TestBareListMixedWithOtherKeysGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_error_not_a_list_parse - function:parse
+// bare_list_error_not_a_list_parse - function:parse feature:path_traversal
 func TestBareListErrorNotAListParse(t *testing.T) {
 	
 
@@ -647,13 +647,13 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 }
 
 
-// bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy
+// bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// bare_list_error_not_a_list_get_list - function:get_list behavior:list_coercion_disabled
+// bare_list_error_not_a_list_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled
 func TestBareListErrorNotAListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -31,10 +31,12 @@ func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
+
 // indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
@@ -111,10 +113,12 @@ host = localhost`
 
 }
 
+
 // mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
@@ -122,7 +126,7 @@ func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
 }
 
 
-// nested_list_access_parse - function:parse
+// nested_list_access_parse - function:parse feature:path_traversal
 func TestNestedListAccessParse(t *testing.T) {
 	
 
@@ -147,13 +151,13 @@ func TestNestedListAccessParse(t *testing.T) {
 }
 
 
-// nested_list_access_build_hierarchy - function:build_hierarchy
+// nested_list_access_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestNestedListAccessBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// nested_list_access_get_list - function:get_list behavior:list_coercion_enabled
+// nested_list_access_get_list - function:get_list feature:path_traversal behavior:list_coercion_enabled
 func TestNestedListAccessGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -180,10 +184,12 @@ func TestEmptyListParse(t *testing.T) {
 
 }
 
+
 // empty_list_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestEmptyListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // empty_list_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestEmptyListGetList(t *testing.T) {
@@ -215,10 +221,12 @@ numbers = 0`
 
 }
 
+
 // list_with_numbers_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithNumbersGetList(t *testing.T) {
@@ -250,10 +258,12 @@ flags = no`
 
 }
 
+
 // list_with_booleans_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithBooleansGetList(t *testing.T) {
@@ -285,10 +295,12 @@ items =   `
 
 }
 
+
 // list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_insertion
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithWhitespaceGetList(t *testing.T) {
@@ -320,10 +332,12 @@ names = العربية`
 
 }
 
+
 // list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_insertion
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithUnicodeGetList(t *testing.T) {
@@ -355,10 +369,12 @@ symbols = <>=+`
 
 }
 
+
 // list_with_special_characters_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithSpecialCharactersGetList(t *testing.T) {
@@ -371,10 +387,12 @@ func TestListMultilineValuesParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
+
 // list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
+
 
 // list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListMultilineValuesGetList(t *testing.T) {
@@ -382,17 +400,19 @@ func TestListMultilineValuesGetList(t *testing.T) {
 }
 
 
-// complex_mixed_list_scenarios_parse_indented - function:parse_indented
+// complex_mixed_list_scenarios_parse_indented - function:parse_indented feature:path_traversal
 func TestComplexMixedListScenariosParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+
+// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_insertion
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
-// complex_mixed_list_scenarios_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
+
+// complex_mixed_list_scenarios_get_list - function:get_list feature:path_traversal behavior:list_coercion_enabled behavior:array_order_insertion
 func TestComplexMixedListScenariosGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -84,7 +84,7 @@ func TestMixedDuplicateSingleKeysReferenceGetList(t *testing.T) {
 }
 
 
-// nested_list_access_reference_parse - function:parse variant:reference_compliant
+// nested_list_access_reference_parse - function:parse feature:path_traversal variant:reference_compliant
 func TestNestedListAccessReferenceParse(t *testing.T) {
 	
 
@@ -109,13 +109,13 @@ func TestNestedListAccessReferenceParse(t *testing.T) {
 }
 
 
-// nested_list_access_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// nested_list_access_reference_build_hierarchy - function:build_hierarchy feature:path_traversal variant:reference_compliant
 func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// nested_list_access_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
+// nested_list_access_reference_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -339,13 +339,13 @@ func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
 }
 
 
-// complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// complex_mixed_list_scenarios_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
+// complex_mixed_list_scenarios_reference_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -1080,3 +1080,317 @@ func TestBooleanEmptyValueErrorGetBool(t *testing.T) {
 }
 
 
+// nested_get_int_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetIntParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `server =
+  port = 8080
+  max_connections = 1000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "server", Value: "\n  port = 8080\n  max_connections = 1000"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetIntBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_int_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetIntGetInt(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_int_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetIntParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `config =
+  database =
+    pool =
+      min = 5
+      max = 50`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "config", Value: "\n  database =\n    pool =\n      min = 5\n      max = 50"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// deeply_nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetIntBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_int_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetIntGetInt(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_float_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetFloatParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `metrics =
+  cpu_threshold = 0.85
+  memory_limit = 2.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "metrics", Value: "\n  cpu_threshold = 0.85\n  memory_limit = 2.5"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetFloatBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_float_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetFloatGetFloat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_float_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetFloatParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `app =
+  scoring =
+    weights =
+      relevance = 0.6
+      freshness = 0.4`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "app", Value: "\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// deeply_nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetFloatBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_float_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetFloatGetFloat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_bool_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetBoolParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `feature_flags =
+  dark_mode = true
+  beta_access = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "feature_flags", Value: "\n  dark_mode = true\n  beta_access = false"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestNestedGetBoolBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_bool_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
+func TestNestedGetBoolGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_bool_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetBoolParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `services =
+  auth =
+    settings =
+      require_mfa = true
+      allow_anonymous = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "services", Value: "\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// deeply_nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestDeeplyNestedGetBoolBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_get_bool_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
+func TestDeeplyNestedGetBoolGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_string_basic_parse - function:parse feature:path_traversal
+func TestNestedGetStringBasicParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  name = mydb`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "database", Value: "\n  host = localhost\n  name = mydb"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// nested_get_string_basic_build_hierarchy - function:build_hierarchy feature:path_traversal
+func TestNestedGetStringBasicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_string_basic_get_string - function:get_string feature:path_traversal
+func TestNestedGetStringBasicGetString(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_parse - function:parse feature:optional_typed_accessors feature:path_traversal
+func TestNestedMixedTypedAccessParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "server", Value: "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// nested_mixed_typed_access_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
+func TestNestedMixedTypedAccessBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_get_string - function:get_string feature:optional_typed_accessors feature:path_traversal
+func TestNestedMixedTypedAccessGetString(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
+func TestNestedMixedTypedAccessGetInt(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
+func TestNestedMixedTypedAccessGetBool(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
+func TestNestedMixedTypedAccessGetFloat(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -157,7 +157,7 @@
             {
               "enum": [
                 "comments", "empty_keys",
-                "multiline", "unicode", "whitespace"
+                "multiline", "path_traversal", "unicode", "whitespace"
               ]
             },
             {

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -167,7 +167,7 @@
       "type": "string",
       "oneOf": [
         {
-          "enum": ["comments", "empty_keys", "multiline", "unicode", "whitespace"]
+          "enum": ["comments", "empty_keys", "multiline", "path_traversal", "unicode", "whitespace"]
         },
         { "pattern": "^experimental_" },
         { "pattern": "^optional_" }

--- a/source_tests/core/api_core_ccl_hierarchy.json
+++ b/source_tests/core/api_core_ccl_hierarchy.json
@@ -289,6 +289,9 @@
           ]
         }
       ],
+      "features": [
+        "path_traversal"
+      ],
       "behaviors": [
         "list_coercion_disabled",
         "array_order_lexicographic"

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -755,7 +755,8 @@
       ],
       "inputs": [
         "mappings =\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "backslashes_in_map_keys",
@@ -1146,7 +1147,8 @@
       ],
       "inputs": [
         "mappings =\n  ../foo = ../bar\n  ../../config = ../../data"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "double_slash_in_nested",
@@ -1218,7 +1220,8 @@
       ],
       "inputs": [
         "config =\n  build = \n    output = ../../dist\n    cache = ../.cache"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "relative_paths_as_nested_keys",
@@ -1255,7 +1258,8 @@
       ],
       "inputs": [
         "imports =\n  .. = \n    main = ../src/main\n    test = ../tests"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "mixed_relative_and_absolute_nested",
@@ -1295,7 +1299,8 @@
       ],
       "inputs": [
         "paths =\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "double_slash_deeply_nested",
@@ -1335,7 +1340,8 @@
       ],
       "inputs": [
         "servers =\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "url_as_key",
@@ -1475,7 +1481,8 @@
       ],
       "inputs": [
         "mappings =\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "urls_deeply_nested",
@@ -1518,7 +1525,8 @@
       ],
       "inputs": [
         "config =\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
-      ]
+      ],
+      "features": ["path_traversal"]
     },
     {
       "name": "url_with_query_params_as_key",

--- a/source_tests/core/api_list_access.json
+++ b/source_tests/core/api_list_access.json
@@ -531,7 +531,8 @@
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "behaviors": [
         "array_order_insertion"
@@ -580,7 +581,8 @@
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "behaviors": [
         "array_order_lexicographic"
@@ -731,7 +733,8 @@
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "behaviors": [
         "array_order_insertion"
@@ -786,7 +789,8 @@
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "behaviors": [
         "array_order_lexicographic"
@@ -835,7 +839,8 @@
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "path_traversal"
       ],
       "inputs": [
         "database =\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
@@ -869,6 +874,9 @@
             "setting"
           ]
         }
+      ],
+      "features": [
+        "path_traversal"
       ],
       "behaviors": [
         "list_coercion_disabled"

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -279,6 +279,9 @@
           ]
         }
       ],
+      "features": [
+        "path_traversal"
+      ],
       "behaviors": [
         "list_coercion_enabled"
       ],
@@ -786,6 +789,9 @@
             ]
           }
         }
+      ],
+      "features": [
+        "path_traversal"
       ],
       "behaviors": [
         "list_coercion_enabled",

--- a/source_tests/core/api_reference_compliant.json
+++ b/source_tests/core/api_reference_compliant.json
@@ -131,6 +131,9 @@
           ]
         }
       ],
+      "features": [
+        "path_traversal"
+      ],
       "behaviors": [
         "list_coercion_disabled"
       ],
@@ -487,6 +490,9 @@
             "features"
           ]
         }
+      ],
+      "features": [
+        "path_traversal"
       ],
       "behaviors": [
         "list_coercion_disabled",

--- a/source_tests/core/api_typed_access.json
+++ b/source_tests/core/api_typed_access.json
@@ -1259,6 +1259,427 @@
       "inputs": [
         "empty ="
       ]
+    },
+    {
+      "name": "nested_get_int",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "server",
+              "value": "\n  port = 8080\n  max_connections = 1000"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "server": {
+              "port": "8080",
+              "max_connections": "1000"
+            }
+          }
+        },
+        {
+          "function": "get_int",
+          "expect": 8080,
+          "args": [
+            "server",
+            "port"
+          ]
+        },
+        {
+          "function": "get_int",
+          "expect": 1000,
+          "args": [
+            "server",
+            "max_connections"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ]
+    },
+    {
+      "name": "deeply_nested_get_int",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "config",
+              "value": "\n  database =\n    pool =\n      min = 5\n      max = 50"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "config": {
+              "database": {
+                "pool": {
+                  "min": "5",
+                  "max": "50"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function": "get_int",
+          "expect": 5,
+          "args": [
+            "config",
+            "database",
+            "pool",
+            "min"
+          ]
+        },
+        {
+          "function": "get_int",
+          "expect": 50,
+          "args": [
+            "config",
+            "database",
+            "pool",
+            "max"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ]
+    },
+    {
+      "name": "nested_get_float",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "metrics",
+              "value": "\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "metrics": {
+              "cpu_threshold": "0.85",
+              "memory_limit": "2.5"
+            }
+          }
+        },
+        {
+          "function": "get_float",
+          "expect": 0.85,
+          "args": [
+            "metrics",
+            "cpu_threshold"
+          ]
+        },
+        {
+          "function": "get_float",
+          "expect": 2.5,
+          "args": [
+            "metrics",
+            "memory_limit"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ]
+    },
+    {
+      "name": "deeply_nested_get_float",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "app",
+              "value": "\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "app": {
+              "scoring": {
+                "weights": {
+                  "relevance": "0.6",
+                  "freshness": "0.4"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function": "get_float",
+          "expect": 0.6,
+          "args": [
+            "app",
+            "scoring",
+            "weights",
+            "relevance"
+          ]
+        },
+        {
+          "function": "get_float",
+          "expect": 0.4,
+          "args": [
+            "app",
+            "scoring",
+            "weights",
+            "freshness"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ]
+    },
+    {
+      "name": "nested_get_bool",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "feature_flags",
+              "value": "\n  dark_mode = true\n  beta_access = false"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "feature_flags": {
+              "dark_mode": "true",
+              "beta_access": "false"
+            }
+          }
+        },
+        {
+          "function": "get_bool",
+          "expect": true,
+          "args": [
+            "feature_flags",
+            "dark_mode"
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": false,
+          "args": [
+            "feature_flags",
+            "beta_access"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ]
+    },
+    {
+      "name": "deeply_nested_get_bool",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "services",
+              "value": "\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "services": {
+              "auth": {
+                "settings": {
+                  "require_mfa": "true",
+                  "allow_anonymous": "false"
+                }
+              }
+            }
+          }
+        },
+        {
+          "function": "get_bool",
+          "expect": true,
+          "args": [
+            "services",
+            "auth",
+            "settings",
+            "require_mfa"
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": false,
+          "args": [
+            "services",
+            "auth",
+            "settings",
+            "allow_anonymous"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ]
+    },
+    {
+      "name": "nested_get_string_basic",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "database",
+              "value": "\n  host = localhost\n  name = mydb"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "database": {
+              "host": "localhost",
+              "name": "mydb"
+            }
+          }
+        },
+        {
+          "function": "get_string",
+          "expect": "localhost",
+          "args": [
+            "database",
+            "host"
+          ]
+        },
+        {
+          "function": "get_string",
+          "expect": "mydb",
+          "args": [
+            "database",
+            "name"
+          ]
+        }
+      ],
+      "features": [
+        "path_traversal"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ]
+    },
+    {
+      "name": "nested_mixed_typed_access",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "server",
+              "value": "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+            }
+          ]
+        },
+        {
+          "function": "build_hierarchy",
+          "expect": {
+            "server": {
+              "host": "0.0.0.0",
+              "port": "3000",
+              "debug": "true",
+              "rate_limit": "1.5"
+            }
+          }
+        },
+        {
+          "function": "get_string",
+          "expect": "0.0.0.0",
+          "args": [
+            "server",
+            "host"
+          ]
+        },
+        {
+          "function": "get_int",
+          "expect": 3000,
+          "args": [
+            "server",
+            "port"
+          ]
+        },
+        {
+          "function": "get_bool",
+          "expect": true,
+          "args": [
+            "server",
+            "debug"
+          ]
+        },
+        {
+          "function": "get_float",
+          "expect": 1.5,
+          "args": [
+            "server",
+            "rate_limit"
+          ]
+        }
+      ],
+      "features": [
+        "optional_typed_accessors",
+        "path_traversal"
+      ],
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ]
     }
   ]
 }

--- a/source_tests/experimental/api_experimental.json
+++ b/source_tests/experimental/api_experimental.json
@@ -369,7 +369,8 @@
         }
       ],
       "features": [
-        "experimental_dotted_keys"
+        "experimental_dotted_keys",
+        "path_traversal"
       ],
       "inputs": [
         "database.hosts = primary\ndatabase.hosts = secondary\ndatabase.port = 5432"


### PR DESCRIPTION
## Summary

- Adds a new `path_traversal` feature to the schema and Go config for tests that use multi-component `args` arrays in typed access functions (`get_string`, `get_int`, `get_bool`, `get_float`, `get_list`)
- Tags 20 existing tests across 7 source test files that use multi-component args
- Adds 9 new path traversal tests covering `get_int`, `get_float`, `get_bool`, `get_string`, and mixed typed access at both 2-level and 4-level nesting depths

This addresses category 3 from #91 — implementations that support typed access functions but only single-key lookups (not recursive hierarchy traversal) can now declare they don't support `path_traversal` and skip these tests.

## Test plan

- [x] `just validate` — schema compliance passes
- [x] `just reset` — 900 tests pass, 473 skipped
- [x] `go test ./config/...` — config package tests pass