### PR TITLE
refactor(schema): clean up multiline feature tags

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -73,7 +73,6 @@ const (
 	FeatureComments               CCLFeature = "comments"
 	FeatureExperimentalDottedKeys CCLFeature = "experimental_dotted_keys"
 	FeatureEmptyKeys              CCLFeature = "empty_keys"
-	FeatureMultiline              CCLFeature = "multiline"
 	FeatureMultilineContinuation  CCLFeature = "multiline_continuation"
 	FeatureMultilineKeys          CCLFeature = "multiline_keys"
 	FeatureUnicode                CCLFeature = "unicode"
@@ -86,7 +85,6 @@ func AllFeatures() []CCLFeature {
 		FeatureComments,
 		FeatureExperimentalDottedKeys,
 		FeatureEmptyKeys,
-		FeatureMultiline,
 		FeatureMultilineContinuation,
 		FeatureMultilineKeys,
 		FeatureUnicode,

--- a/config/config.go
+++ b/config/config.go
@@ -75,6 +75,7 @@ const (
 	FeatureEmptyKeys              CCLFeature = "empty_keys"
 	FeatureMultiline              CCLFeature = "multiline"
 	FeatureMultilineContinuation  CCLFeature = "multiline_continuation"
+	FeatureMultilineKeys          CCLFeature = "multiline_keys"
 	FeatureUnicode                CCLFeature = "unicode"
 	FeatureWhitespace             CCLFeature = "whitespace"
 )
@@ -86,6 +87,8 @@ func AllFeatures() []CCLFeature {
 		FeatureExperimentalDottedKeys,
 		FeatureEmptyKeys,
 		FeatureMultiline,
+		FeatureMultilineContinuation,
+		FeatureMultilineKeys,
 		FeatureUnicode,
 		FeatureWhitespace,
 	}
@@ -112,6 +115,7 @@ const (
 	BehaviorArrayOrderInsertion     CCLBehavior = "array_order_insertion"
 	BehaviorArrayOrderLexicographic CCLBehavior = "array_order_lexicographic"
 	BehaviorPathTraversal           CCLBehavior = "path_traversal"
+	BehaviorMultilineValues         CCLBehavior = "multiline_values"
 )
 
 // GetBehaviorConflicts returns mutually exclusive behavior groups

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -17,7 +17,7 @@ func TestImplementationConfig_JSONMarshaling(t *testing.T) {
 		},
 		SupportedFeatures: []CCLFeature{
 			FeatureComments,
-			FeatureMultiline,
+			FeatureMultilineContinuation,
 		},
 		BehaviorChoices: []CCLBehavior{
 			BehaviorCRLFNormalize,
@@ -107,7 +107,8 @@ func TestAllFeatures_Completeness(t *testing.T) {
 		FeatureComments,
 		FeatureExperimentalDottedKeys,
 		FeatureEmptyKeys,
-		FeatureMultiline,
+		FeatureMultilineContinuation,
+		FeatureMultilineKeys,
 		FeatureUnicode,
 		FeatureWhitespace,
 	}
@@ -321,7 +322,7 @@ func TestImplementationConfig_HasFeature_Positive(t *testing.T) {
 	config := ImplementationConfig{
 		SupportedFeatures: []CCLFeature{
 			FeatureComments,
-			FeatureMultiline,
+			FeatureMultilineContinuation,
 		},
 	}
 
@@ -329,7 +330,7 @@ func TestImplementationConfig_HasFeature_Positive(t *testing.T) {
 	if !config.HasFeature(FeatureComments) {
 		t.Error("Should have comments feature")
 	}
-	if !config.HasFeature(FeatureMultiline) {
+	if !config.HasFeature(FeatureMultilineContinuation) {
 		t.Error("Should have multiline feature")
 	}
 }
@@ -366,7 +367,7 @@ func TestImplementationConfig_HasFeature_ExplicitlyUnsupported(t *testing.T) {
 	}
 
 	// Feature not listed anywhere (default false)
-	if config.HasFeature(FeatureMultiline) {
+	if config.HasFeature(FeatureMultilineContinuation) {
 		t.Error("Should not have unlisted multiline feature")
 	}
 }
@@ -515,7 +516,8 @@ func TestCCLFeature_StringValues(t *testing.T) {
 		{FeatureComments, "comments"},
 		{FeatureExperimentalDottedKeys, "experimental_dotted_keys"},
 		{FeatureEmptyKeys, "empty_keys"},
-		{FeatureMultiline, "multiline"},
+		{FeatureMultilineContinuation, "multiline_continuation"},
+		{FeatureMultilineKeys, "multiline_keys"},
 		{FeatureUnicode, "unicode"},
 		{FeatureWhitespace, "whitespace"},
 	}

--- a/docs/test-selection-guide.md
+++ b/docs/test-selection-guide.md
@@ -50,6 +50,8 @@ A feature represents a language capability that all implementations are expected
 | `comments` | `/=` comment syntax | `/= This is a comment` |
 | `empty_keys` | Anonymous list items | `= item1\n= item2` |
 | `multiline` | Multi-line values | `description = Line 1\nLine 2` |
+| `multiline_continuation` | Indented continuation lines | `desc = First\n  second line` |
+| `multiline_keys` | Keys spanning multiple lines | `key\n= val` |
 | `unicode` | Unicode content | `name = José` |
 | `whitespace` | Complex whitespace handling | Preserving tabs, spaces |
 
@@ -75,6 +77,7 @@ Behaviors fall into two categories:
 | `tabs_as_whitespace` | Tabs are whitespace (count for indentation, get trimmed) |
 | `indent_spaces` | Use spaces for printed indentation |
 | `indent_tabs` | Use tabs for printed indentation |
+| `multiline_values` | Multi-line value construction edge cases (empty first line, continuation preservation, blank line lookahead) |
 
 **API-specific behaviors** (affect individual functions like `get_bool`):
 | Behavior | Description |

--- a/docs/test-selection-guide.md
+++ b/docs/test-selection-guide.md
@@ -49,7 +49,6 @@ A feature represents a language capability that all implementations are expected
 |---------|-------------|---------|
 | `comments` | `/=` comment syntax | `/= This is a comment` |
 | `empty_keys` | Anonymous list items | `= item1\n= item2` |
-| `multiline` | Multi-line values | `description = Line 1\nLine 2` |
 | `multiline_continuation` | Indented continuation lines | `desc = First\n  second line` |
 | `multiline_keys` | Keys spanning multiple lines | `key\n= val` |
 | `unicode` | Unicode content | `name = José` |

--- a/generated_tests/api_core_ccl_integration.json
+++ b/generated_tests/api_core_ccl_integration.json
@@ -378,7 +378,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -393,7 +395,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -407,7 +409,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -421,7 +425,7 @@
         }
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "build_hierarchy"
@@ -441,7 +445,7 @@
         "value": "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"

--- a/generated_tests/api_core_ccl_parsing.json
+++ b/generated_tests/api_core_ccl_parsing.json
@@ -121,7 +121,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -136,7 +138,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -156,7 +158,7 @@
         "value": "description = First line\n  Second line\n  Third line\ndone = yes"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -730,7 +730,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -741,7 +743,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -755,7 +757,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -766,7 +770,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"

--- a/generated_tests/api_errors.json
+++ b/generated_tests/api_errors.json
@@ -79,7 +79,7 @@
         "count": 0
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -98,7 +98,7 @@
         "count": 0
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -2,7 +2,9 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "tests": [
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -18,7 +20,7 @@
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -61,7 +63,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -76,7 +80,6 @@
         ]
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [
@@ -92,7 +95,8 @@
     },
     {
       "behaviors": [
-        "array_order_insertion"
+        "array_order_insertion",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -109,7 +113,6 @@
         }
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [
@@ -145,7 +148,6 @@
         ]
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [
@@ -160,7 +162,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 4,
         "entries": [
@@ -183,7 +187,6 @@
         ]
       },
       "features": [
-        "multiline",
         "multiline_continuation",
         "empty_keys"
       ],
@@ -199,7 +202,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "object": {
@@ -211,7 +216,6 @@
         }
       },
       "features": [
-        "multiline",
         "multiline_continuation",
         "empty_keys"
       ],
@@ -1079,7 +1083,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 4,
         "entries": [
@@ -1102,7 +1108,6 @@
         ]
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [
@@ -1118,7 +1123,8 @@
     },
     {
       "behaviors": [
-        "array_order_insertion"
+        "array_order_insertion",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -1137,7 +1143,6 @@
         }
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [
@@ -1174,7 +1179,6 @@
         ]
       },
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "functions": [

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -327,7 +327,8 @@
     },
     {
       "behaviors": [
-        "tabs_as_content"
+        "tabs_as_content",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -345,7 +346,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -360,7 +361,8 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace"
+        "tabs_as_whitespace",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -378,7 +380,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -393,7 +395,8 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace"
+        "tabs_as_whitespace",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -411,7 +414,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -485,7 +488,8 @@
     {
       "behaviors": [
         "tabs_as_whitespace",
-        "indent_spaces"
+        "indent_spaces",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -499,7 +503,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
@@ -784,7 +788,8 @@
     {
       "behaviors": [
         "tabs_as_whitespace",
-        "indent_tabs"
+        "indent_tabs",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -798,7 +803,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
@@ -1007,7 +1012,8 @@
     },
     {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_normalize_to_lf",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -1025,7 +1031,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -1040,7 +1046,8 @@
     },
     {
       "behaviors": [
-        "crlf_preserve_literal"
+        "crlf_preserve_literal",
+        "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
@@ -1058,7 +1065,7 @@
       },
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"

--- a/generated_tests/property_round_trip.json
+++ b/generated_tests/property_round_trip.json
@@ -328,7 +328,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "entries": [
@@ -339,7 +341,7 @@
         ]
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -359,7 +361,7 @@
         "value": "script =\n  #!/bin/bash\n  echo hello\n  exit 0"
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -373,13 +375,15 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "value": true
       },
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
@@ -608,7 +612,9 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 2,
         "entries": [
@@ -624,7 +630,7 @@
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -645,7 +651,7 @@
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "print"
@@ -659,14 +665,16 @@
       "variants": []
     },
     {
-      "behaviors": [],
+      "behaviors": [
+        "multiline_values"
+      ],
       "expected": {
         "count": 1,
         "value": true
       },
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -206,7 +206,7 @@ func TestCompleteListsWorkflowLexicographicPrint(t *testing.T) {
 }
 
 
-// complete_multiline_workflow_parse - function:parse feature:multiline
+// complete_multiline_workflow_parse - function:parse feature:multiline_continuation behavior:multiline_values
 func TestCompleteMultilineWorkflowParse(t *testing.T) {
 	
 
@@ -234,13 +234,13 @@ config =
 }
 
 
-// complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline
+// complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:multiline_values
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// complete_multiline_workflow_print - function:print feature:multiline
+// complete_multiline_workflow_print - function:print feature:multiline_continuation
 func TestCompleteMultilineWorkflowPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -95,7 +95,7 @@ other = normal`
 }
 
 
-// multiline_values_parse - function:parse feature:multiline
+// multiline_values_parse - function:parse feature:multiline_continuation behavior:multiline_values
 func TestMultilineValuesParse(t *testing.T) {
 	
 
@@ -120,7 +120,7 @@ done = yes`
 }
 
 
-// multiline_values_print - function:print feature:multiline
+// multiline_values_print - function:print feature:multiline_continuation
 func TestMultilineValuesPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -548,7 +548,7 @@ func TestNestedSingleLineParse(t *testing.T) {
 }
 
 
-// nested_multi_line_parse - function:parse feature:multiline
+// nested_multi_line_parse - function:parse feature:multiline_continuation behavior:multiline_values
 func TestNestedMultiLineParse(t *testing.T) {
 	
 
@@ -572,7 +572,7 @@ func TestNestedMultiLineParse(t *testing.T) {
 }
 
 
-// nested_with_blank_line_parse_indented - function:parse_indented feature:multiline
+// nested_with_blank_line_parse_indented - function:parse_indented feature:multiline_continuation behavior:multiline_values
 func TestNestedWithBlankLineParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_errors_test.go
+++ b/go_tests/parsing/api_errors_test.go
@@ -102,7 +102,7 @@ func TestJustStringErrorParse(t *testing.T) {
 }
 
 
-// multiline_plain_error_parse - function:parse feature:multiline
+// multiline_plain_error_parse - function:parse feature:multiline_continuation
 func TestMultilinePlainErrorParse(t *testing.T) {
 	
 
@@ -125,7 +125,7 @@ func TestMultilinePlainErrorParse(t *testing.T) {
 }
 
 
-// multiline_plain_nested_error_parse - function:parse feature:multiline
+// multiline_plain_nested_error_parse - function:parse feature:multiline_continuation
 func TestMultilinePlainNestedErrorParse(t *testing.T) {
 	
 

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -14,7 +14,7 @@ import (
 
 
 
-// multiline_section_header_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline
+// multiline_section_header_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline_continuation behavior:multiline_values
 func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -26,31 +26,31 @@ func TestUnindentedMultilineBecomesContinuationParseIndented(t *testing.T) {
 }
 
 
-// indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline feature:multiline_continuation
+// indented_line_is_continuation_parse_indented - function:parse_indented feature:multiline_continuation behavior:multiline_values
 func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline feature:multiline_continuation behavior:array_order_insertion
+// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// indented_line_is_continuation_get_list - function:get_list feature:multiline feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
+// indented_line_is_continuation_get_list - function:get_list feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline feature:multiline_continuation feature:empty_keys
+// mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline_continuation feature:empty_keys behavior:multiline_values
 func TestMixedIndentationLevelsParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline feature:multiline_continuation feature:empty_keys
+// mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline_continuation feature:empty_keys behavior:multiline_values
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -382,19 +382,19 @@ func TestListWithSpecialCharactersGetList(t *testing.T) {
 }
 
 
-// list_multiline_values_parse_indented - function:parse_indented feature:multiline feature:multiline_continuation
+// list_multiline_values_parse_indented - function:parse_indented feature:multiline_continuation behavior:multiline_values
 func TestListMultilineValuesParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline feature:multiline_continuation behavior:array_order_insertion
+// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// list_multiline_values_get_list - function:get_list feature:multiline feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
+// list_multiline_values_get_list - function:get_list feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListMultilineValuesGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -80,19 +80,19 @@ func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
 }
 
 
-// tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_content
+// tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_content behavior:multiline_values
 func TestTabsAsContentMultilineParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
 }
 
 
-// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
+// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:multiline_values
 func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
 }
 
 
-// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline behavior:tabs_as_whitespace
+// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:multiline_values
 func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
 }
@@ -110,7 +110,7 @@ func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_spaces
+// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:indent_spaces behavior:multiline_values
 func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
 }
@@ -251,7 +251,7 @@ key3	=	value3`
 }
 
 
-// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline behavior:tabs_as_whitespace behavior:indent_tabs
+// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:indent_tabs behavior:multiline_values
 func TestTabsAsWhitespaceMultilineCanonicalIndentTabsCanonicalFormat(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
 }
@@ -350,7 +350,7 @@ func TestCrlfPreserveLiteralBasicBuildHierarchy(t *testing.T) {
 }
 
 
-// crlf_normalize_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_normalize_to_lf
+// crlf_normalize_multiline_value_parse - function:parse feature:whitespace feature:multiline_continuation behavior:crlf_normalize_to_lf behavior:multiline_values
 func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
 	
 
@@ -372,7 +372,7 @@ func TestCrlfNormalizeMultilineValueParse(t *testing.T) {
 }
 
 
-// crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline behavior:crlf_preserve_literal
+// crlf_preserve_multiline_value_parse - function:parse feature:whitespace feature:multiline_continuation behavior:crlf_preserve_literal behavior:multiline_values
 func TestCrlfPreserveMultilineValueParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
 }

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -238,7 +238,7 @@ func TestRoundTripNestedStructuresRoundTrip(t *testing.T) {
 }
 
 
-// round_trip_multiline_values_parse - function:parse feature:multiline
+// round_trip_multiline_values_parse - function:parse feature:multiline_continuation behavior:multiline_values
 func TestRoundTripMultilineValuesParse(t *testing.T) {
 	
 
@@ -263,13 +263,13 @@ func TestRoundTripMultilineValuesParse(t *testing.T) {
 }
 
 
-// round_trip_multiline_values_print - function:print feature:multiline
+// round_trip_multiline_values_print - function:print feature:multiline_continuation
 func TestRoundTripMultilineValuesPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// round_trip_multiline_values_round_trip - function:parse function:print feature:multiline
+// round_trip_multiline_values_round_trip - function:parse function:print feature:multiline_continuation behavior:multiline_values
 func TestRoundTripMultilineValuesRoundTrip(t *testing.T) {
 	
 
@@ -474,7 +474,7 @@ func TestRoundTripDeeplyNestedRoundTrip(t *testing.T) {
 }
 
 
-// round_trip_empty_multiline_parse - function:parse feature:empty_keys feature:multiline
+// round_trip_empty_multiline_parse - function:parse feature:empty_keys feature:multiline_continuation behavior:multiline_values
 func TestRoundTripEmptyMultilineParse(t *testing.T) {
 	
 
@@ -498,13 +498,13 @@ other = value`
 }
 
 
-// round_trip_empty_multiline_print - function:print feature:empty_keys feature:multiline
+// round_trip_empty_multiline_print - function:print feature:empty_keys feature:multiline_continuation
 func TestRoundTripEmptyMultilinePrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// round_trip_empty_multiline_round_trip - function:parse function:print feature:empty_keys feature:multiline
+// round_trip_empty_multiline_round_trip - function:parse function:print feature:empty_keys feature:multiline_continuation behavior:multiline_values
 func TestRoundTripEmptyMultilineRoundTrip(t *testing.T) {
 	
 

--- a/internal/config/simple_config.go
+++ b/internal/config/simple_config.go
@@ -195,8 +195,10 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 			supportedFeatures = append(supportedFeatures, config.FeatureExperimentalDottedKeys)
 		case "unicode":
 			supportedFeatures = append(supportedFeatures, config.FeatureUnicode)
-		case "multiline":
-			supportedFeatures = append(supportedFeatures, config.FeatureMultiline)
+		case "multiline_continuation":
+			supportedFeatures = append(supportedFeatures, config.FeatureMultilineContinuation)
+		case "multiline_keys":
+			supportedFeatures = append(supportedFeatures, config.FeatureMultilineKeys)
 		case "whitespace":
 			supportedFeatures = append(supportedFeatures, config.FeatureWhitespace)
 		case "empty_keys":

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -157,7 +157,8 @@
             "array_order_insertion", "array_order_lexicographic",
             "toplevel_indent_strip", "toplevel_indent_preserve",
             "delimiter_first_equals", "delimiter_prefer_spaced",
-            "path_traversal"
+            "path_traversal",
+            "multiline_values"
           ]
         },
         "uniqueItems": true
@@ -180,7 +181,7 @@
             {
               "enum": [
                 "comments", "empty_keys",
-                "multiline", "multiline_continuation", "unicode", "whitespace"
+                "multiline", "multiline_continuation", "multiline_keys", "unicode", "whitespace"
               ]
             },
             {

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -181,7 +181,7 @@
             {
               "enum": [
                 "comments", "empty_keys",
-                "multiline", "multiline_continuation", "multiline_keys", "unicode", "whitespace"
+                "multiline_continuation", "multiline_keys", "unicode", "whitespace"
               ]
             },
             {

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -169,7 +169,7 @@
       "type": "string",
       "oneOf": [
         {
-          "enum": ["comments", "empty_keys", "multiline", "multiline_continuation", "multiline_keys", "unicode", "whitespace"]
+          "enum": ["comments", "empty_keys", "multiline_continuation", "multiline_keys", "unicode", "whitespace"]
         },
         { "pattern": "^experimental_" },
         { "pattern": "^optional_" }

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -152,7 +152,8 @@
         "array_order_insertion", "array_order_lexicographic",
         "toplevel_indent_strip", "toplevel_indent_preserve",
         "delimiter_first_equals", "delimiter_prefer_spaced",
-        "path_traversal"
+        "path_traversal",
+        "multiline_values"
       ]
     },
     "functionName": {
@@ -168,7 +169,7 @@
       "type": "string",
       "oneOf": [
         {
-          "enum": ["comments", "empty_keys", "multiline", "multiline_continuation", "unicode", "whitespace"]
+          "enum": ["comments", "empty_keys", "multiline", "multiline_continuation", "multiline_keys", "unicode", "whitespace"]
         },
         { "pattern": "^experimental_" },
         { "pattern": "^optional_" }
@@ -433,6 +434,11 @@
       "path_traversal": {
         "description": "Support accessing values within nested CCL objects via multi-level key path arguments to typed access functions.",
         "affectedFunctions": ["get_string", "get_int", "get_bool", "get_float", "get_list"],
+        "mutuallyExclusiveWith": []
+      },
+      "multiline_values": {
+        "description": "Multi-line value construction edge cases: empty first line after '=', continuation line preservation, and empty line lookahead within indented blocks.",
+        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy", "canonical_format", "round_trip"],
         "mutuallyExclusiveWith": []
       }
     },

--- a/source_tests/core/api_core_ccl_integration.json
+++ b/source_tests/core/api_core_ccl_integration.json
@@ -232,6 +232,9 @@
           }
         }
       ],
+      "behaviors": [
+        "multiline_values"
+      ],
       "features": [
         "multiline"
       ],

--- a/source_tests/core/api_core_ccl_integration.json
+++ b/source_tests/core/api_core_ccl_integration.json
@@ -236,7 +236,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"

--- a/source_tests/core/api_core_ccl_parsing.json
+++ b/source_tests/core/api_core_ccl_parsing.json
@@ -96,6 +96,9 @@
           "expect": "description = First line\n  Second line\n  Third line\ndone = yes"
         }
       ],
+      "behaviors": [
+        "multiline_values"
+      ],
       "features": [
         "multiline"
       ],

--- a/source_tests/core/api_core_ccl_parsing.json
+++ b/source_tests/core/api_core_ccl_parsing.json
@@ -100,7 +100,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "description = First line\n  Second line\n  Third line\ndone = yes"

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -584,7 +584,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "key =\n  line1\n  line2"
@@ -607,7 +607,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "key =\n  line1\n\n  line2"

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -580,6 +580,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "multiline_values"
+      ],
       "features": [
         "multiline"
       ],
@@ -599,6 +602,9 @@
             }
           ]
         }
