### PR TITLE
fix(tests): correct tabs_as_whitespace to only strip leading tabs

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -168,7 +168,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "value with tabs"
+            "value": "value\twith\ttabs"
           }
         ]
       },
@@ -198,7 +198,7 @@
       "expected": {
         "count": 1,
         "object": {
-          "key": "value with tabs"
+          "key": "value\twith\ttabs"
         }
       },
       "features": [
@@ -222,7 +222,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": "value with tabs"
+        "value": "value\twith\ttabs"
       },
       "features": [
         "whitespace"
@@ -525,7 +525,7 @@
       },
       "expected": {
         "count": 1,
-        "value": "key = value with tabs"
+        "value": "key = value\twith\ttabs"
       },
       "features": [
         "whitespace"

--- a/go_tests/parsing/api_comments_test.go
+++ b/go_tests/parsing/api_comments_test.go
@@ -43,7 +43,27 @@ connections = 16`
 
 // comment_extension_filter - function:filter feature:comments
 func TestCommentExtensionFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is an environment section
+port = 8080
+serve = index.html
+/= Database section
+mode = in-memory
+connections = 16`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -71,7 +91,22 @@ func TestCommentSyntaxSlashEqualsParse(t *testing.T) {
 
 // comment_syntax_slash_equals_filter - function:filter feature:comments
 func TestCommentSyntaxSlashEqualsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= this is a comment`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -104,7 +139,27 @@ port = 6379`
 
 // section_headers_with_comments_filter - function:filter feature:comments feature:empty_keys
 func TestSectionHeadersWithCommentsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Database Config ==
+/= Connection settings
+host = localhost
+=== Cache Config ===
+/= Redis configuration
+port = 6379`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -39,13 +39,47 @@ age = 42`
 
 // basic_object_construction_build_hierarchy - function:build_hierarchy
 func TestBasicObjectConstructionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // basic_object_construction_print - function:print
 func TestBasicObjectConstructionPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -78,13 +112,55 @@ func TestDeepNestedObjectsParse(t *testing.T) {
 
 // deep_nested_objects_build_hierarchy - function:build_hierarchy
 func TestDeepNestedObjectsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": map[string]interface{}{"cache": map[string]interface{}{"enabled": "true"}, "database": map[string]interface{}{"host": "localhost", "port": "5432"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // deep_nested_objects_print - function:print
 func TestDeepNestedObjectsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -114,13 +190,49 @@ item = third`
 
 // duplicate_keys_to_lists_build_hierarchy - function:build_hierarchy
 func TestDuplicateKeysToListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second
+item = third`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": []interface{}{"first", "second", "third"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // duplicate_keys_to_lists_print - function:print
 func TestDuplicateKeysToListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second
+item = third`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -151,13 +263,51 @@ func TestNestedDuplicateKeysParse(t *testing.T) {
 
 // nested_duplicate_keys_build_hierarchy - function:build_hierarchy
 func TestNestedDuplicateKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1
+  server = web2
+  port = 80`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_duplicate_keys_print - function:print
 func TestNestedDuplicateKeysPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1
+  server = web2
+  port = 80`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -189,13 +339,53 @@ version = 1.0`
 
 // mixed_flat_and_nested_build_hierarchy - function:build_hierarchy
 func TestMixedFlatAndNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+  debug = true
+  timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "timeout": "30"}, "name": "Alice", "version": "1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // mixed_flat_and_nested_print - function:print
 func TestMixedFlatAndNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+  debug = true
+  timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -230,13 +420,59 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
 
 // nested_objects_with_lists_build_hierarchy - function:build_hierarchy
 func TestNestedObjectsWithListsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `environments =
+  prod =
+    server = web1
+    server = web2
+    port = 80
+  dev =
+    server = localhost
+    port = 3000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"environments": map[string]interface{}{"dev": map[string]interface{}{"port": "3000", "server": "localhost"}, "prod": map[string]interface{}{"port": "80", "server": []interface{}{"web1", "web2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_objects_with_lists_print - function:print
 func TestNestedObjectsWithListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `environments =
+  prod =
+    server = web1
+    server = web2
+    port = 80
+  dev =
+    server = localhost
+    port = 3000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -269,13 +505,61 @@ func TestDeeplyNestedListParse(t *testing.T) {
 
 // deeply_nested_list_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": []interface{}{"api1", "web1", "web2"}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // deeply_nested_list_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestDeeplyNestedListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers = web1
+      servers = web2
+      servers = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -39,13 +39,47 @@ age = 42`
 
 // complete_basic_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteBasicWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"age": "42", "name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_basic_workflow_print - function:print
 func TestCompleteBasicWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -76,13 +110,51 @@ func TestCompleteNestedWorkflowParse(t *testing.T) {
 
 // complete_nested_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteNestedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"enabled": "true", "host": "localhost", "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_nested_workflow_print - function:print
 func TestCompleteNestedWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -116,13 +188,57 @@ config =
 
 // complete_mixed_workflow_build_hierarchy - function:build_hierarchy
 func TestCompleteMixedWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app = MyApp
+version = 1.0.0
+config =
+  debug = true
+  features =
+    feature1 = enabled
+    feature2 = disabled`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"app": "MyApp", "config": map[string]interface{}{"debug": "true", "features": map[string]interface{}{"feature1": "enabled", "feature2": "disabled"}}, "version": "1.0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_mixed_workflow_print - function:print
 func TestCompleteMixedWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app = MyApp
+version = 1.0.0
+config =
+  debug = true
+  features =
+    feature1 = enabled
+    feature2 = disabled`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -156,13 +272,57 @@ ports =
 
 // complete_lists_workflow_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestCompleteListsWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"80", "443"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_lists_workflow_print - function:print
 func TestCompleteListsWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -196,13 +356,57 @@ ports =
 
 // complete_lists_workflow_lexicographic_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestCompleteListsWorkflowLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"ports": map[string]interface{}{"port": []interface{}{"443", "80"}}, "servers": map[string]interface{}{"server": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_lists_workflow_lexicographic_print - function:print
 func TestCompleteListsWorkflowLexicographicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  server = web1
+  server = web2
+  server = web3
+ports =
+  port = 80
+  port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -236,13 +440,57 @@ config =
 
 // complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = Welcome to our app
+  This is a multi-line description
+  With several lines
+config =
+  settings =
+    value1 = one
+    value2 = two`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"settings": map[string]interface{}{"value1": "one", "value2": "two"}}, "description": "Welcome to our app\n  This is a multi-line description\n  With several lines"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complete_multiline_workflow_print - function:print feature:multiline
 func TestCompleteMultilineWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = Welcome to our app
+  This is a multi-line description
+  With several lines
+config =
+  settings =
+    value1 = one
+    value2 = two`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -290,13 +538,85 @@ features =
 
 // real_world_complete_workflow_build_hierarchy - function:build_hierarchy
 func TestRealWorldCompleteWorkflowBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `service = MyMicroservice
+version = 2.1.0
+database =
+  host = db.example.com
+  port = 5432
+  credentials =
+    user = service_user
+    password = secret123
+  pools =
+    read = 5
+    write = 2
+logging =
+  level = info
+  outputs =
+    output = console
+    output = file
+    output = syslog
+features =
+  feature_a = enabled
+  feature_b = disabled
+  feature_c = experimental`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"credentials": map[string]interface{}{"password": "secret123", "user": "service_user"}, "host": "db.example.com", "pools": map[string]interface{}{"read": "5", "write": "2"}, "port": "5432"}, "features": map[string]interface{}{"feature_a": "enabled", "feature_b": "disabled", "feature_c": "experimental"}, "logging": map[string]interface{}{"level": "info", "outputs": map[string]interface{}{"output": []interface{}{"console", "file", "syslog"}}}, "service": "MyMicroservice", "version": "2.1.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // real_world_complete_workflow_print - function:print
 func TestRealWorldCompleteWorkflowPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `service = MyMicroservice
+version = 2.1.0
+database =
+  host = db.example.com
+  port = 5432
+  credentials =
+    user = service_user
+    password = secret123
+  pools =
+    read = 5
+    write = 2
+logging =
+  level = info
+  outputs =
+    output = console
+    output = file
+    output = syslog
+features =
+  feature_a = enabled
+  feature_b = disabled
+  feature_c = experimental`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -39,7 +39,23 @@ age = 42`
 
 // basic_key_value_pairs_print - function:print
 func TestBasicKeyValuePairsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+age = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -68,7 +84,23 @@ path = /bin/app=prod`
 
 // equals_in_values_print - function:print
 func TestEqualsInValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `msg = k=v pairs work fine
+path = /bin/app=prod`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -122,7 +154,25 @@ done = yes`
 
 // multiline_values_print - function:print feature:multiline
 func TestMultilineValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `description = First line
+  Second line
+  Third line
+done = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -151,7 +201,23 @@ other = value`
 
 // empty_values_print - function:print feature:empty_keys
 func TestEmptyValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty =
+other = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -181,7 +247,24 @@ func TestNestedStructureParsingParse(t *testing.T) {
 
 // nested_structure_parsing_print - function:print
 func TestNestedStructureParsingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -210,7 +293,23 @@ func TestUnicodeParsingParse(t *testing.T) {
 
 // unicode_parsing_print - function:print feature:unicode
 func TestUnicodeParsingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `emoji = 😀😃😄
+配置 = config`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -238,7 +337,22 @@ func TestEmptyInputParse(t *testing.T) {
 
 // empty_input_print - function:print
 func TestEmptyInputPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -290,7 +404,24 @@ key2 = value2`
 
 // leading_whitespace_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestLeadingWhitespaceToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key = value
+  second = entry`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "second", Value: "entry"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -60,7 +60,22 @@ func TestBasicWithSpacesParse(t *testing.T) {
 
 // indented_key_parse_indented - function:parse_indented feature:whitespace
 func TestIndentedKeyParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  key = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -201,7 +216,22 @@ func TestEmptyValueWithSpacesParse(t *testing.T) {
 
 // empty_key_indented_parse_indented - function:parse_indented feature:empty_keys
 func TestEmptyKeyIndentedParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `  = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -319,13 +349,45 @@ key2 = val2`
 
 // key_with_tabs_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestKeyWithTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // key_with_tabs_ocaml_reference_parse - function:parse feature:whitespace behavior:tabs_as_whitespace variant:reference_compliant
 func TestKeyWithTabsOcamlReferenceParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
@@ -353,13 +415,47 @@ func TestWhitespaceOnlyValueParse(t *testing.T) {
 
 // spaces_vs_tabs_continuation_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // spaces_vs_tabs_continuation_ocaml_reference_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
 func TestSpacesVsTabsContinuationOcamlReferenceParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `text = First
+    four spaces
+ 	tab preserved`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -574,13 +670,50 @@ func TestNestedMultiLineParse(t *testing.T) {
 
 // nested_with_blank_line_parse_indented - function:parse_indented feature:multiline
 func TestNestedWithBlankLineParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  line1
+
+  line2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // deep_nested_structure_parse_indented - function:parse_indented
 func TestDeepNestedStructureParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key =
+  field1 = value1
+  field2 =
+    subfield = x
+    another = y`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -651,13 +784,84 @@ user =
 
 // ocaml_stress_test_original_build_hierarchy - function:build_hierarchy feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": "This is a CCL document", "database": map[string]interface{}{"enabled": "true", "limits": map[string]interface{}{"cpu": "1500mi", "memory": "10Gb"}, "ports": map[string]interface{}{"": []interface{}{"8000", "8001", "8002"}}}, "title": "CCL Example", "user": map[string]interface{}{"createdAt": "2024-12-31", "guestId": "42", "login": "chshersh"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // ocaml_stress_test_original_get_string - function:get_string feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/= This is a CCL document
+title = CCL Example
+
+database =
+  enabled = true
+  ports =
+    = 8000
+    = 8001
+    = 8002
+  limits =
+    cpu = 1500mi
+    memory = 10Gb
+
+user =
+  guestId = 42
+
+user =
+  login = chshersh
+  createdAt = 2024-12-31`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"title"})
+	require.NoError(t, err)
+	assert.Equal(t, "CCL Example", result)
+
 }
 
 
@@ -687,13 +891,52 @@ func TestForwardSlashesInMapKeysParse(t *testing.T) {
 
 // forward_slashes_in_map_keys_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestForwardSlashesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  config/settings.json = .vscode/settings.json
+  src/template.env = .env`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mappings": map[string]interface{}{"config/settings.json": ".vscode/settings.json", "src/template.env": ".env"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // forward_slashes_in_map_keys_get_string - function:get_string feature:path_traversal
 func TestForwardSlashesInMapKeysGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  config/settings.json = .vscode/settings.json
+  src/template.env = .env`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mappings", "config/settings.json"})
+	require.NoError(t, err)
+	assert.Equal(t, ".vscode/settings.json", result)
+
 }
 
 
@@ -723,7 +966,26 @@ func TestBackslashesInMapKeysParse(t *testing.T) {
 
 // backslashes_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestBackslashesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `paths =
+  C:\Users\config = user_settings
+  D:\data\file.txt = backup`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"paths": map[string]interface{}{"C:\\Users\\config": "user_settings", "D:\\data\\file.txt": "backup"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -753,7 +1015,26 @@ func TestColonsInMapKeysParse(t *testing.T) {
 
 // colons_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestColonsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `timestamps =
+  12:30:45 = morning
+  23:59:59 = midnight`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"timestamps": map[string]interface{}{"12:30:45": "morning", "23:59:59": "midnight"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -783,7 +1064,26 @@ func TestHyphensInMapKeysParse(t *testing.T) {
 
 // hyphens_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestHyphensInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `packages =
+  my-package-name = 1.0.0
+  another-lib = 2.3.4`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"packages": map[string]interface{}{"another-lib": "2.3.4", "my-package-name": "1.0.0"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -813,7 +1113,26 @@ func TestAtSignsInMapKeysParse(t *testing.T) {
 
 // at_signs_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestAtSignsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `emails =
+  user@example.com = primary
+  admin@test.org = secondary`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"emails": map[string]interface{}{"admin@test.org": "secondary", "user@example.com": "primary"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -843,7 +1162,26 @@ func TestHashInMapKeysParse(t *testing.T) {
 
 // hash_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestHashInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `issues =
+  issue#123 = open
+  bug#456 = closed`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"issues": map[string]interface{}{"bug#456": "closed", "issue#123": "open"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -873,7 +1211,26 @@ func TestBracketsInMapKeysParse(t *testing.T) {
 
 // brackets_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestBracketsInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `arrays =
+  items[0] = first
+  items[1] = second`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"arrays": map[string]interface{}{"items[0]": "first", "items[1]": "second"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -903,7 +1260,26 @@ func TestParenthesesInMapKeysParse(t *testing.T) {
 
 // parentheses_in_map_keys_build_hierarchy - function:build_hierarchy
 func TestParenthesesInMapKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `functions =
+  init() = setup
+  run(args) = execute`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"functions": map[string]interface{}{"init()": "setup", "run(args)": "execute"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -934,7 +1310,27 @@ func TestMixedSpecialCharsInKeysParse(t *testing.T) {
 
 // mixed_special_chars_in_keys_build_hierarchy - function:build_hierarchy
 func TestMixedSpecialCharsInKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `complex =
+  user@host:8080/api = endpoint
+  file#v1.2.3 = release
+  path\to\[item] = location`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"complex": map[string]interface{}{"file#v1.2.3": "release", "path\\to\\[item]": "location", "user@host:8080/api": "endpoint"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -964,7 +1360,26 @@ func TestUrlLikeKeysParse(t *testing.T) {
 
 // url_like_keys_build_hierarchy - function:build_hierarchy
 func TestUrlLikeKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `endpoints =
+  https://api.example.com/v1 = production
+  http://localhost:3000/test = development`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"endpoints": map[string]interface{}{"http://localhost:3000/test": "development", "https://api.example.com/v1": "production"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -992,7 +1407,24 @@ func TestRelativePathParentParentParse(t *testing.T) {
 
 // relative_path_parent_parent_build_hierarchy - function:build_hierarchy
 func TestRelativePathParentParentBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `../.. = up_two_levels`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"../..": "up_two_levels"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1020,7 +1452,24 @@ func TestRelativePathParentParse(t *testing.T) {
 
 // relative_path_parent_build_hierarchy - function:build_hierarchy
 func TestRelativePathParentBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `../ = parent_dir`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"../": "parent_dir"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1048,7 +1497,24 @@ func TestRelativePathSingleDotParse(t *testing.T) {
 
 // relative_path_single_dot_build_hierarchy - function:build_hierarchy
 func TestRelativePathSingleDotBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `. = current_dir`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{".": "current_dir"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1076,7 +1542,24 @@ func TestDoubleSlashParse(t *testing.T) {
 
 // double_slash_build_hierarchy - function:build_hierarchy
 func TestDoubleSlashBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `// = double_slash_value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"//": "double_slash_value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1104,13 +1587,48 @@ func TestRelativePathInValueParse(t *testing.T) {
 
 // relative_path_in_value_build_hierarchy - function:build_hierarchy
 func TestRelativePathInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = ../../src`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "../../src"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // relative_path_in_value_get_string - function:get_string
 func TestRelativePathInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = ../../src`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "../../src", result)
+
 }
 
 
@@ -1140,13 +1658,52 @@ func TestRelativePathInNestedValueParse(t *testing.T) {
 
 // relative_path_in_nested_value_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathInNestedValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  ../foo = ../bar
+  ../../config = ../../data`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mappings": map[string]interface{}{"../../config": "../../data", "../foo": "../bar"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // relative_path_in_nested_value_get_string - function:get_string feature:path_traversal
 func TestRelativePathInNestedValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  ../foo = ../bar
+  ../../config = ../../data`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mappings", "../foo"})
+	require.NoError(t, err)
+	assert.Equal(t, "../bar", result)
+
 }
 
 
@@ -1176,7 +1733,26 @@ func TestDoubleSlashInNestedParse(t *testing.T) {
 
 // double_slash_in_nested_build_hierarchy - function:build_hierarchy
 func TestDoubleSlashInNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `urls =
+  //api = //backup
+  //server = /root`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"urls": map[string]interface{}{"//api": "//backup", "//server": "/root"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1207,13 +1783,54 @@ func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 
 // relative_paths_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathsDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  build = 
+    output = ../../dist
+    cache = ../.cache`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"build": map[string]interface{}{"cache": "../.cache", "output": "../../dist"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // relative_paths_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestRelativePathsDeeplyNestedGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  build = 
+    output = ../../dist
+    cache = ../.cache`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"config", "build", "cache"})
+	require.NoError(t, err)
+	assert.Equal(t, "../.cache", result)
+
 }
 
 
@@ -1244,13 +1861,54 @@ func TestRelativePathsAsNestedKeysParse(t *testing.T) {
 
 // relative_paths_as_nested_keys_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestRelativePathsAsNestedKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `imports =
+  .. = 
+    main = ../src/main
+    test = ../tests`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"imports": map[string]interface{}{"..": map[string]interface{}{"main": "../src/main", "test": "../tests"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // relative_paths_as_nested_keys_get_string - function:get_string feature:path_traversal
 func TestRelativePathsAsNestedKeysGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `imports =
+  .. = 
+    main = ../src/main
+    test = ../tests`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"imports", "..", "main"})
+	require.NoError(t, err)
+	assert.Equal(t, "../src/main", result)
+
 }
 
 
@@ -1283,13 +1941,58 @@ func TestMixedRelativeAndAbsoluteNestedParse(t *testing.T) {
 
 // mixed_relative_and_absolute_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestMixedRelativeAndAbsoluteNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `paths =
+  relative = 
+    up = ../../
+    current = .
+  absolute = 
+    root = /`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"paths": map[string]interface{}{"absolute": map[string]interface{}{"root": "/"}, "relative": map[string]interface{}{"current": ".", "up": "../../"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // mixed_relative_and_absolute_nested_get_string - function:get_string feature:path_traversal
 func TestMixedRelativeAndAbsoluteNestedGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `paths =
+  relative = 
+    up = ../../
+    current = .
+  absolute = 
+    root = /`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"paths", "relative", "up"})
+	require.NoError(t, err)
+	assert.Equal(t, "../../", result)
+
 }
 
 
@@ -1322,13 +2025,58 @@ func TestDoubleSlashDeeplyNestedParse(t *testing.T) {
 
 // double_slash_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestDoubleSlashDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  primary = 
+    api = //api.example.com
+    cdn = //cdn.example.com
+  secondary = 
+    //internal = //backup.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": map[string]interface{}{"primary": map[string]interface{}{"api": "//api.example.com", "cdn": "//cdn.example.com"}, "secondary": map[string]interface{}{"//internal": "//backup.example.com"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // double_slash_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestDoubleSlashDeeplyNestedGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  primary = 
+    api = //api.example.com
+    cdn = //cdn.example.com
+  secondary = 
+    //internal = //backup.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"servers", "primary", "api"})
+	require.NoError(t, err)
+	assert.Equal(t, "//api.example.com", result)
+
 }
 
 
@@ -1356,13 +2104,48 @@ func TestUrlAsKeyParse(t *testing.T) {
 
 // url_as_key_build_hierarchy - function:build_hierarchy
 func TestUrlAsKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com = production`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"https://api.example.com": "production"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // url_as_key_get_string - function:get_string
 func TestUrlAsKeyGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com = production`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"https://api.example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "production", result)
+
 }
 
 
@@ -1390,7 +2173,24 @@ func TestUrlWithPortAsKeyParse(t *testing.T) {
 
 // url_with_port_as_key_build_hierarchy - function:build_hierarchy
 func TestUrlWithPortAsKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `http://localhost:8080 = dev`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"http://localhost:8080": "dev"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1418,7 +2218,24 @@ func TestUrlWithPathAsKeyParse(t *testing.T) {
 
 // url_with_path_as_key_build_hierarchy - function:build_hierarchy
 func TestUrlWithPathAsKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com/v1/users = users_endpoint`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"https://api.example.com/v1/users": "users_endpoint"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1446,13 +2263,48 @@ func TestUrlInValueParse(t *testing.T) {
 
 // url_in_value_build_hierarchy - function:build_hierarchy
 func TestUrlInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `endpoint = https://api.example.com/v1/data`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"endpoint": "https://api.example.com/v1/data"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // url_in_value_get_string - function:get_string
 func TestUrlInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `endpoint = https://api.example.com/v1/data`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"endpoint"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com/v1/data", result)
+
 }
 
 
@@ -1482,13 +2334,52 @@ func TestUrlsAsNestedKeysAndValuesParse(t *testing.T) {
 
 // urls_as_nested_keys_and_values_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestUrlsAsNestedKeysAndValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  https://api.example.com = https://prod.example.com
+  https://staging.example.com = https://stage.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mappings": map[string]interface{}{"https://api.example.com": "https://prod.example.com", "https://staging.example.com": "https://stage.example.com"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // urls_as_nested_keys_and_values_get_string - function:get_string feature:path_traversal
 func TestUrlsAsNestedKeysAndValuesGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mappings =
+  https://api.example.com = https://prod.example.com
+  https://staging.example.com = https://stage.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mappings", "https://api.example.com"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://prod.example.com", result)
+
 }
 
 
@@ -1522,25 +2413,105 @@ func TestUrlsDeeplyNestedParse(t *testing.T) {
 
 // urls_deeply_nested_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestUrlsDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  services = 
+    api = 
+      url = https://api.example.com
+      backup = https://backup.example.com
+    cdn = 
+      url = https://cdn.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"services": map[string]interface{}{"api": map[string]interface{}{"backup": "https://backup.example.com", "url": "https://api.example.com"}, "cdn": map[string]interface{}{"url": "https://cdn.example.com"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // urls_deeply_nested_get_string - function:get_string feature:path_traversal
 func TestUrlsDeeplyNestedGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  services = 
+    api = 
+      url = https://api.example.com
+      backup = https://backup.example.com
+    cdn = 
+      url = https://cdn.example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"config", "services", "api", "url"})
+	require.NoError(t, err)
+	assert.Equal(t, "https://api.example.com", result)
+
 }
 
 
 // url_with_query_params_as_key_parse - function:parse behavior:delimiter_prefer_spaced
 func TestUrlWithQueryParamsAsKeyParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com/search?q=test&page=1 = search_results`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "https://api.example.com/search?q=test&page=1", Value: "search_results"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // url_with_query_params_as_key_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestUrlWithQueryParamsAsKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com/search?q=test&page=1 = search_results`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"https://api.example.com/search?q=test&page=1": "search_results"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1568,7 +2539,24 @@ func TestDelimiterFirstUrlWithQueryParamsParse(t *testing.T) {
 
 // delimiter_first_url_with_query_params_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstUrlWithQueryParamsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://api.example.com/search?q=test&page=1 = search_results`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"https://api.example.com/search?q": "test&page=1 = search_results"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1596,7 +2584,24 @@ func TestDelimiterFirstMultipleEqualsParse(t *testing.T) {
 
 // delimiter_first_multiple_equals_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstMultipleEqualsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `a=b = c=d`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"a": "b = c=d"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1624,43 +2629,159 @@ func TestDelimiterFirstEmptyValueParse(t *testing.T) {
 
 // delimiter_first_empty_value_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstEmptyValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `a=b =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"a": "b ="}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // delimiter_spaced_multiple_equals_parse - function:parse behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedMultipleEqualsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
+	
+
+	ccl := mock.New()
+	input := `a=b = c=d`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "a=b", Value: "c=d"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // delimiter_spaced_multiple_equals_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedMultipleEqualsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `a=b = c=d`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"a=b": "c=d"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // delimiter_spaced_fallback_no_space_parse - function:parse behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedFallbackNoSpaceParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
+	
+
+	ccl := mock.New()
+	input := `key=value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // delimiter_spaced_fallback_no_space_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedFallbackNoSpaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key=value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // delimiter_spaced_empty_value_parse - function:parse behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedEmptyValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
+	
+
+	ccl := mock.New()
+	input := `a=b =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "a=b", Value: ""}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // delimiter_spaced_empty_value_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedEmptyValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `a=b =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"a=b": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1688,7 +2809,24 @@ func TestUrlWithFragmentAsKeyParse(t *testing.T) {
 
 // url_with_fragment_as_key_build_hierarchy - function:build_hierarchy
 func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `https://docs.example.com/guide#section-1 = docs_section_1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"https://docs.example.com/guide#section-1": "docs_section_1"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
@@ -808,13 +808,48 @@ func TestS1FuzzValName0Parse(t *testing.T) {
 
 // s1_fuzz_val_name_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data?x77]x88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data?x77]x88"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_val_name_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data?x77]x88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data?x77]x88", result)
+
 }
 
 
@@ -842,13 +877,48 @@ func TestS1FuzzValData1Parse(t *testing.T) {
 
 // s1_fuzz_val_data_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValData1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data'x23!x22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"data": "data'x23!x22"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_val_data_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValData1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data'x23!x22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"data"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x23!x22", result)
+
 }
 
 
@@ -876,13 +946,48 @@ func TestS1FuzzValMode2Parse(t *testing.T) {
 
 // s1_fuzz_val_mode_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValMode2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data?x30"x15~x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mode": "data?x30\"x15~x73"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_val_mode_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValMode2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data?x30"x15~x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mode"})
+	require.NoError(t, err)
+	assert.Equal(t, "data?x30\"x15~x73", result)
+
 }
 
 
@@ -910,13 +1015,48 @@ func TestS1FuzzValName3Parse(t *testing.T) {
 
 // s1_fuzz_val_name_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data$x23~x81@x41`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data$x23~x81@x41"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_val_name_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data$x23~x81@x41`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data$x23~x81@x41", result)
+
 }
 
 
@@ -944,13 +1084,48 @@ func TestS1FuzzValUser4Parse(t *testing.T) {
 
 // s1_fuzz_val_user_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValUser4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `user = data}x85$x2$x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"user": "data}x85$x2$x43"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_val_user_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValUser4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `user = data}x85$x2$x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"user"})
+	require.NoError(t, err)
+	assert.Equal(t, "data}x85$x2$x43", result)
+
 }
 
 
@@ -979,13 +1154,50 @@ func TestS1FuzzNestedAmpersandRbrace0Parse(t *testing.T) {
 
 // s1_fuzz_nested_ampersand_rbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&alpha = nested297
+}gamma = deep715`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&alpha": "nested297", "}gamma": "deep715"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_ampersand_rbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&alpha = nested297
+}gamma = deep715`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested297", result)
+
 }
 
 
@@ -1014,13 +1226,50 @@ func TestS1FuzzNestedQuestionRbracket1Parse(t *testing.T) {
 
 // s1_fuzz_nested_question_rbracket_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?port = nested105
+]name = deep997`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"?port": "nested105", "]name": "deep997"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_question_rbracket_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?port = nested105
+]name = deep997`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested105", result)
+
 }
 
 
@@ -1049,13 +1298,50 @@ func TestS1FuzzNestedPlusSlash2Parse(t *testing.T) {
 
 // s1_fuzz_nested_plus_slash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+config = nested427
+/server = deep329`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"+config": "nested427", "/server": "deep329"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_plus_slash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+config = nested427
+/server = deep329`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"+config"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested427", result)
+
 }
 
 
@@ -1084,13 +1370,50 @@ $port = deep486`
 
 // s1_fuzz_nested_ampersand_dollar_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&name = nested41
+$port = deep486`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$port": "deep486", "&name": "nested41"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_ampersand_dollar_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&name = nested41
+$port = deep486`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested41", result)
+
 }
 
 
@@ -1119,13 +1442,50 @@ func TestS1FuzzNestedTildeSquote4Parse(t *testing.T) {
 
 // s1_fuzz_nested_tilde_squote_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested332
+'beta = deep158`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"'beta": "deep158", "~beta": "nested332"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_tilde_squote_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested332
+'beta = deep158`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"~beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested332", result)
+
 }
 
 
@@ -1154,13 +1514,50 @@ func TestS1FuzzNestedHyphenAmpersand5Parse(t *testing.T) {
 
 // s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `-config = nested723
+&epsilon = deep891`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&epsilon": "deep891", "-config": "nested723"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_hyphen_ampersand_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `-config = nested723
+&epsilon = deep891`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"-config"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested723", result)
+
 }
 
 
@@ -1189,13 +1586,50 @@ func TestS1FuzzNestedDollarAsterisk6Parse(t *testing.T) {
 
 // s1_fuzz_nested_dollar_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$path = nested884
+*mode = deep88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$path": "nested884", "*mode": "deep88"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_dollar_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$path = nested884
+*mode = deep88`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"$path"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested884", result)
+
 }
 
 
@@ -1224,13 +1658,50 @@ func TestS1FuzzNestedUnderscoreSemicolon7Parse(t *testing.T) {
 
 // s1_fuzz_nested_underscore_semicolon_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `_path = nested515
+;alpha = deep519`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{";alpha": "deep519", "_path": "nested515"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_underscore_semicolon_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `_path = nested515
+;alpha = deep519`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"_path"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested515", result)
+
 }
 
 
@@ -1259,13 +1730,50 @@ func TestS1FuzzNestedAtRparen8Parse(t *testing.T) {
 
 // s1_fuzz_nested_at_rparen_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@server = nested286
+)gamma = deep475`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")gamma": "deep475", "@server": "nested286"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_at_rparen_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@server = nested286
+)gamma = deep475`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"@server"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested286", result)
+
 }
 
 
@@ -1294,13 +1802,50 @@ func TestS1FuzzNestedRbraceTilde9Parse(t *testing.T) {
 
 // s1_fuzz_nested_rbrace_tilde_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}beta = nested295
+~alpha = deep415`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"}beta": "nested295", "~alpha": "deep415"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s1_fuzz_nested_rbrace_tilde_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}beta = nested295
+~alpha = deep415`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested295", result)
+
 }
 
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
@@ -808,13 +808,48 @@ func TestS42FuzzValData0Parse(t *testing.T) {
 
 // s42_fuzz_val_data_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValData0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data|x58`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"data": "data|x58"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_val_data_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValData0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `data = data|x58`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"data"})
