### PR TITLE
fix(release): bump heading levels in commit body descriptions

### DIFF
--- a/templates/CHANGELOG.md.j2
+++ b/templates/CHANGELOG.md.j2
@@ -11,8 +11,10 @@ All notable changes to the CCL test data will be documented in this file.
 {% for commit in commits %}
 - {% if commit.scope %}**{{ commit.scope }}:** {% endif %}{{ commit.descriptions[0] | capitalize }} ([`{{ commit.hexsha[:7] }}`]({{ commit.hexsha | commit_hash_url }}))
 {%- if commit.descriptions | length > 1 %}
+{% set body = "\n" ~ commit.descriptions[1:] | join("\n\n") %}
+{% set body = body | replace("\n#### ", "\n###### ") | replace("\n### ", "\n##### ") | replace("\n## ", "\n#### ") %}
 
-  {{ commit.descriptions[1:] | join("\n\n  ") | indent(2, first=false) }}
+  {{ body | trim | indent(2, first=false) }}
 {%- endif %}
 {% endfor %}
 {% endif %}


### PR DESCRIPTION
## Summary

- Markdown headings in commit body descriptions (e.g. `## Summary`, `### Changes`) rendered at the same level as the changelog's structural `## [version]` and `### Type` headings, breaking document hierarchy
- The Jinja2 template now bumps heading levels by 2 in commit descriptions: `##` → `####`, `###` → `#####`, `####` → `######`
- Replacements are applied from longest to shortest `#` sequences to avoid double-processing