+      ],
+      "behaviors": [
+        "multiline_values"
       ],
       "features": [
         "multiline"

--- a/source_tests/core/api_errors.json
+++ b/source_tests/core/api_errors.json
@@ -64,7 +64,7 @@
         }
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "val\n  next"
@@ -79,7 +79,7 @@
         }
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "\nval\n  next"

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -18,6 +18,9 @@
           ]
         }
       ],
+      "behaviors": [
+        "multiline_values"
+      ],
       "features": [
         "empty_keys",
         "multiline"
@@ -88,7 +91,8 @@
       ],
       "behaviors": [
         "list_coercion_enabled",
-        "array_order_insertion"
+        "array_order_insertion",
+        "multiline_values"
       ],
       "features": [
         "multiline",
@@ -132,6 +136,9 @@
             }
           }
         }
+      ],
+      "behaviors": [
+        "multiline_values"
       ],
       "features": [
         "multiline",
@@ -660,7 +667,8 @@
       ],
       "behaviors": [
         "list_coercion_enabled",
-        "array_order_insertion"
+        "array_order_insertion",
+        "multiline_values"
       ],
       "features": [
         "multiline",

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -23,7 +23,7 @@
       ],
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "== Section Header =\n  This continues the header\nkey = value"
@@ -95,7 +95,6 @@
         "multiline_values"
       ],
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "inputs": [
@@ -141,7 +140,6 @@
         "multiline_values"
       ],
       "features": [
-        "multiline",
         "multiline_continuation",
         "empty_keys"
       ],