+	require.NoError(t, err)
+	assert.Equal(t, "data|x58", result)
+
 }
 
 
@@ -842,13 +877,48 @@ func TestS42FuzzValBeta1Parse(t *testing.T) {
 
 // s42_fuzz_val_beta_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValBeta1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `beta = data\x12`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"beta": "data\\x12"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_val_beta_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValBeta1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `beta = data\x12`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "data\\x12", result)
+
 }
 
 
@@ -876,13 +946,48 @@ func TestS42FuzzValName2Parse(t *testing.T) {
 
 // s42_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data\x77"x95_x85`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data\\x77\"x95_x85"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValName2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data\x77"x95_x85`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data\\x77\"x95_x85", result)
+
 }
 
 
@@ -910,13 +1015,48 @@ func TestS42FuzzValPath3Parse(t *testing.T) {
 
 // s42_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValPath3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data-x45`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data-x45"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValPath3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data-x45`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data-x45", result)
+
 }
 
 
@@ -944,13 +1084,48 @@ func TestS42FuzzValName4Parse(t *testing.T) {
 
 // s42_fuzz_val_name_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data{x49"x55`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data{x49\"x55"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_val_name_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValName4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data{x49"x55`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data{x49\"x55", result)
+
 }
 
 
@@ -979,13 +1154,50 @@ func TestS42FuzzNestedLbraceRbracket0Parse(t *testing.T) {
 
 // s42_fuzz_nested_lbrace_rbracket_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested259
+]name = deep985`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"]name": "deep985", "{host": "nested259"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_lbrace_rbracket_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested259
+]name = deep985`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested259", result)
+
 }
 
 
