### PR TITLE
fix(tests): align behavior_combo_tabs_and_crlf with tabs_as_whitespace semantics

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -1782,7 +1782,7 @@
         "entries": [
           {
             "key": "key",
-            "value": "value with tabs"
+            "value": "value\twith\ttabs"
           }
         ]
       },

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -385,7 +385,7 @@ func TestMultipleEmptyEqualityParse(t *testing.T) {
 }
 
 
-// key_with_newline_before_equals_parse - function:parse feature:multiline feature:whitespace
+// key_with_newline_before_equals_parse - function:parse feature:multiline_keys feature:whitespace
 func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 	
 
@@ -409,7 +409,7 @@ func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 }
 
 
-// complex_multi_newline_whitespace_parse - function:parse feature:multiline feature:whitespace
+// complex_multi_newline_whitespace_parse - function:parse feature:multiline_keys feature:whitespace
 func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
 	
 
@@ -418,6 +418,149 @@ func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
  key  
 =  val  
 `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_with_spaces_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyWithSpacesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `my
+ key
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "my key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_three_lines_parse - function:parse feature:multiline_keys
+func TestMultilineKeyThreeLinesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `a
+ b
+ c
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "a b c", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_empty_value_parse - function:parse feature:multiline_keys feature:empty_keys
+func TestMultilineKeyEmptyValueParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+=`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: ""}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_with_regular_entry_parse - function:parse feature:multiline_keys
+func TestMultilineKeyWithRegularEntryParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `first = val1
+key
+= val2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "first", Value: "val1"}, mock.Entry{Key: "key", Value: "val2"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_blank_lines_between_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyBlankLinesBetweenParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_tabs_in_continuation_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyTabsInContinuationParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+	= val`
 	
 	// Declare variables for reuse across validations
 	
@@ -1692,140 +1835,3 @@ func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
 }
 
 
-
-// multiline_key_with_spaces_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyWithSpacesParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `my
- key
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "my key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_three_lines_parse - function:parse feature:multiline_keys
-func TestMultilineKeyThreeLinesParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `a
- b
- c
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "a b c", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_empty_value_parse - function:parse feature:multiline_keys feature:empty_keys
-func TestMultilineKeyEmptyValueParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-=`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: ""}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_with_regular_entry_parse - function:parse feature:multiline_keys
-func TestMultilineKeyWithRegularEntryParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `first = val1
-key
-= val2`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "first", Value: "val1"}, mock.Entry{Key: "key", Value: "val2"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_blank_lines_between_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyBlankLinesBetweenParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_tabs_in_continuation_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyTabsInContinuationParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-	= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -983,7 +983,7 @@
           "expect": [
             {
               "key": "key",
-              "value": "value with tabs"
+              "value": "value\twith\ttabs"
             }
           ]
         }


### PR DESCRIPTION
## Summary

Fixes the unambiguous part of #122.

`behavior_combo_tabs_and_crlf` declared `behaviors: [tabs_as_whitespace, crlf_normalize_to_lf]` but expected internal value tabs to collapse to spaces (`"value with tabs"`). Its sibling `tabs_as_whitespace_in_value` — same input modulo a trailing `\r\n`, same `tabs_as_whitespace` flag — expects `"value\twith\ttabs"` (internal tabs preserved). Both cannot be right under a single interpretation of the flag.

This PR corrects `behavior_combo_tabs_and_crlf` to match its sibling.

## What this PR does NOT do

Issue #122 also identifies four additional tests whose expectations are debatable (multiline indentation stripping vs. tab→space normalization vs. verbatim). Those require a spec decision on what `tabs_as_whitespace` means for multiline continuation lines and canonical formatting — tracked separately in #122 for follow-up.

## Extra changes

The regenerate picked up small pre-existing drift in `go_tests/parsing/api_edge_cases_test.go` from #126 (tag rename `feature:multiline` → `feature:multiline_keys` and one missing test entry). Included as true-up.

## Test plan

- [x] `just reset` passes (450 active tests, all green)
- [x] `TestBehaviorComboTabsAndCrlfParse` passes against the mock
- [x] `just validate` passes (schema-clean)

Refs #122