@@ -671,7 +669,6 @@
         "multiline_values"
       ],
       "features": [
-        "multiline",
         "multiline_continuation"
       ],
       "inputs": [

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -170,7 +170,8 @@
         }
       ],
       "behaviors": [
-        "tabs_as_content"
+        "tabs_as_content",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -194,7 +195,8 @@
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace"
+        "tabs_as_whitespace",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -218,7 +220,8 @@
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace"
+        "tabs_as_whitespace",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -274,7 +277,8 @@
       ],
       "behaviors": [
         "tabs_as_whitespace",
-        "indent_spaces"
+        "indent_spaces",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -455,7 +459,8 @@
       ],
       "behaviors": [
         "tabs_as_whitespace",
-        "indent_tabs"
+        "indent_tabs",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -585,7 +590,8 @@
         }
       ],
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_normalize_to_lf",
+        "multiline_values"
       ],
       "features": [
         "whitespace",
@@ -609,7 +615,8 @@
         }
       ],
       "behaviors": [
-        "crlf_preserve_literal"
+        "crlf_preserve_literal",
+        "multiline_values"
       ],
       "features": [
         "whitespace",

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -175,7 +175,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n \tindented_with_tabs\n \tanother_line"
@@ -200,7 +200,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented_with_tabs\n\t\tanother_line"
@@ -225,7 +225,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n \tmixed_indent\n\t another_line"
@@ -282,7 +282,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -464,7 +464,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -595,7 +595,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "multiline =\r\n  line1\r\n  line2"
@@ -620,7 +620,7 @@
       ],
       "features": [
         "whitespace",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "multiline =\r\n  line1\r\n  line2"

--- a/source_tests/core/property_round_trip.json
+++ b/source_tests/core/property_round_trip.json
@@ -173,6 +173,9 @@
           "expect": true
         }
       ],