@@ -1014,13 +1226,50 @@ func TestS42FuzzNestedLbraceRbrace1Parse(t *testing.T) {
 
 // s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{port = nested169
+}mode = deep270`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"{port": "nested169", "}mode": "deep270"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_lbrace_rbrace_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{port = nested169
+}mode = deep270`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested169", result)
+
 }
 
 
@@ -1049,13 +1298,50 @@ func TestS42FuzzNestedAmpersandPercent2Parse(t *testing.T) {
 
 // s42_fuzz_nested_ampersand_percent_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&delta = nested56
+%data = deep952`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%data": "deep952", "&delta": "nested56"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_ampersand_percent_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `&delta = nested56
+%data = deep952`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"&delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested56", result)
+
 }
 
 
@@ -1084,13 +1370,50 @@ func TestS42FuzzNestedDquoteGt3Parse(t *testing.T) {
 
 // s42_fuzz_nested_dquote_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"epsilon = nested885
+>user = deep168`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"epsilon": "nested885", ">user": "deep168"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_dquote_gt_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"epsilon = nested885
+>user = deep168`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested885", result)
+
 }
 
 
@@ -1119,13 +1442,50 @@ $path = deep65`
 
 // s42_fuzz_nested_percent_dollar_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%alpha = nested438
+$path = deep65`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$path": "deep65", "%alpha": "nested438"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_percent_dollar_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%alpha = nested438
+$path = deep65`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"%alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested438", result)
+
 }
 
 
