### PR TITLE
fix(tests): correct metadata for algebraic and edge case tests

### DIFF
--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -568,7 +568,7 @@
         ]
       },
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "functions": [
@@ -594,7 +594,7 @@
         ]
       },
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "functions": [

--- a/generated_tests/property_algebraic.json
+++ b/generated_tests/property_algebraic.json
@@ -9,7 +9,8 @@
       },
       "features": [],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "a = 1",
@@ -29,7 +30,8 @@
       },
       "features": [],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "config =\n  host = localhost",
@@ -51,7 +53,8 @@
         "empty_keys"
       ],
       "functions": [
-        "compose_associative"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "= item1",
@@ -71,7 +74,8 @@
       },
       "features": [],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -90,7 +94,8 @@
       },
       "features": [],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "key = value\nnested =\n  sub = val",
@@ -109,7 +114,8 @@
       },
       "features": [],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -128,7 +134,8 @@
       },
       "features": [],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "config =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    redis = true",
@@ -149,7 +156,8 @@
         "empty_keys"
       ],
       "functions": [
-        "identity_left"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "",
@@ -170,7 +178,8 @@
         "empty_keys"
       ],
       "functions": [
-        "identity_right"
+        "parse",
+        "compose"
       ],
       "inputs": [
         "= item1\n= item2\n= item3",

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -278,9 +278,12 @@ func (fg *FlatGenerator) TransformSourceToFlat(sourceTest types.TestCase) ([]typ
 // compositeFunctionMap defines validations that require multiple underlying functions.
 // For example, round_trip validation requires both parse and print functions.
 var compositeFunctionMap = map[string][]string{
-	"round_trip":       {"parse", "print"},
-	"load":             {"parse", "build_hierarchy"},
-	"canonical_format": {"parse", "print", "canonical_format"},
+	"round_trip":          {"parse", "print"},
+	"load":               {"parse", "build_hierarchy"},
+	"canonical_format":   {"parse", "print", "canonical_format"},
+	"compose_associative": {"parse", "compose"},
+	"identity_left":       {"parse", "compose"},
+	"identity_right":      {"parse", "compose"},
 }
 
 // GenerateMetadataFromValidation creates type-safe metadata from validation type

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -385,7 +385,7 @@ func TestMultipleEmptyEqualityParse(t *testing.T) {
 }
 
 
-// key_with_newline_before_equals_parse - function:parse feature:empty_keys feature:whitespace
+// key_with_newline_before_equals_parse - function:parse feature:multiline feature:whitespace
 func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 	
 
@@ -409,7 +409,7 @@ func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 }
 
 
-// complex_multi_newline_whitespace_parse - function:parse feature:empty_keys feature:whitespace
+// complex_multi_newline_whitespace_parse - function:parse feature:multiline feature:whitespace
 func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
 	
 

--- a/go_tests/parsing/property_algebraic_test.go
+++ b/go_tests/parsing/property_algebraic_test.go
@@ -14,57 +14,246 @@ import (
 
 
 
-// semigroup_associativity_basic_compose_associative - function:compose_associative
+// semigroup_associativity_basic_compose_associative - function:parse function:compose
 func TestSemigroupAssociativityBasicComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `a = 1`
+	input1 := `b = 2`
+	input2 := `c = 3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// semigroup_associativity_nested_compose_associative - function:compose_associative
+// semigroup_associativity_nested_compose_associative - function:parse function:compose
 func TestSemigroupAssociativityNestedComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  host = localhost`
+	input1 := `config =
+  port = 8080`
+	input2 := `db =
+  name = test`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// semigroup_associativity_lists_compose_associative - function:compose_associative feature:empty_keys
+// semigroup_associativity_lists_compose_associative - function:parse function:compose feature:empty_keys
 func TestSemigroupAssociativityListsComposeAssociative(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1`
+	input1 := `= item2`
+	input2 := `= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement compose_associative validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = input2 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_left_identity_basic_identity_left - function:identity_left
+// monoid_left_identity_basic_identity_left - function:parse function:compose
 func TestMonoidLeftIdentityBasicIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `key = value
+nested =
+  sub = val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_right_identity_basic_identity_right - function:identity_right
+// monoid_right_identity_basic_identity_right - function:parse function:compose
 func TestMonoidRightIdentityBasicIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `key = value
+nested =
+  sub = val`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_left_identity_nested_identity_left - function:identity_left
+// monoid_left_identity_nested_identity_left - function:parse function:compose
 func TestMonoidLeftIdentityNestedIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_right_identity_nested_identity_right - function:identity_right
+// monoid_right_identity_nested_identity_right - function:parse function:compose
 func TestMonoidRightIdentityNestedIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `config =
+  database =
+    host = localhost
+    port = 5432
+  cache =
+    redis = true`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_left_identity_lists_identity_left - function:identity_left feature:empty_keys
+// monoid_left_identity_lists_identity_left - function:parse function:compose feature:empty_keys
 func TestMonoidLeftIdentityListsIdentityLeft(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := ""
+	input1 := `= item1
+= item2
+= item3`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_left validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// monoid_right_identity_lists_identity_right - function:identity_right feature:empty_keys
+// monoid_right_identity_lists_identity_right - function:parse function:compose feature:empty_keys
 func TestMonoidRightIdentityListsIdentityRight(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
+	
+
+	ccl := mock.New()
+	
+	input0 := `= item1
+= item2
+= item3`
+	input1 := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement identity_right validation
+	_ = ccl // Prevent unused variable warning
+	_ = input0 // Prevent unused variable warning
+	_ = input1 // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -446,7 +446,7 @@
         }
       ],
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "inputs": [
@@ -467,7 +467,7 @@
         }
       ],
       "features": [
-        "empty_keys",
+        "multiline_keys",
         "whitespace"
       ],
       "inputs": [


### PR DESCRIPTION
## Summary

Fixes two test data correctness issues.

* **fix(generator)**: add `compose_associative`, `identity_left`, and `identity_right` to `compositeFunctionMap`. These validations require `parse` and `compose`, but their generated `functions` arrays incorrectly listed the composite validation names, causing implementations declaring `compose` support to filter out these tests. Matches the pattern established for `round_trip` in #61.

  Closes #115.

* **fix(tests)**: replace `empty_keys` with `multiline` on `key_with_newline_before_equals` and `complex_multi_newline_whitespace`. Both tests exercise multi-line key accumulation (key spans newlines before `=`) and produce non-empty keys, so the `empty_keys` tag was misleading.

  Closes #116.