### PR TITLE
fix(tests): update round_trip_empty_multiline to expect true

### DIFF
--- a/generated_tests/property_round_trip.json
+++ b/generated_tests/property_round_trip.json
@@ -662,7 +662,7 @@
       "behaviors": [],
       "expected": {
         "count": 1,
-        "value": false
+        "value": true
       },
       "features": [
         "empty_keys",

--- a/source_tests/core/property_round_trip.json
+++ b/source_tests/core/property_round_trip.json
@@ -285,7 +285,7 @@
       "tests": [
         {
           "function": "round_trip",
-          "expect": false
+          "expect": true
         },
         {
           "function": "parse",


### PR DESCRIPTION
The round_trip_empty_multiline test expected false because the sickle printer previously added a trailing space after = for section keys, causing re-parse to differ. Now that the printer correctly omits the trailing space, parse(print(parse(x))) == parse(x) holds true.