+      "behaviors": [
+        "multiline_values"
+      ],
       "features": [
         "multiline"
       ],
@@ -304,6 +307,9 @@
           "function": "print",
           "expect": "empty_section =\nother = value"
         }
+      ],
+      "behaviors": [
+        "multiline_values"
       ],
       "features": [
         "empty_keys",

--- a/source_tests/core/property_round_trip.json
+++ b/source_tests/core/property_round_trip.json
@@ -177,7 +177,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "script =\n  #!/bin/bash\n  echo hello\n  exit 0"
@@ -313,7 +313,7 @@
       ],
       "features": [
         "empty_keys",
-        "multiline"
+        "multiline_continuation"
       ],
       "inputs": [
         "empty_section =\n\nother = value"

--- a/types/structured.go
+++ b/types/structured.go
@@ -129,7 +129,6 @@ const (
 	FeatureComments               Feature = "comments"
 	FeatureEmptyKeys              Feature = "empty_keys"
 	FeatureExperimentalDottedKeys Feature = "experimental_dotted_keys"
-	FeatureMultiline              Feature = "multiline"
 	FeatureUnicode                Feature = "unicode"
 	FeatureWhitespace             Feature = "whitespace"
 )


### PR DESCRIPTION
## Summary

Reworks multi-line tagging: adds `multiline_keys` feature and `multiline_values` behavior, and removes the generic `multiline` feature that was redundant with `multiline_continuation`.

## Feature vs behavior

Per #120:
- **`multiline_keys` (feature)** — keys spanning multiple lines (e.g., `key\n= val`). Capability tag for gap reporting; all implementations should eventually support it.
- **`multiline_continuation` (feature)** — any test requiring indented continuation support (pre-existing).
- **`multiline_values` (behavior)** — narrower filter for tests whose expected output encodes a contested edge-case decision: empty first line after `=`, blank line lookahead, or continuation preservation.

Every `multiline_values` test is also `multiline_continuation`. The behavior tag is narrower — it only applies to tests whose expected output reflects a specific choice that another implementation could defensibly make differently.

## `multiline_continuation` vs `multiline_values` — why both?

The names sound similar, so here's how they differ.

### `multiline_continuation` alone — plain continuation, no contested decision

```
description = First line
  Second line
  Third line
```
Every impl that supports indented continuations agrees: `value = "First line\n  Second line\n  Third line"`. No filtering needed.

### `multiline_continuation` + `multiline_values` — empty first line after `=`

```
key =
  line1
  line2
```
This suite's expected value: `"\n  line1\n  line2"` (leading newline preserved because the line after `=` was empty). An impl that strips the leading empty line (→ `"line1\n  line2"`) is also defensible. The `multiline_values` tag lets that impl filter this test out.

### `multiline_continuation` + `multiline_values` — blank line within continuation

```
key =
  line1

  line2
```
This suite: `"\n  line1\n\n  line2"` (blank line preserved, continuation not terminated). Another impl could terminate at the blank line and treat `line2` separately.

## Why remove `multiline`

The previous `multiline` feature example in the docs was `description = Line 1\nLine 2` — but that isn't a real CCL construct. Without indentation, `Line 2` is either its own entry or a parse error. Every actual multi-line value in the suite already qualified as `multiline_continuation`, so `multiline` was a less-specific alias and got dropped.

## Changes

- **Schema**: add `multiline_keys` to feature enum, add `multiline_values` to behavior enum (with `x-behaviorMetadata`), remove `multiline` from feature enum in both source + generated formats.
- **Config (Go)**: add `FeatureMultilineKeys` and `BehaviorMultilineValues` constants; remove `FeatureMultiline`; include `FeatureMultilineContinuation` in `AllFeatures()`.
- **Tests**: tag 18 existing tests with `multiline_values` behavior; retag tests from `multiline` to `multiline_continuation` across 7 source files (dropping the tag on tests that already had both).
- **Docs**: update test-selection-guide feature/behavior tables.

Closes #119