@@ -1154,13 +1514,50 @@ func TestS42FuzzNestedDquoteRbracket5Parse(t *testing.T) {
 
 // s42_fuzz_nested_dquote_rbracket_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"gamma = nested524
+]mode = deep57`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"gamma": "nested524", "]mode": "deep57"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_dquote_rbracket_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"gamma = nested524
+]mode = deep57`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"gamma"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested524", result)
+
 }
 
 
@@ -1189,13 +1586,50 @@ func TestS42FuzzNestedLbraceAmpersand6Parse(t *testing.T) {
 
 // s42_fuzz_nested_lbrace_ampersand_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{data = nested474
+&port = deep22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&port": "deep22", "{data": "nested474"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_lbrace_ampersand_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{data = nested474
+&port = deep22`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested474", result)
+
 }
 
 
@@ -1224,13 +1658,50 @@ func TestS42FuzzNestedSemicolonHyphen7Parse(t *testing.T) {
 
 // s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;data = nested239
+-server = deep284`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"-server": "deep284", ";data": "nested239"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_semicolon_hyphen_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;data = nested239
+-server = deep284`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{";data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested239", result)
+
 }
 
 
@@ -1259,13 +1730,50 @@ func TestS42FuzzNestedLbraceRbrace8Parse(t *testing.T) {
 
 // s42_fuzz_nested_lbrace_rbrace_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested125
+}user = deep615`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"{host": "nested125", "}user": "deep615"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_lbrace_rbrace_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `{host = nested125
+}user = deep615`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"{host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested125", result)
+
 }
 
 
@@ -1294,13 +1802,50 @@ func TestS42FuzzNestedTildeAmpersand9Parse(t *testing.T) {
 
 // s42_fuzz_nested_tilde_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested835
+&gamma = deep966`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&gamma": "deep966", "~beta": "nested835"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s42_fuzz_nested_tilde_ampersand_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `~beta = nested835
+&gamma = deep966`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"~beta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested835", result)
+
 }
 
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
@@ -808,13 +808,48 @@ func TestS49FuzzValEpsilon0Parse(t *testing.T) {
 
 // s49_fuzz_val_epsilon_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `epsilon = data;x5&x96?x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"epsilon": "data;x5&x96?x73"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_val_epsilon_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `epsilon = data;x5&x96?x73`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "data;x5&x96?x73", result)
+
 }
 
 
@@ -842,13 +877,48 @@ func TestS49FuzzValConfig1Parse(t *testing.T) {
 
 // s49_fuzz_val_config_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValConfig1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config = data'x33`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": "data'x33"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_val_config_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValConfig1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config = data'x33`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"config"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x33", result)
+
 }
 
 
@@ -876,13 +946,48 @@ func TestS49FuzzValName2Parse(t *testing.T) {
 
 // s49_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValName2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data<x71`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "data<x71"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValName2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = data<x71`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "data<x71", result)
+
 }
 
 
@@ -910,13 +1015,48 @@ func TestS49FuzzValMode3Parse(t *testing.T) {
 
 // s49_fuzz_val_mode_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValMode3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data+x19`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"mode": "data+x19"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_val_mode_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValMode3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mode = data+x19`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"mode"})
+	require.NoError(t, err)
+	assert.Equal(t, "data+x19", result)
+
 }
 
 
@@ -944,13 +1084,48 @@ func TestS49FuzzValServer4Parse(t *testing.T) {
 
 // s49_fuzz_val_server_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValServer4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data#x70-x10`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": "data#x70-x10"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_val_server_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValServer4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data#x70-x10`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"server"})
+	require.NoError(t, err)
+	assert.Equal(t, "data#x70-x10", result)
+
 }
 
 
@@ -979,13 +1154,50 @@ func TestS49FuzzNestedSquoteLbrace0Parse(t *testing.T) {
 
 // s49_fuzz_nested_squote_lbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `'name = nested330
+{user = deep34`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"'name": "nested330", "{user": "deep34"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_squote_lbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `'name = nested330
+{user = deep34`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"'name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested330", result)
+
 }
 
 
@@ -1014,13 +1226,50 @@ _user = deep650`
 
 // s49_fuzz_nested_at_underscore_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@name = nested517
+_user = deep650`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"@name": "nested517", "_user": "deep650"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_at_underscore_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `@name = nested517
+_user = deep650`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"@name"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested517", result)
+
 }
 
 
@@ -1049,13 +1298,50 @@ func TestS49FuzzNestedRparenBackslash2Parse(t *testing.T) {
 
 // s49_fuzz_nested_rparen_backslash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)epsilon = nested451
+\delta = deep648`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")epsilon": "nested451", "\\delta": "deep648"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_rparen_backslash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)epsilon = nested451
+\delta = deep648`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{")epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested451", result)
+
 }
 
 
@@ -1084,13 +1370,50 @@ func TestS49FuzzNestedDollarGt3Parse(t *testing.T) {
 
 // s49_fuzz_nested_dollar_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$port = nested76
+>host = deep444`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$port": "nested76", ">host": "deep444"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_dollar_gt_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `$port = nested76
+>host = deep444`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"$port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested76", result)
+
 }
 
 
@@ -1119,13 +1442,50 @@ func TestS49FuzzNestedDquoteLbrace4Parse(t *testing.T) {
 
 // s49_fuzz_nested_dquote_lbrace_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested587
+{gamma = deep774`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"host": "nested587", "{gamma": "deep774"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_dquote_lbrace_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested587
+{gamma = deep774`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested587", result)
+
 }
 
 
@@ -1154,13 +1514,50 @@ func TestS49FuzzNestedSemicolonAsterisk5Parse(t *testing.T) {
 
 // s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;host = nested246
+*item = deep424`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"*item": "deep424", ";host": "nested246"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_semicolon_asterisk_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `;host = nested246
+*item = deep424`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{";host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested246", result)
+
 }
 
 
@@ -1189,13 +1586,50 @@ func TestS49FuzzNestedQuestionAsterisk6Parse(t *testing.T) {
 
 // s49_fuzz_nested_question_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?epsilon = nested334
+*delta = deep689`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"*delta": "deep689", "?epsilon": "nested334"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_question_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?epsilon = nested334
+*delta = deep689`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested334", result)
+
 }
 
 
@@ -1224,13 +1658,50 @@ func TestS49FuzzNestedPlusAmpersand7Parse(t *testing.T) {
 
 // s49_fuzz_nested_plus_ampersand_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+server = nested496
+&gamma = deep440`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"&gamma": "deep440", "+server": "nested496"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_plus_ampersand_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `+server = nested496
+&gamma = deep440`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"+server"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested496", result)
+
 }
 
 
@@ -1259,13 +1730,50 @@ func TestS49FuzzNestedAsteriskDquote8Parse(t *testing.T) {
 
 // s49_fuzz_nested_asterisk_dquote_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `*item = nested578
+"delta = deep232`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"delta": "deep232", "*item": "nested578"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_asterisk_dquote_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `*item = nested578
+"delta = deep232`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"*item"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested578", result)
+
 }
 
 
@@ -1294,13 +1802,50 @@ func TestS49FuzzNestedRbraceSlash9Parse(t *testing.T) {
 
 // s49_fuzz_nested_rbrace_slash_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}host = nested668
+/delta = deep756`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/delta": "deep756", "}host": "nested668"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s49_fuzz_nested_rbrace_slash_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}host = nested668
+/delta = deep756`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested668", result)
+
 }
 
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
@@ -808,13 +808,48 @@ func TestS99FuzzValPath0Parse(t *testing.T) {
 
 // s99_fuzz_val_path_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data'x66`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data'x66"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_val_path_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data'x66`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data'x66", result)
+
 }
 
 
@@ -842,13 +877,48 @@ func TestS99FuzzValItem1Parse(t *testing.T) {
 
 // s99_fuzz_val_item_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValItem1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = data]x41!x78`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "data]x41!x78"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_val_item_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValItem1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = data]x41!x78`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"item"})
+	require.NoError(t, err)
+	assert.Equal(t, "data]x41!x78", result)
+
 }
 
 
@@ -876,13 +946,48 @@ func TestS99FuzzValServer2Parse(t *testing.T) {
 
 // s99_fuzz_val_server_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValServer2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data[x73;x54!x24`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": "data[x73;x54!x24"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_val_server_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValServer2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server = data[x73;x54!x24`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"server"})
+	require.NoError(t, err)
+	assert.Equal(t, "data[x73;x54!x24", result)
+
 }
 
 
@@ -910,13 +1015,48 @@ func TestS99FuzzValPath3Parse(t *testing.T) {
 
 // s99_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data~x4>x82~x46`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"path": "data~x4>x82~x46"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `path = data~x4>x82~x46`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"path"})
+	require.NoError(t, err)
+	assert.Equal(t, "data~x4>x82~x46", result)
+
 }
 
 
@@ -944,13 +1084,48 @@ func TestS99FuzzValAlpha4Parse(t *testing.T) {
 
 // s99_fuzz_val_alpha_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValAlpha4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `alpha = data<x11[x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"alpha": "data<x11[x43"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_val_alpha_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValAlpha4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `alpha = data<x11[x43`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"alpha"})
+	require.NoError(t, err)
+	assert.Equal(t, "data<x11[x43", result)
+
 }
 
 
@@ -979,13 +1154,50 @@ func TestS99FuzzNestedSlashRparen0Parse(t *testing.T) {
 
 // s99_fuzz_nested_slash_rparen_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/data = nested929
+)item = deep37`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")item": "deep37", "/data": "nested929"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_slash_rparen_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/data = nested929
+)item = deep37`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"/data"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested929", result)
+
 }
 
 
@@ -1014,13 +1226,50 @@ func TestS99FuzzNestedLtPercent1Parse(t *testing.T) {
 
 // s99_fuzz_nested_lt_percent_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `<port = nested722
+%config = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%config": "deep795", "<port": "nested722"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_lt_percent_1_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `<port = nested722
+%config = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"<port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested722", result)
+
 }
 
 
