### PR TITLE
docs(schema): clarify features vs behaviors distinction

### DIFF
--- a/docs/test-runner-implementation-guide.md
+++ b/docs/test-runner-implementation-guide.md
@@ -57,9 +57,9 @@ function all_functions_implemented(required, implemented) {
 }
 ```
 
-### Behavior and Feature Filtering
+### Behavior Filtering
 
-Filter tests based on implementation behaviors and supported features:
+Filter tests based on implementation behavior choices. Note that **features are not used for filtering** — they are informational tags for gap reporting (see the [Test Selection Guide](test-selection-guide.md) for details).
 
 ```pseudocode
 function test_is_compatible(test, capabilities) {
@@ -70,14 +70,7 @@ function test_is_compatible(test, capabilities) {
     }
   }
   
-  // Check feature requirements  
-  for feature_name in test.features {
-    if feature_name not in capabilities.features {
-      return false
-    }
-  }
-  
-  // Check behavior compatibility
+  // Check behavior compatibility — skip tests for choices you didn't make
   for behavior_name in test.behaviors {
     if behavior_name not in capabilities.behaviors {
       return false
@@ -158,7 +151,6 @@ ccl-test-runner generate \
 ```pseudocode
 capabilities = {
   functions: ["parse"],
-  features: [],
   behaviors: ["crlf_normalize_to_lf", "boolean_lenient"]
 }
 
@@ -170,7 +162,6 @@ capabilities = {
 ```pseudocode
 capabilities = {
   functions: ["parse", "filter", "compose", "expand_dotted"],
-  features: ["comments"],
   behaviors: ["crlf_normalize_to_lf", "boolean_lenient"]
 }
 ```
@@ -179,7 +170,6 @@ capabilities = {
 ```pseudocode
 capabilities = {
   functions: ["parse", "make_objects"],
-  features: ["dotted_keys", "empty_keys"],
   behaviors: ["crlf_normalize_to_lf", "boolean_lenient"]
 }
 ```
@@ -188,7 +178,6 @@ capabilities = {
 ```pseudocode
 capabilities = {
   functions: ["parse", "make_objects", "get_string", "get_int", "get_bool", "get_float", "get_list"],
-  features: ["dotted_keys", "empty_keys", "comments"],
   behaviors: ["crlf_normalize_to_lf", "boolean_lenient"]
 }
 ```
@@ -306,12 +295,10 @@ ccl-test-runner test --format verbose
   "implementation_name": "my_ccl_parser",
   "capabilities": {
     "functions": ["parse", "make_objects", "get_string", "get_int"],
-    "features": ["dotted_keys", "empty_keys"],
     "behaviors": ["crlf_normalize_to_lf", "boolean_lenient"]
   },
   "test_selection": {
     "skip_behaviors": ["tabs_as_content", "crlf_preserve_literal"],
-    "skip_features": ["unicode", "multiline"],
     "skip_variants": ["proposed_behavior"]
   }
 }
@@ -327,12 +314,10 @@ function create_test_runner_from_config(config_file) {
   // Generate CLI args for test generation
   run_only_tags = []
   run_only_tags.extend("function:" + f for f in capabilities.functions)
-  run_only_tags.extend("feature:" + f for f in capabilities.features) 
   run_only_tags.extend("behavior:" + b for b in capabilities.behaviors)
   
   skip_tags = []
   skip_tags.extend("behavior:" + b for b in config.test_selection.skip_behaviors)
-  skip_tags.extend("feature:" + f for f in config.test_selection.skip_features)
   
   return TestRunner(capabilities, run_only_tags, skip_tags)
 }
@@ -436,11 +421,11 @@ ccl-test-runner generate
 ccl-test-runner test --format json > results.json
 ```
 
-### Feature Development Testing
+### Feature Gap Reporting
 ```bash
-# Test specific features during development
-ccl-test-runner generate --run-only feature:comments
-ccl-test-runner test --features comments
+# After running tests, use feature tags to identify gaps
+ccl-test-runner test --format json > results.json
+# Analyze which feature areas have failing tests
 ```
 
 This simplified approach eliminates the complexity of partial validation execution while providing clear, predictable test behavior that matches the flat format's design.

--- a/docs/test-selection-guide.md
+++ b/docs/test-selection-guide.md
@@ -41,7 +41,9 @@ const functionsSupported = test.functions.every(fn =>
 
 ### Features Array (`test.features[]`)
 
-**Informational tags** describing which language features a test exercises. Features are for reporting, not filtering.
+**Informational tags** describing which language capabilities a test exercises. Features are for **gap reporting, not filtering**.
+
+A feature represents a language capability that all implementations are expected to eventually support. Features may be associated with specific functions or behaviors (e.g., `comments` is relevant to implementations supporting `filter`). Use feature tags to identify where your implementation still needs work.
 
 | Feature | Description | Example |
 |---------|-------------|---------|
@@ -60,7 +62,9 @@ console.log(`Could support unicode by fixing ${unicodeGaps.length} tests`);
 
 ### Behaviors Array (`test.behaviors[]`)
 
-**Implementation choices** describing how a test expects certain operations to behave. Behaviors fall into two categories:
+**Implementation choices** describing how a test expects certain operations to behave. Behaviors are used for **test filtering** — implementations declare their choices and skip tests written for the alternative approach.
+
+Behaviors fall into two categories:
 
 **Parsing behaviors** (affect core parsing):
 | Behavior | Description |
@@ -101,10 +105,16 @@ if (test.conflicts?.variants?.some(v => v === myVariant)) skipTest(test);
 
 **Important:** These variant values are **temporary disambiguation mechanisms**. Once the CCL specification owners clarify these ambiguities, the variant system will be eliminated and these choices will be converted to specific behaviors (e.g., `multiline-flexible` vs `multiline-strict`).
 
-## Behavior vs Variant
+## Features vs Behaviors vs Variants
 
-**Behaviors** are stable implementation choices:
-- Technical decisions (CRLF handling, boolean parsing)
+**Features** describe *what* a test exercises:
+- A language capability all implementations should eventually support
+- Used for gap reporting — *"Which areas does my implementation still need work?"*
+- Not used for test filtering
+
+**Behaviors** describe *how* a test expects something to work:
+- A legitimate implementation choice where multiple valid approaches exist
+- Used for test filtering — *"Which approach does my implementation take?"*
 - Won't change based on spec evolution
 
 **Variants** are temporary spec disambiguation:

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -173,7 +173,7 @@
       },
       "features": {
         "type": "array",
-        "description": "Required language features",
+        "description": "Language features exercised by this test (informational, for gap reporting)",
         "items": {
           "type": "string",
           "oneOf": [

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -301,7 +301,7 @@
           },
           "features": {
             "type": "array",
-            "description": "Required language features for this test",
+            "description": "Language features exercised by this test (informational, for gap reporting)",
             "items": { "$ref": "#/$defs/featureName" },
             "uniqueItems": true
           },


### PR DESCRIPTION
## Summary

Clarifies the distinction between **features** and **behaviors** across documentation and schemas to prevent future misunderstandings.

- **Features** describe *what* a test exercises — informational tags for gap reporting. Features represent capabilities all implementations should eventually support. Not used for test filtering.
- **Behaviors** describe *how* a test expects something to work — used for test filtering via conflicts. Behaviors represent legitimate implementation choices where multiple valid approaches exist.

## Changes

### test-selection-guide.md
- Expanded the features section to explain they're for gap reporting, not filtering
- Added a **"Features vs Behaviors vs Variants"** rubric section with clear definitions

### test-runner-implementation-guide.md
- Renamed "Behavior and Feature Filtering" → "Behavior Filtering"
- Removed feature-based filtering from `test_is_compatible()` pseudocode
- Removed `features` from capabilities in all implementation stage examples
- Removed `skip_features` from config and tag generation code
- Changed "Feature Development Testing" CLI example to "Feature Gap Reporting"

### schemas (source-format.json & generated-format.json)
- Updated features field description from `"Required language features..."` to `"Language features exercised by this test (informational, for gap reporting)"`

## Motivation

The test-selection-guide correctly stated features are for reporting, but the test-runner-implementation-guide showed feature-based filtering in pseudocode and config examples. The schema description also used "Required" language that implied filtering. This inconsistency made it unclear when to use features vs behaviors for new tags (e.g., #119).

Relates to #119
