### PR TITLE
feat(tests): add multiline key test coverage

### DIFF
--- a/cmd/ccl-test-runner/main.go
+++ b/cmd/ccl-test-runner/main.go
@@ -359,6 +359,12 @@ func testAction(ctx *cli.Context) error {
 		defaultSkipTests := []string{
 			"TestKeyWithNewlineBeforeEqualsParse",
 			"TestComplexMultiNewlineWhitespaceParse",
+			"TestMultilineKeyWithSpacesParse",
+			"TestMultilineKeyThreeLinesParse",
+			"TestMultilineKeyEmptyValueParse",
+			"TestMultilineKeyWithRegularEntryParse",
+			"TestMultilineKeyBlankLinesBetweenParse",
+			"TestMultilineKeyTabsInContinuationParse",
 			"TestRoundTripWhitespaceNormalizationParse",
 		}
 		skipTests = append(skipTests, defaultSkipTests...)

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -614,6 +614,164 @@
         "count": 1,
         "entries": [
           {
+            "key": "my key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "my\n key\n= val"
+      ],
+      "name": "multiline_key_with_spaces_parse",
+      "source_test": "multiline_key_with_spaces",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "a b c",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "a\n b\n c\n= val"
+      ],
+      "name": "multiline_key_three_lines_parse",
+      "source_test": "multiline_key_three_lines",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": ""
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "empty_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n="
+      ],
+      "name": "multiline_key_empty_value_parse",
+      "source_test": "multiline_key_empty_value",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "first",
+            "value": "val1"
+          },
+          {
+            "key": "key",
+            "value": "val2"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "first = val1\nkey\n= val2"
+      ],
+      "name": "multiline_key_with_regular_entry_parse",
+      "source_test": "multiline_key_with_regular_entry",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n\n= val"
+      ],
+      "name": "multiline_key_blank_lines_between_parse",
+      "source_test": "multiline_key_blank_lines_between",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "val"
+          }
+        ]
+      },
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n\t= val"
+      ],
+      "name": "multiline_key_tabs_in_continuation_parse",
+      "source_test": "multiline_key_tabs_in_continuation",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
             "key": "key",
             "value": ""
           }

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -1692,3 +1692,140 @@ func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
 }
 
 
+
+// multiline_key_with_spaces_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyWithSpacesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `my
+ key
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "my key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// multiline_key_three_lines_parse - function:parse feature:multiline_keys
+func TestMultilineKeyThreeLinesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `a
+ b
+ c
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "a b c", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// multiline_key_empty_value_parse - function:parse feature:multiline_keys feature:empty_keys
+func TestMultilineKeyEmptyValueParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+=`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: ""}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// multiline_key_with_regular_entry_parse - function:parse feature:multiline_keys
+func TestMultilineKeyWithRegularEntryParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `first = val1
+key
+= val2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "first", Value: "val1"}, mock.Entry{Key: "key", Value: "val2"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// multiline_key_blank_lines_between_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyBlankLinesBetweenParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+// multiline_key_tabs_in_continuation_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyTabsInContinuationParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+	= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -475,6 +475,134 @@
       ]
     },
     {
+      "name": "multiline_key_with_spaces",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "my key",
+              "value": "val"
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "inputs": [
+        "my\n key\n= val"
+      ]
+    },
+    {
+      "name": "multiline_key_three_lines",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "a b c",
+              "value": "val"
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys"
+      ],
+      "inputs": [
+        "a\n b\n c\n= val"
+      ]
+    },
+    {
+      "name": "multiline_key_empty_value",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": ""
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys",
+        "empty_keys"
+      ],
+      "inputs": [
+        "key\n="
+      ]
+    },
+    {
+      "name": "multiline_key_with_regular_entry",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "first",
+              "value": "val1"
+            },
+            {
+              "key": "key",
+              "value": "val2"
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys"
+      ],
+      "inputs": [
+        "first = val1\nkey\n= val2"
+      ]
+    },
+    {
+      "name": "multiline_key_blank_lines_between",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "val"
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "inputs": [
+        "key\n\n= val"
+      ]
+    },
+    {
+      "name": "multiline_key_tabs_in_continuation",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "val"
+            }
+          ]
+        }
+      ],
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "inputs": [
+        "key\n\t= val"
+      ]
+    },
+    {
       "name": "empty_value_with_trailing_spaces_newline",
       "tests": [
         {


### PR DESCRIPTION
## Summary

Adds 6 new tests exercising multi-line key accumulation edge cases, tagged with the `multiline_keys` feature added in #121:

- `multiline_key_with_spaces` — multi-word key across lines
- `multiline_key_three_lines` — key continues across three lines
- `multiline_key_empty_value` — multi-line key with no value
- `multiline_key_with_regular_entry` — multi-line key adjacent to a normal entry
- `multiline_key_blank_lines_between` — blank line between key lines
- `multiline_key_tabs_in_continuation` — tab-indented continuation

Also adds these tests to the `--basic-only` skip list so implementations that don't yet support multi-line keys keep passing CI.

This is the rework of the feat portion of #118. The schema/config plumbing originally in #118 is no longer needed — #121 covered it, and #121 moved `multiline_values` from feature to behavior, so only the new test cases remain.

Closes #119.