@@ -1049,13 +1298,50 @@ func TestS99FuzzNestedSlashLbrace2Parse(t *testing.T) {
 
 // s99_fuzz_nested_slash_lbrace_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/epsilon = nested268
+{server = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/epsilon": "nested268", "{server": "deep795"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_slash_lbrace_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `/epsilon = nested268
+{server = deep795`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"/epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested268", result)
+
 }
 
 
@@ -1084,13 +1370,50 @@ func TestS99FuzzNestedDquoteLbracket3Parse(t *testing.T) {
 
 // s99_fuzz_nested_dquote_lbracket_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested435
+[server = deep479`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"host": "nested435", "[server": "deep479"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_dquote_lbracket_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"host = nested435
+[server = deep479`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested435", result)
+
 }
 
 
@@ -1119,13 +1442,50 @@ func TestS99FuzzNestedBackslashBackslash4Parse(t *testing.T) {
 
 // s99_fuzz_nested_backslash_backslash_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `\item = nested708
+\name = deep133`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\\item": "nested708", "\\name": "deep133"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_backslash_backslash_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `\item = nested708
+\name = deep133`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\\item"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested708", result)
+
 }
 
 
@@ -1154,13 +1514,50 @@ func TestS99FuzzNestedQuestionDquote5Parse(t *testing.T) {
 
 // s99_fuzz_nested_question_dquote_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?delta = nested18
+"item = deep576`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"item": "deep576", "?delta": "nested18"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_question_dquote_5_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `?delta = nested18
+"item = deep576`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"?delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested18", result)
+
 }
 
 
@@ -1189,13 +1586,50 @@ func TestS99FuzzNestedDquoteBackslash6Parse(t *testing.T) {
 
 // s99_fuzz_nested_dquote_backslash_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"user = nested759
+\data = deep718`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"\"user": "nested759", "\\data": "deep718"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_dquote_backslash_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `"user = nested759
+\data = deep718`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"\"user"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested759", result)
+
 }
 
 
@@ -1224,13 +1658,50 @@ func TestS99FuzzNestedRparenBackslash7Parse(t *testing.T) {
 
 // s99_fuzz_nested_rparen_backslash_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)port = nested292
+\server = deep527`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{")port": "nested292", "\\server": "deep527"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_rparen_backslash_7_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `)port = nested292
+\server = deep527`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{")port"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested292", result)
+
 }
 
 
@@ -1259,13 +1730,50 @@ $gamma = deep225`
 
 // s99_fuzz_nested_rbrace_dollar_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}delta = nested591
+$gamma = deep225`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"$gamma": "deep225", "}delta": "nested591"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_rbrace_dollar_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `}delta = nested591
+$gamma = deep225`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"}delta"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested591", result)
+
 }
 
 
@@ -1294,13 +1802,50 @@ func TestS99FuzzNestedPercentAmpersand9Parse(t *testing.T) {
 
 // s99_fuzz_nested_percent_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9BuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%epsilon = nested761
+&port = deep211`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"%epsilon": "nested761", "&port": "deep211"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // s99_fuzz_nested_percent_ampersand_9_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9GetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `%epsilon = nested761
+&port = deep211`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"%epsilon"})
+	require.NoError(t, err)
+	assert.Equal(t, "nested761", result)
+
 }
 
 

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -40,13 +40,52 @@ servers = web3`
 
 // basic_list_from_duplicates_build_hierarchy - function:build_hierarchy
 func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // basic_list_from_duplicates_get_list - function:get_list behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+servers = web2
+servers = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
 
@@ -93,13 +132,86 @@ items = item20`
 
 // large_list_build_hierarchy - function:build_hierarchy
 func TestLargeListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // large_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestLargeListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items = item01
+items = item02
+items = item03
+items = item04
+items = item05
+items = item06
+items = item07
+items = item08
+items = item09
+items = item10
+items = item11
+items = item12
+items = item13
+items = item14
+items = item15
+items = item16
+items = item17
+items = item18
+items = item19
+items = item20`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"item01", "item02", "item03", "item04", "item05", "item06", "item07", "item08", "item09", "item10", "item11", "item12", "item13", "item14", "item15", "item16", "item17", "item18", "item19", "item20"}, result)
+
 }
 
 
@@ -131,13 +243,56 @@ servers = web3
 
 // list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_insertion
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"Production servers", "End of list"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_comments_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
 
@@ -169,13 +324,56 @@ servers = web3
 
 // list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"End of list", "Production servers"}, "servers": []interface{}{"web1", "web2", "web3"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_comments_lexicographic_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers = web1
+/= Production servers
+servers = web2
+servers = web3
+/= End of list`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
 
@@ -203,13 +401,51 @@ func TestListErrorMissingKeyParse(t *testing.T) {
 
 // list_error_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_error_missing_key_get_list - function:get_list
 func TestListErrorMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -238,13 +474,53 @@ func TestListErrorNestedMissingKeyParse(t *testing.T) {
 
 // list_error_nested_missing_key_build_hierarchy - function:build_hierarchy
 func TestListErrorNestedMissingKeyBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"server": "web1"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_error_nested_missing_key_get_list - function:get_list
 func TestListErrorNestedMissingKeyGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  server = web1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -272,13 +548,51 @@ func TestListErrorNonObjectPathParse(t *testing.T) {
 
 // list_error_non_object_path_build_hierarchy - function:build_hierarchy
 func TestListErrorNonObjectPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"value": "simple"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_error_non_object_path_get_list - function:get_list
 func TestListErrorNonObjectPathGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `value = simple`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"value", "nested"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -306,13 +620,51 @@ func TestListEdgeCaseZeroLengthParse(t *testing.T) {
 
 // list_edge_case_zero_length_build_hierarchy - function:build_hierarchy
 func TestListEdgeCaseZeroLengthBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_edge_case_zero_length_get_list - function:get_list
 func TestListEdgeCaseZeroLengthGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"nonexistent"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -343,13 +695,54 @@ func TestBareListBasicParse(t *testing.T) {
 
 // bare_list_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "web3"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_basic_get_list - function:get_list feature:empty_keys
 func TestBareListBasicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `servers =
+  = web1
+  = web2
+  = web3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "web3"}, result)
+
 }
 
 
@@ -381,13 +774,56 @@ func TestBareListNestedParse(t *testing.T) {
 
 // bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"80", "443", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_nested_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"80", "443", "8080"}, result)
+
 }
 
 
@@ -419,13 +855,56 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 
 // bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"network": map[string]interface{}{"ports": map[string]interface{}{"": []interface{}{"443", "80", "8080"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_nested_lexicographic_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `network =
+  ports =
+    = 80
+    = 443
+    = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"network", "ports"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"443", "80", "8080"}, result)
+
 }
 
 
@@ -457,13 +936,56 @@ func TestBareListWithCommentsParse(t *testing.T) {
 
 // bare_list_with_comments_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"localhost", "127.0.0.1", "example.com"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost", "127.0.0.1", "example.com"}, result)
+
 }
 
 
@@ -495,13 +1017,56 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
 
 // bare_list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"allowed_hosts": map[string]interface{}{"": []interface{}{"127.0.0.1", "example.com", "localhost"}, "/": "Production hosts"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_with_comments_lexicographic_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `allowed_hosts =
+  /= Production hosts
+  = localhost
+  = 127.0.0.1
+  = example.com`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"allowed_hosts"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"127.0.0.1", "example.com", "localhost"}, result)
+
 }
 
 
@@ -535,13 +1100,60 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
 
 // bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"web1", "web2", "api1"}}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_deeply_nested_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_insertion
 func TestBareListDeeplyNestedGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"web1", "web2", "api1"}, result)
+
 }
 
 
@@ -575,13 +1187,60 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 
 // bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"environments": map[string]interface{}{"production": map[string]interface{}{"servers": map[string]interface{}{"": []interface{}{"api1", "web1", "web2"}}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_deeply_nested_lexicographic_get_list - function:get_list feature:empty_keys feature:path_traversal behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  environments =
+    production =
+      servers =
+        = web1
+        = web2
+        = api1`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "environments", "production", "servers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"api1", "web1", "web2"}, result)
+
 }
 
 
@@ -614,13 +1273,58 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 
 // bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys feature:path_traversal
 func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"host": "localhost", "port": "5432", "replicas": map[string]interface{}{"": []interface{}{"replica1", "replica2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys feature:path_traversal
 func TestBareListMixedWithOtherKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432
+  replicas =
+    = replica1
+    = replica2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "replicas"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"replica1", "replica2"}, result)
+
 }
 
 
@@ -649,13 +1353,53 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 
 // bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"setting": "value"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_error_not_a_list_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled
 func TestBareListErrorNotAListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  setting = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"config", "setting"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -689,13 +1433,60 @@ func TestBareListNestedObjectsBasicParse(t *testing.T) {
 
 // bare_list_nested_objects_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "first", "value": "1"}, map[string]interface{}{"name": "second", "value": "2"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_nested_objects_basic_get_list - function:get_list feature:empty_keys
 func TestBareListNestedObjectsBasicGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{map[string]interface {}{"name":"first", "value":"1"}, map[string]interface {}{"name":"second", "value":"2"}}, result)
+
 }
 
 
@@ -726,13 +1517,54 @@ func TestBareListNestedObjectsSingleItemParse(t *testing.T) {
 
 // bare_list_nested_objects_single_item_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsSingleItemBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = only
+    value = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "only", "value": "42"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // bare_list_nested_objects_single_item_get_list - function:get_list feature:empty_keys
 func TestBareListNestedObjectsSingleItemGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = only
+    value = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{map[string]interface {}{"name":"only", "value":"42"}}, result)
+
 }
 
 
@@ -764,7 +1596,28 @@ func TestBareListNestedObjectsMinimalParse(t *testing.T) {
 
 // bare_list_nested_objects_minimal_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsMinimalBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+  =
+    name = second`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"name": "first"}, map[string]interface{}{"name": "second"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -800,7 +1653,32 @@ func TestBareListNestedObjectsDeeplyNestedParse(t *testing.T) {
 
 // bare_list_nested_objects_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsDeeplyNestedBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    config =
+      host = localhost
+      port = 8080
+  =
+    config =
+      host = example.com
+      port = 443`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{map[string]interface{}{"config": map[string]interface{}{"host": "localhost", "port": "8080"}}, map[string]interface{}{"config": map[string]interface{}{"host": "example.com", "port": "443"}}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -833,7 +1711,29 @@ func TestBareListNestedObjectsMixedWithStringsParse(t *testing.T) {
 
 // bare_list_nested_objects_mixed_with_strings_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedObjectsMixedWithStringsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  = simple_string
+  =
+    name = nested
+    value = obj
+  = another_string`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": map[string]interface{}{"": []interface{}{"simple_string", map[string]interface{}{"name": "nested", "value": "obj"}, "another_string"}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -867,7 +1767,28 @@ func TestBareListNestedObjectsRoundTripParse(t *testing.T) {
 
 // bare_list_nested_objects_round_trip_print - function:print feature:empty_keys
 func TestBareListNestedObjectsRoundTripPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =
+  =
+    name = first
+    value = 1
+  =
+    name = second
+    value = 2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -16,43 +16,173 @@ import (
 
 // multiline_section_header_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline
 func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+  This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // unindented_multiline_becomes_continuation_parse_indented - function:parse_indented feature:empty_keys
 func TestUnindentedMultilineBecomesContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+This continues the header
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline
 func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line\n  second line", "Another item"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // indented_line_is_continuation_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+  second line
+descriptions = Another item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line\n  second line", "Another item"}, result)
+
 }
 
 
 // mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline feature:empty_keys
 func TestMixedIndentationLevelsParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline feature:empty_keys
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key1 = value1
+  indented continuation
+key2 = value2
+not indented key
+  indented for not indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1\n  indented continuation", "key2": "value2", "not indented key": map[string]interface{}{"indented for not indented": ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -80,13 +210,48 @@ func TestSingleItemAsListParse(t *testing.T) {
 
 // single_item_as_list_build_hierarchy - function:build_hierarchy
 func TestSingleItemAsListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // single_item_as_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestSingleItemAsListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"single"}, result)
+
 }
 
 
@@ -116,13 +281,52 @@ host = localhost`
 
 // mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"80", "443"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // mixed_duplicate_single_keys_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"localhost"}, result)
+
 }
 
 
@@ -153,13 +357,54 @@ func TestNestedListAccessParse(t *testing.T) {
 
 // nested_list_access_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestNestedListAccessBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_list_access_get_list - function:get_list feature:path_traversal behavior:list_coercion_enabled
 func TestNestedListAccessGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"5432"}, result)
+
 }
 
 
@@ -187,13 +432,48 @@ func TestEmptyListParse(t *testing.T) {
 
 // empty_list_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestEmptyListBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // empty_list_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestEmptyListGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{""}, result)
+
 }
 
 
@@ -224,13 +504,54 @@ numbers = 0`
 
 // list_with_numbers_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"1", "42", "-17", "0"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithNumbersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"1", "42", "-17", "0"}, result)
+
 }
 
 
@@ -261,13 +582,54 @@ flags = no`
 
 // list_with_booleans_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"true", "false", "yes", "no"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_booleans_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithBooleansGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"true", "false", "yes", "no"}, result)
