### PR TITLE
docs(tests): clarify build_hierarchy dependency on parse_indented

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,10 +55,13 @@ function shouldRun(test, myCapabilities) {
 | Function                                                     | Description                      |
 | ------------------------------------------------------------ | -------------------------------- |
 | `parse`                                                      | Basic key-value parsing          |
+| `parse_indented`                                             | Indentation-normalized parsing   |
 | `build_hierarchy`                                            | Object construction from entries |
 | `get_string`, `get_int`, `get_bool`, `get_float`, `get_list` | Typed value access               |
 | `filter`, `compose`                                          | Entry processing                 |
 | `canonical_format`, `round_trip`                             | Formatting and validation        |
+
+> **Note:** `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
 
 ### Behaviors
 

--- a/README.md
+++ b/README.md
@@ -61,7 +61,8 @@ function shouldRun(test, myCapabilities) {
 | `filter`, `compose`                                          | Entry processing                 |
 | `canonical_format`, `round_trip`                             | Formatting and validation        |
 
-> **Note:** `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
+> \[!NOTE]
+> `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
 
 ### Behaviors
 

--- a/docs/test-selection-guide.md
+++ b/docs/test-selection-guide.md
@@ -31,7 +31,8 @@ Direct array containing CCL functions required for a test to run:
 | `get_list` | List value access | `GetList(obj, "items")` |
 | `pretty_print` | Formatting output | `PrettyPrint(obj)` |
 
-> **Note:** `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
+> [!NOTE]
+> `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
 
 **Type-safe filtering:**
 ```javascript

--- a/docs/test-selection-guide.md
+++ b/docs/test-selection-guide.md
@@ -31,6 +31,8 @@ Direct array containing CCL functions required for a test to run:
 | `get_list` | List value access | `GetList(obj, "items")` |
 | `pretty_print` | Formatting output | `PrettyPrint(obj)` |
 
+> **Note:** `build_hierarchy` internally requires `parse_indented` to produce its input entries — it cannot work with `parse` alone. `parse_indented` handles indentation-based nesting and lines without `=` delimiters that `parse` rejects. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if `parse_indented` is not exposed as a public API.
+
 **Type-safe filtering:**
 ```javascript
 // Check if implementation supports all required functions


### PR DESCRIPTION
## Summary

Adds notes to the functions table in `README.md` and `docs/test-selection-guide.md` explaining that `build_hierarchy` requires `parse_indented` internally. `parse` rejects lines without `=` delimiters, while `parse_indented` handles indentation-based nesting. Implementations that support `build_hierarchy` implicitly support `parse_indented`, even if it is not exposed as a public API.

Ref #114.