+
 }
 
 
@@ -298,13 +660,54 @@ items =   `
 
 // list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_insertion
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"spaced", "normal", "", ""}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithWhitespaceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"spaced", "normal", "", ""}, result)
+
 }
 
 
@@ -335,13 +738,54 @@ names = العربية`
 
 // list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_insertion
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"张三", "José", "François", "العربية"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_unicode_get_list - function:get_list feature:unicode behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithUnicodeGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"张三", "José", "François", "العربية"}, result)
+
 }
 
 
@@ -372,49 +816,229 @@ symbols = <>=+`
 
 // list_with_special_characters_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"@#$%", "!^&*()", "[]{}|", "<>=+"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithSpecialCharactersGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|
+symbols = <>=+`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"@#$%", "!^&*()", "[]{}|", "<>=+"}, result)
+
 }
 
 
 // list_multiline_values_parse_indented - function:parse_indented feature:multiline
 func TestListMultilineValuesParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline behavior:array_order_insertion
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"descriptions": []interface{}{"First line", "Another item", "Third item"}, "second line": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_multiline_values_get_list - function:get_list feature:multiline behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListMultilineValuesGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `descriptions = First line
+second line
+descriptions = Another item
+descriptions = Third item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"descriptions"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"First line", "Another item", "Third item"}, result)
+
 }
 
 
 // complex_mixed_list_scenarios_parse_indented - function:parse_indented feature:path_traversal
 func TestComplexMixedListScenariosParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement parse_indented validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_insertion
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"primary", "backup"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"auth", "api", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complex_mixed_list_scenarios_get_list - function:get_list feature:path_traversal behavior:list_coercion_enabled behavior:array_order_insertion
 func TestComplexMixedListScenariosGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"auth", "api", "ui"}, result)
+
 }
 
 
@@ -442,13 +1066,48 @@ func TestListPathTraversalProtectionParse(t *testing.T) {
 
 // list_path_traversal_protection_build_hierarchy - function:build_hierarchy
 func TestListPathTraversalProtectionBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_path_traversal_protection_get_list - function:get_list behavior:list_coercion_enabled
 func TestListPathTraversalProtectionGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	require.NoError(t, err)
+	assert.Equal(t, []interface {}{"value"}, result)
+
 }
 
 
@@ -476,13 +1135,48 @@ func TestParseEmptyValueParse(t *testing.T) {
 
 // parse_empty_value_build_hierarchy - function:build_hierarchy
 func TestParseEmptyValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_empty_value_get_string - function:get_string
 func TestParseEmptyValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"empty_key"})
+	require.NoError(t, err)
+	assert.Equal(t, "", result)
+
 }
 
 

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -38,13 +38,51 @@ func TestSingleItemAsListReferenceParse(t *testing.T) {
 
 // single_item_as_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestSingleItemAsListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"item": "single"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // single_item_as_list_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `item = single`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"item"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -74,13 +112,55 @@ host = localhost`
 
 // mixed_duplicate_single_keys_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"host": "localhost", "ports": []interface{}{"443", "80"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // mixed_duplicate_single_keys_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `ports = 80
+ports = 443
+host = localhost`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"host"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -111,13 +191,57 @@ func TestNestedListAccessReferenceParse(t *testing.T) {
 
 // nested_list_access_reference_build_hierarchy - function:build_hierarchy feature:path_traversal variant:reference_compliant
 func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"hosts": []interface{}{"primary", "secondary"}, "port": "5432"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_list_access_reference_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled variant:reference_compliant
 func TestNestedListAccessReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  hosts = primary
+  hosts = secondary
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"database", "port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -145,13 +269,51 @@ func TestEmptyListReferenceParse(t *testing.T) {
 
 // empty_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyListReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_list": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // empty_list_reference_get_list - function:get_list variant:reference_compliant
 func TestEmptyListReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_list =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"empty_list"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -182,13 +344,57 @@ numbers = 0`
 
 // list_with_numbers_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithNumbersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"numbers": []interface{}{"-17", "0", "1", "42"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_numbers_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `numbers = 1
+numbers = 42
+numbers = -17
+numbers = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"numbers"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -219,13 +425,57 @@ flags = no`
 
 // list_with_booleans_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithBooleansReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flags": []interface{}{"false", "no", "true", "yes"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_booleans_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithBooleansReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flags = true
+flags = false
+flags = yes
+flags = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"flags"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -256,13 +506,57 @@ items =   `
 
 // list_with_whitespace_reference_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"items": []interface{}{"normal", "spaced"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_whitespace_reference_get_list - function:get_list feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `items =   spaced   
+items = normal
+items =
+items =   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"items"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -293,13 +587,57 @@ names = العربية`
 
 // list_with_unicode_reference_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"names": []interface{}{"François", "José", "العربية", "张三"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_unicode_reference_get_list - function:get_list feature:unicode behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `names = 张三
+names = José
+names = François
+names = العربية`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"names"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -329,25 +667,125 @@ symbols = []{}|`
 
 // list_with_special_characters_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"symbols": []interface{}{"!^&*()", "@#$%", "[]{}|"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_with_special_characters_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `symbols = @#$%
+symbols = !^&*()
+symbols = []{}|`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"symbols"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
 // complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy feature:path_traversal behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"cache": "redis", "database": map[string]interface{}{"hosts": []interface{}{"backup", "primary"}, "port": "5432"}, "servers": []interface{}{"web1", "web2"}}, "features": []interface{}{"api", "auth", "ui"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // complex_mixed_list_scenarios_reference_get_list - function:get_list feature:path_traversal behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  servers = web1
+  servers = web2
+  database =
+    hosts = primary
+    hosts = backup
+    port = 5432
+  cache = redis
+features = auth
+features = api
+features = ui`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"features"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -375,13 +813,51 @@ func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
 
 // list_path_traversal_protection_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestListPathTraversalProtectionReferenceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"safe": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // list_path_traversal_protection_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `safe = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_list validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetList(hierarchy, []string{"safe"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Empty(t, result)
+	}
+
 }
 
 
@@ -409,7 +885,24 @@ func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
 
 // empty_value_reference_behavior_build_hierarchy - function:build_hierarchy variant:reference_compliant
 func TestEmptyValueReferenceBehaviorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_key =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"empty_key": ""}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -436,7 +929,22 @@ func TestCanonicalFormatEmptyValuesOcamlReferenceCanonicalFormat(t *testing.T) {
 
 // canonical_format_tab_preservation_ocaml_reference_canonical_format - function:parse function:print function:canonical_format behavior:tabs_as_content behavior:indent_spaces
 func TestCanonicalFormatTabPreservationOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `value_with_tabs = text		with	tabs	`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -464,13 +972,44 @@ emo = 🌟✨`
 
 // canonical_format_line_endings_reference_behavior_parse - function:parse behavior:crlf_preserve_literal
 func TestCanonicalFormatLineEndingsReferenceBehaviorParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // canonical_format_line_endings_reference_behavior_canonical_format - function:parse function:print function:canonical_format behavior:crlf_preserve_literal behavior:indent_spaces
 func TestCanonicalFormatLineEndingsReferenceBehaviorCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -38,13 +38,48 @@ func TestParseBasicIntegerParse(t *testing.T) {
 
 // parse_basic_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "8080"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_basic_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBasicIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
 
 
@@ -72,13 +107,48 @@ func TestParseBasicFloatParse(t *testing.T) {
 
 // parse_basic_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicFloatBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "98.6"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_basic_float_get_float - function:get_float feature:optional_typed_accessors
 func TestParseBasicFloatGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = 98.6`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	require.NoError(t, err)
+	assert.Equal(t, 98.6, result)
+
 }
 
 
@@ -106,13 +176,48 @@ func TestParseBooleanTrueParse(t *testing.T) {
 
 // parse_boolean_true_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanTrueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "true"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_true_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
@@ -140,13 +245,48 @@ func TestParseBooleanYesParse(t *testing.T) {
 
 // parse_boolean_yes_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_yes_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanYesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
@@ -174,13 +314,51 @@ func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
 
 // parse_boolean_yes_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"active": "yes"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_yes_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanYesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `active = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"active"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -208,13 +386,48 @@ func TestParseBooleanFalseParse(t *testing.T) {
 
 // parse_boolean_false_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanFalseBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"disabled": "false"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_false_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanFalseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `disabled = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
 
 
@@ -242,13 +455,48 @@ func TestParseStringFallbackParse(t *testing.T) {
 
 // parse_string_fallback_build_hierarchy - function:build_hierarchy
 func TestParseStringFallbackBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"name": "Alice"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_string_fallback_get_string - function:get_string
 func TestParseStringFallbackGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"name"})
+	require.NoError(t, err)
+	assert.Equal(t, "Alice", result)
+
 }
 
 
@@ -276,13 +524,48 @@ func TestParseNegativeIntegerParse(t *testing.T) {
 
 // parse_negative_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseNegativeIntegerBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"offset": "-42"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_negative_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseNegativeIntegerGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `offset = -42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"offset"})
+	require.NoError(t, err)
+	assert.Equal(t, -42, result)
+
 }
 
 
@@ -312,25 +595,104 @@ disabled = no`
 
 // parse_zero_values_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_zero_values_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
 
 
 // parse_zero_values_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseZeroValuesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
 
 
 // parse_zero_values_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
 
 
@@ -360,25 +722,107 @@ disabled = no`
 
 // parse_zero_values_strict_literal_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"count": "0", "disabled": "no", "distance": "0.0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_zero_values_strict_literal_get_int - function:get_int feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"count"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
 
 
 // parse_zero_values_strict_literal_get_bool - function:get_bool feature:empty_keys feature:optional_typed_accessors behavior:boolean_strict
 func TestParseZeroValuesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"disabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
 // parse_zero_values_strict_literal_get_float - function:get_float feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `count = 0
+distance = 0.0
+disabled = no`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"distance"})
+	require.NoError(t, err)
+	assert.Equal(t, 0, result)
+
 }
 
 
@@ -412,19 +856,90 @@ flag7 = 0`
 
 // parse_boolean_variants_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBooleanVariantsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
 
 
 // parse_boolean_variants_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseBooleanVariantsGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
@@ -458,19 +973,93 @@ flag7 = 0`
 
 // parse_boolean_variants_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag1": "yes", "flag2": "on", "flag3": "1", "flag4": "false", "flag5": "no", "flag6": "off", "flag7": "0"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_variants_strict_literal_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag3"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
 
 
 // parse_boolean_variants_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanVariantsStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag1 = yes
+flag2 = on
+flag3 = 1
+flag4 = false
+flag5 = no
+flag6 = off
+flag7 = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag1"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -502,31 +1091,140 @@ debug = off`
 
 // parse_mixed_types_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_mixed_types_get_string - function:get_string feature:optional_typed_accessors
 func TestParseMixedTypesGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
 }
 
 
 // parse_mixed_types_get_int - function:get_int feature:optional_typed_accessors
 func TestParseMixedTypesGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
 
 
 // parse_mixed_types_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestParseMixedTypesGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
 // parse_mixed_types_get_float - function:get_float feature:optional_typed_accessors
 func TestParseMixedTypesGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
 }
 
 
@@ -558,31 +1256,140 @@ debug = off`
 
 // parse_mixed_types_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"debug": "off", "host": "localhost", "port": "8080", "ssl": "true", "timeout": "30.5"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_mixed_types_strict_literal_get_string - function:get_string feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"host"})
+	require.NoError(t, err)
+	assert.Equal(t, "localhost", result)
+
 }
 
 
 // parse_mixed_types_strict_literal_get_int - function:get_int feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	require.NoError(t, err)
+	assert.Equal(t, 8080, result)
+
 }
 
 
 // parse_mixed_types_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseMixedTypesStrictLiteralGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"ssl"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
 // parse_mixed_types_strict_literal_get_float - function:get_float feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080
+ssl = true
+timeout = 30.5
+debug = off`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"timeout"})
+	require.NoError(t, err)
+	assert.Equal(t, 30.5, result)
+
 }
 
 
@@ -611,19 +1418,75 @@ flag =  true  `
 
 // parse_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"flag": "true", "number": "42"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_with_whitespace_get_int - function:get_int feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
 
 
 // parse_with_whitespace_get_bool - function:get_bool feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number =   42   
+flag =  true  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"flag"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
@@ -654,19 +1517,81 @@ text = hello`
 
 // parse_with_conservative_options_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseWithConservativeOptionsBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"decimal": "3.14", "flag": "true", "number": "42", "text": "hello"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_with_conservative_options_get_string - function:get_string feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"decimal"})
+	require.NoError(t, err)
+	assert.Equal(t, "3.14", result)
+
 }
 
 
 // parse_with_conservative_options_get_int - function:get_int feature:optional_typed_accessors
 func TestParseWithConservativeOptionsGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42
+decimal = 3.14
+flag = true
+text = hello`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"number"})
+	require.NoError(t, err)
+	assert.Equal(t, 42, result)
+
 }
 
 
@@ -694,13 +1619,51 @@ func TestParseIntegerErrorParse(t *testing.T) {
 
 // parse_integer_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseIntegerErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"port": "not_a_number"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_integer_error_get_int - function:get_int feature:optional_typed_accessors
 func TestParseIntegerErrorGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `port = not_a_number`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"port"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
 
 
@@ -728,13 +1691,51 @@ func TestParseFloatErrorParse(t *testing.T) {
 
 // parse_float_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseFloatErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"temperature": "invalid"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_float_error_get_float - function:get_float feature:optional_typed_accessors
 func TestParseFloatErrorGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `temperature = invalid`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"temperature"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
 
 
@@ -762,13 +1763,51 @@ func TestParseBooleanErrorParse(t *testing.T) {
 
 // parse_boolean_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"enabled": "maybe"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_boolean_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `enabled = maybe`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"enabled"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -796,13 +1835,51 @@ func TestParseMissingPathErrorParse(t *testing.T) {
 
 // parse_missing_path_error_build_hierarchy - function:build_hierarchy
 func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"existing": "value"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // parse_missing_path_error_get_string - function:get_string
 func TestParseMissingPathErrorGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `existing = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"missing"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, "", result)
+	}
+
 }
 
 
@@ -831,7 +1908,29 @@ upper_false = FALSE`
 
 // boolean_case_sensitivity_uppercase_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityUppercaseGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_true = TRUE
+upper_false = FALSE`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -860,7 +1959,29 @@ mixed_false = False`
 
 // boolean_case_sensitivity_mixed_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanCaseSensitivityMixedGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `mixed_true = True
+mixed_false = False`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"mixed_true"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -889,7 +2010,29 @@ upper_no = NO`
 
 // boolean_lenient_uppercase_yes_no_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_lenient
 func TestBooleanLenientUppercaseYesNoGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `upper_yes = YES
+upper_no = NO`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"upper_yes"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -918,13 +2061,54 @@ zero = 0`
 
 // boolean_numeric_one_zero_strict_get_int - function:get_int feature:optional_typed_accessors
 func TestBooleanNumericOneZeroStrictGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"one"})
+	require.NoError(t, err)
+	assert.Equal(t, 1, result)
+
 }
 
 
 // boolean_numeric_one_zero_strict_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanNumericOneZeroStrictGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `one = 1
+zero = 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"one"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -952,13 +2136,51 @@ func TestBooleanWithWhitespaceParse(t *testing.T) {
 
 // boolean_with_whitespace_get_bool - function:get_bool feature:optional_typed_accessors feature:whitespace behavior:boolean_strict
 func TestBooleanWithWhitespaceGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `padded =   true   `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"padded"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
 // boolean_nested_object_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  debug = true
+  verbose = false
+  experimental = yes`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"debug": "true", "experimental": "yes", "verbose": "false"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -986,7 +2208,28 @@ func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
 
 // type_mismatch_get_int_on_bool_get_int - function:get_int feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0, result)
+	}
+
 }
 
 
@@ -1014,7 +2257,28 @@ func TestTypeMismatchGetBoolOnIntParse(t *testing.T) {
 
 // type_mismatch_get_bool_on_int_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestTypeMismatchGetBoolOnIntGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `number = 42`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"number"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -1042,13 +2306,53 @@ func TestTypeMismatchGetFloatOnBoolParse(t *testing.T) {
 
 // type_mismatch_get_float_on_bool_get_float - function:get_float feature:optional_typed_accessors
 func TestTypeMismatchGetFloatOnBoolGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `flag = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"flag"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, 0.0, result)
+	}
+
 }
 
 
 // type_mismatch_nested_path_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
 func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  name = test
+  count = abc`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"count": "abc", "name": "test"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -1076,7 +2380,28 @@ func TestBooleanEmptyValueErrorParse(t *testing.T) {
 
 // boolean_empty_value_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestBooleanEmptyValueErrorGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty =`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"empty"})
+	if err != nil {
+		require.Error(t, err)
+	} else {
+		assert.Equal(t, false, result)
+	}
+
 }
 
 
@@ -1106,13 +2431,52 @@ func TestNestedGetIntParse(t *testing.T) {
 
 // nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestNestedGetIntBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  port = 8080
+  max_connections = 1000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": map[string]interface{}{"max_connections": "1000", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_get_int_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
 func TestNestedGetIntGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  port = 8080
+  max_connections = 1000`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"server", "max_connections"})
+	require.NoError(t, err)
+	assert.Equal(t, 1000, result)
+
 }
 
 
@@ -1144,13 +2508,56 @@ func TestDeeplyNestedGetIntParse(t *testing.T) {
 
 // deeply_nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestDeeplyNestedGetIntBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  database =
+    pool =
+      min = 5
+      max = 50`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"database": map[string]interface{}{"pool": map[string]interface{}{"max": "50", "min": "5"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // deeply_nested_get_int_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
 func TestDeeplyNestedGetIntGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  database =
+    pool =
+      min = 5
+      max = 50`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"config", "database", "pool", "max"})
+	require.NoError(t, err)
+	assert.Equal(t, 50, result)
+
 }
 
 
@@ -1180,13 +2587,52 @@ func TestNestedGetFloatParse(t *testing.T) {
 
 // nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestNestedGetFloatBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `metrics =
+  cpu_threshold = 0.85
+  memory_limit = 2.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"metrics": map[string]interface{}{"cpu_threshold": "0.85", "memory_limit": "2.5"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_get_float_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
 func TestNestedGetFloatGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `metrics =
+  cpu_threshold = 0.85
+  memory_limit = 2.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"metrics", "memory_limit"})
+	require.NoError(t, err)
+	assert.Equal(t, 2.5, result)
+
 }
 
 
@@ -1218,13 +2664,56 @@ func TestDeeplyNestedGetFloatParse(t *testing.T) {
 
 // deeply_nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestDeeplyNestedGetFloatBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app =
+  scoring =
+    weights =
+      relevance = 0.6
+      freshness = 0.4`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"app": map[string]interface{}{"scoring": map[string]interface{}{"weights": map[string]interface{}{"freshness": "0.4", "relevance": "0.6"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // deeply_nested_get_float_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
 func TestDeeplyNestedGetFloatGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app =
+  scoring =
+    weights =
+      relevance = 0.6
+      freshness = 0.4`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"app", "scoring", "weights", "freshness"})
+	require.NoError(t, err)
+	assert.Equal(t, 0.4, result)
+
 }
 
 
@@ -1254,13 +2743,52 @@ func TestNestedGetBoolParse(t *testing.T) {
 
 // nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestNestedGetBoolBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `feature_flags =
+  dark_mode = true
+  beta_access = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"feature_flags": map[string]interface{}{"beta_access": "false", "dark_mode": "true"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_get_bool_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
 func TestNestedGetBoolGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `feature_flags =
+  dark_mode = true
+  beta_access = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"feature_flags", "beta_access"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
 
 
@@ -1292,13 +2820,56 @@ func TestDeeplyNestedGetBoolParse(t *testing.T) {
 
 // deeply_nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestDeeplyNestedGetBoolBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `services =
+  auth =
+    settings =
+      require_mfa = true
+      allow_anonymous = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"services": map[string]interface{}{"auth": map[string]interface{}{"settings": map[string]interface{}{"allow_anonymous": "false", "require_mfa": "true"}}}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // deeply_nested_get_bool_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
 func TestDeeplyNestedGetBoolGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `services =
+  auth =
+    settings =
+      require_mfa = true
+      allow_anonymous = false`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"services", "auth", "settings", "allow_anonymous"})
+	require.NoError(t, err)
+	assert.Equal(t, false, result)
+
 }
 
 
@@ -1328,13 +2899,52 @@ func TestNestedGetStringBasicParse(t *testing.T) {
 
 // nested_get_string_basic_build_hierarchy - function:build_hierarchy feature:path_traversal
 func TestNestedGetStringBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  name = mydb`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"database": map[string]interface{}{"host": "localhost", "name": "mydb"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_get_string_basic_get_string - function:get_string feature:path_traversal
 func TestNestedGetStringBasicGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  name = mydb`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"database", "name"})
+	require.NoError(t, err)
+	assert.Equal(t, "mydb", result)
+
 }
 
 
@@ -1366,31 +2976,140 @@ func TestNestedMixedTypedAccessParse(t *testing.T) {
 
 // nested_mixed_typed_access_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors feature:path_traversal
 func TestNestedMixedTypedAccessBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"server": map[string]interface{}{"debug": "true", "host": "0.0.0.0", "port": "3000", "rate_limit": "1.5"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // nested_mixed_typed_access_get_string - function:get_string feature:optional_typed_accessors feature:path_traversal
 func TestNestedMixedTypedAccessGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"server", "host"})
+	require.NoError(t, err)
+	assert.Equal(t, "0.0.0.0", result)
+
 }
 
 
 // nested_mixed_typed_access_get_int - function:get_int feature:optional_typed_accessors feature:path_traversal
 func TestNestedMixedTypedAccessGetInt(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_int validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetInt(hierarchy, []string{"server", "port"})
+	require.NoError(t, err)
+	assert.Equal(t, 3000, result)
+
 }
 
 
 // nested_mixed_typed_access_get_bool - function:get_bool feature:optional_typed_accessors feature:path_traversal behavior:boolean_strict behavior:boolean_lenient
 func TestNestedMixedTypedAccessGetBool(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_bool validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetBool(hierarchy, []string{"server", "debug"})
+	require.NoError(t, err)
+	assert.Equal(t, true, result)
+
 }
 
 
 // nested_mixed_typed_access_get_float - function:get_float feature:optional_typed_accessors feature:path_traversal
 func TestNestedMixedTypedAccessGetFloat(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  host = 0.0.0.0
+  port = 3000
+  debug = true
+  rate_limit = 1.5`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_float validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetFloat(hierarchy, []string{"server", "rate_limit"})
+	require.NoError(t, err)
+	assert.Equal(t, 1.5, result)
+
 }
 
 

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -16,109 +16,411 @@ import (
 
 // tabs_as_content_in_value_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tvalue\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_content_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "\tvalue\twith\ttabs"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // tabs_as_content_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tvalue\twith\ttabs", result)
+
 }
 
 
 // tabs_as_content_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "\tindented"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_content
 func TestTabsAsContentLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "\tindented", result)
+
 }
 
 
 // tabs_as_whitespace_in_value_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key": "value\twith\ttabs"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace
 func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "value\twith\ttabs", result)
+
 }
 
 
 // tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "indented"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_whitespace_leading_tab_get_string - function:get_string feature:whitespace
 func TestTabsAsWhitespaceLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// get_string validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	hierarchy := ccl.BuildHierarchy(parseResult)
+	result, err := ccl.GetString(hierarchy, []string{"key"})
+	require.NoError(t, err)
+	assert.Equal(t, "indented", result)
+
 }
 
 
 // tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 			three_tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "three_tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_content
 func TestTabsAsContentMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	indented_with_tabs
+ 	another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\n \tindented_with_tabs\n \tanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented_with_tabs
+		another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nindented_with_tabs\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	mixed_indent
+	 another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\nmixed_indent\nanother_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // tabs_canonical_format_as_content_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:tabs_as_content
 func TestTabsCanonicalFormatAsContentCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:tabs_as_whitespace
 func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_spaces
 func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented
+		another`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // tabs_as_whitespace_round_trip_round_trip - function:parse function:print feature:whitespace behavior:tabs_as_whitespace
 func TestTabsAsWhitespaceRoundTripRoundTrip(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -177,31 +479,124 @@ func TestDeeplyNestedBareListIndentationCanonicalFormat(t *testing.T) {
 
 // print_nested_indent_spaces_print - function:print behavior:indent_spaces
 func TestPrintNestedIndentSpacesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+  host = localhost
+  port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // print_deeply_nested_indent_spaces_print - function:print behavior:indent_spaces
 func TestPrintDeeplyNestedIndentSpacesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // print_nested_indent_tabs_print - function:print behavior:indent_tabs
 func TestPrintNestedIndentTabsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `database =
+	host = localhost
+	port = 5432`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // print_deeply_nested_indent_tabs_print - function:print behavior:indent_tabs
 func TestPrintDeeplyNestedIndentTabsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `server =
+	database =
+		host = localhost
+		port = 5432
+	cache =
+		enabled = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // print_mixed_flat_and_nested_indent_tabs_print - function:print behavior:indent_tabs
 func TestPrintMixedFlatAndNestedIndentTabsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+config =
+	debug = true
+	timeout = 30
+version = 1.0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -253,7 +648,24 @@ key3	=	value3`
 
 // tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_tabs
 func TestTabsAsWhitespaceMultilineCanonicalIndentTabsCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented
+		another`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -334,19 +746,69 @@ func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
 
 // crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1", "key2": "value2"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // crlf_preserve_literal_basic_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1\r"}, mock.Entry{Key: "key2", Value: "value2\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // crlf_preserve_literal_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "key1 = value1\r\nkey2 = value2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"key1": "value1\r", "key2": "value2\r"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -374,7 +836,23 @@ func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
 
 // crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_preserve_literal
 func TestCrlfPreserveMultilineValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "multiline =\r\n  line1\r\n  line2"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "multiline", Value: "\r\n  line1\r\n  line2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
@@ -424,19 +902,69 @@ func TestCrlfNestedStructureParse(t *testing.T) {
 
 // crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"host": "localhost", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // crlf_preserve_nested_structure_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "config", Value: "\r\n  host = localhost\r\n  port = 8080"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // crlf_preserve_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "config =\r\n  host = localhost\r\n  port = 8080"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"config": map[string]interface{}{"host": "localhost\r", "port": "8080"}}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -464,19 +992,65 @@ func TestCrlfNormalizeCommentOnlyParse(t *testing.T) {
 
 // crlf_normalize_comment_only_filter - function:filter feature:comments feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeCommentOnlyFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // crlf_preserve_comment_only_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentOnlyParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "this is a comment\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // crlf_preserve_comment_only_filter - function:filter feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentOnlyFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= this is a comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -504,31 +1078,111 @@ func TestCrlfNormalizeCommentsAndValuesParse(t *testing.T) {
 
 // crlf_normalize_comments_and_values_filter - function:filter feature:comments feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeCommentsAndValuesFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // crlf_normalize_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeCommentsAndValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"Server config", "Port setting"}, "host": "localhost", "port": "8080"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
 // crlf_preserve_comments_and_values_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "Server config\r"}, mock.Entry{Key: "host", Value: "localhost\r"}, mock.Entry{Key: "/", Value: "Port setting\r"}, mock.Entry{Key: "port", Value: "8080\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // crlf_preserve_comments_and_values_filter - function:filter feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // crlf_preserve_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// BuildHierarchy validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	objectResult := ccl.BuildHierarchy(parseResult)
+	expected := map[string]interface{}{"/": []interface{}{"Server config\r", "Port setting\r"}, "host": "localhost\r", "port": "8080\r"}
+	assert.Equal(t, expected, objectResult)
+
 }
 
 
@@ -556,31 +1210,109 @@ func TestCrlfNormalizeMultipleCommentsParse(t *testing.T) {
 
 // crlf_normalize_multiple_comments_filter - function:filter feature:comments feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeMultipleCommentsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // crlf_preserve_multiple_comments_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveMultipleCommentsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "/", Value: "first comment\r"}, mock.Entry{Key: "/", Value: "second comment\r"}, mock.Entry{Key: "/", Value: "third comment\r"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // crlf_preserve_multiple_comments_filter - function:filter feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveMultipleCommentsFilter(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement filter validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_as_whitespace behavior:crlf_normalize_to_lf
 func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := "key = \tvalue\twith\ttabs\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value with tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // behavior_combo_content_tabs_crlf_parse - function:parse feature:whitespace behavior:tabs_as_content behavior:crlf_normalize_to_lf
 func TestBehaviorComboContentTabsCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
+	
+
+	ccl := mock.New()
+	input := "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "\tvalue1"}, mock.Entry{Key: "key2", Value: "\tvalue2"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 

--- a/go_tests/parsing/property_algebraic_test.go
+++ b/go_tests/parsing/property_algebraic_test.go
@@ -16,55 +16,244 @@ import (
 
 // semigroup_associativity_basic_compose_associative - function:compose_associative
 func TestSemigroupAssociativityBasicComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `a = 1`
+	input1 := `b = 2`
+	input2 := `c = 3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // semigroup_associativity_nested_compose_associative - function:compose_associative
 func TestSemigroupAssociativityNestedComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  host = localhost`
+	input1 := `config =
+  port = 8080`
+	input2 := `db =
+  name = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // semigroup_associativity_lists_compose_associative - function:compose_associative feature:empty_keys
 func TestSemigroupAssociativityListsComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1`
+	input1 := `= item2`
+	input2 := `= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_left_identity_basic_identity_left - function:identity_left
 func TestMonoidLeftIdentityBasicIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_right_identity_basic_identity_right - function:identity_right
 func TestMonoidRightIdentityBasicIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `key = value
+nested =
+  sub = val`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_left_identity_nested_identity_left - function:identity_left
 func TestMonoidLeftIdentityNestedIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_right_identity_nested_identity_right - function:identity_right
 func TestMonoidRightIdentityNestedIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_left_identity_lists_identity_left - function:identity_left feature:empty_keys
 func TestMonoidLeftIdentityListsIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `= item1
+= item2
+= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
 // monoid_right_identity_lists_identity_right - function:identity_right feature:empty_keys
 func TestMonoidRightIdentityListsIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1
+= item2
+= item3`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -93,7 +282,23 @@ another = test`
 
 // round_trip_property_basic_print - function:print
 func TestRoundTripPropertyBasicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = value
+another = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -148,7 +353,27 @@ func TestRoundTripPropertyNestedParse(t *testing.T) {
 
 // round_trip_property_nested_print - function:print
 func TestRoundTripPropertyNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -211,7 +436,31 @@ final = end`
 
 // round_trip_property_complex_print - function:print feature:empty_keys
 func TestRoundTripPropertyComplexPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+config =
+  nested =
+    deep = value
+  list =
+    = a
+    = b
+    = c
+final = end`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -40,7 +40,24 @@ nested =
 
 // round_trip_basic_print - function:print
 func TestRoundTripBasicPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -116,13 +133,48 @@ func TestRoundTripWhitespaceNormalizationRoundTrip(t *testing.T) {
 
 // round_trip_whitespace_normalization_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
 func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}, mock.Entry{Key: "nested", Value: "\n    sub  =  val"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
 // round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip - function:parse function:print feature:whitespace behavior:toplevel_indent_preserve
 func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveRoundTrip(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
+	
+
+	ccl := mock.New()
+	input := `  key  =  value  
+  nested  = 
+    sub  =  val  `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -152,7 +204,24 @@ regular = value`
 
 // round_trip_empty_keys_lists_print - function:print feature:empty_keys
 func TestRoundTripEmptyKeysListsPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `= item1
+= item2
+regular = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -208,7 +277,27 @@ func TestRoundTripNestedStructuresParse(t *testing.T) {
 
 // round_trip_nested_structures_print - function:print
 func TestRoundTripNestedStructuresPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `config =
+  host = localhost
+  port = 8080
+  db =
+    name = mydb
+    user = admin`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -265,7 +354,25 @@ func TestRoundTripMultilineValuesParse(t *testing.T) {
 
 // round_trip_multiline_values_print - function:print feature:multiline
 func TestRoundTripMultilineValuesPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `script =
+  #!/bin/bash
+  echo hello
+  exit 0`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -322,7 +429,27 @@ final = value`
 
 // round_trip_mixed_content_print - function:print feature:empty_keys
 func TestRoundTripMixedContentPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `name = Alice
+= first item
+config =
+  port = 3000
+= second item
+final = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -383,7 +510,29 @@ func TestRoundTripComplexNestingParse(t *testing.T) {
 
 // round_trip_complex_nesting_print - function:print feature:empty_keys
 func TestRoundTripComplexNestingPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `app =
+  = item1
+  config =
+    = nested_item
+    db =
+      host = localhost
+      = db_item
+  = item2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -444,7 +593,27 @@ func TestRoundTripDeeplyNestedParse(t *testing.T) {
 
 // round_trip_deeply_nested_print - function:print feature:empty_keys
 func TestRoundTripDeeplyNestedPrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `level1 =
+  level2 =
+    level3 =
+      level4 =
+        deep = value
+        = deep_item`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -500,7 +669,24 @@ other = value`
 
 // round_trip_empty_multiline_print - function:print feature:empty_keys feature:multiline
 func TestRoundTripEmptyMultilinePrint(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	input := `empty_section =
+
+other = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement print validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -75,14 +75,14 @@
           "expect": [
             {
               "key": "key",
-              "value": "value with tabs"
+              "value": "value\twith\ttabs"
             }
           ]
         },
         {
           "function": "build_hierarchy",
           "expect": {
-            "key": "value with tabs"
+            "key": "value\twith\ttabs"
           }
         },
         {
@@ -90,7 +90,7 @@
           "args": [
             "key"
           ],
-          "expect": "value with tabs"
+          "expect": "value\twith\ttabs"
         }
       ],
       "behaviors": [
@@ -289,7 +289,7 @@
       "tests": [
         {
           "function": "round_trip",
-          "expect": "key = value with tabs"
+          "expect": "key = value\twith\ttabs"
         }
       ],
       "behaviors": [


### PR DESCRIPTION
## Summary

Fix test expectations for `tabs_as_whitespace` behavior. This behavior applies to **indentation only**, not to tab characters within value content.

### Changes
- `tabs_as_whitespace_in_value`: expectations now preserve internal tabs (`"value\twith\ttabs"` instead of `"value with tabs"`)
- `tabs_as_whitespace_round_trip`: same fix for round_trip output
- `tabs_canonical_format_as_whitespace`: verified correct (only has leading tab)
- Flat + Go tests regenerated

### Before
Input: `key = \tvalue\twith\ttabs`
Expected: `"value with tabs"` (all tabs converted — **wrong**)

### After
Expected: `"value\twith\ttabs"` (only leading tab stripped — **correct**)

Closes #96