### PR TITLE
refactor(schema)!: reshape tab/indent taxonomy to canonical semantics

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -78,7 +78,6 @@ const (
 	FeatureUnicode                CCLFeature = "unicode"
 	FeatureWhitespace             CCLFeature = "whitespace"
 	FeatureTabInValuePreserved    CCLFeature = "tab_in_value_preserved"
-	FeatureContinuationTabToSpace CCLFeature = "continuation_tab_to_space"
 	FeatureToplevelIndentStrip    CCLFeature = "toplevel_indent_strip"
 )
 
@@ -93,7 +92,6 @@ func AllFeatures() []CCLFeature {
 		FeatureUnicode,
 		FeatureWhitespace,
 		FeatureTabInValuePreserved,
-		FeatureContinuationTabToSpace,
 		FeatureToplevelIndentStrip,
 	}
 }
@@ -106,6 +104,8 @@ const (
 	BehaviorCRLFPreserve            CCLBehavior = "crlf_preserve_literal"
 	BehaviorIndentSpaces            CCLBehavior = "indent_spaces"
 	BehaviorIndentTabs              CCLBehavior = "indent_tabs"
+	BehaviorContinuationTabToSpace  CCLBehavior = "continuation_tab_to_space"
+	BehaviorContinuationTabPreserve CCLBehavior = "continuation_tab_preserve"
 	BehaviorBooleanStrict           CCLBehavior = "boolean_strict"
 	BehaviorBooleanLenient          CCLBehavior = "boolean_lenient"
 	BehaviorListCoercionOn          CCLBehavior = "list_coercion_enabled"
@@ -121,12 +121,13 @@ const (
 // GetBehaviorConflicts returns mutually exclusive behavior groups
 func GetBehaviorConflicts() map[string][]CCLBehavior {
 	return map[string][]CCLBehavior{
-		"crlf_handling":  {BehaviorCRLFNormalize, BehaviorCRLFPreserve},
-		"indent_output":  {BehaviorIndentSpaces, BehaviorIndentTabs},
-		"boolean":        {BehaviorBooleanStrict, BehaviorBooleanLenient},
-		"list_coercion":  {BehaviorListCoercionOn, BehaviorListCoercionOff},
-		"delimiter":      {BehaviorDelimiterFirstEquals, BehaviorDelimiterPreferSpaced},
-		"array_ordering": {BehaviorArrayOrderInsertion, BehaviorArrayOrderLexicographic},
+		"crlf_handling":             {BehaviorCRLFNormalize, BehaviorCRLFPreserve},
+		"indent_output":             {BehaviorIndentSpaces, BehaviorIndentTabs},
+		"continuation_tab_handling": {BehaviorContinuationTabToSpace, BehaviorContinuationTabPreserve},
+		"boolean":                   {BehaviorBooleanStrict, BehaviorBooleanLenient},
+		"list_coercion":             {BehaviorListCoercionOn, BehaviorListCoercionOff},
+		"delimiter":                 {BehaviorDelimiterFirstEquals, BehaviorDelimiterPreferSpaced},
+		"array_ordering":            {BehaviorArrayOrderInsertion, BehaviorArrayOrderLexicographic},
 	}
 }
 

--- a/config/config.go
+++ b/config/config.go
@@ -77,6 +77,9 @@ const (
 	FeatureMultilineKeys          CCLFeature = "multiline_keys"
 	FeatureUnicode                CCLFeature = "unicode"
 	FeatureWhitespace             CCLFeature = "whitespace"
+	FeatureTabInValuePreserved    CCLFeature = "tab_in_value_preserved"
+	FeatureContinuationTabToSpace CCLFeature = "continuation_tab_to_space"
+	FeatureToplevelIndentStrip    CCLFeature = "toplevel_indent_strip"
 )
 
 // AllFeatures returns all valid CCL features
@@ -89,6 +92,9 @@ func AllFeatures() []CCLFeature {
 		FeatureMultilineKeys,
 		FeatureUnicode,
 		FeatureWhitespace,
+		FeatureTabInValuePreserved,
+		FeatureContinuationTabToSpace,
+		FeatureToplevelIndentStrip,
 	}
 }
 
@@ -98,16 +104,12 @@ type CCLBehavior string
 const (
 	BehaviorCRLFNormalize           CCLBehavior = "crlf_normalize_to_lf"
 	BehaviorCRLFPreserve            CCLBehavior = "crlf_preserve_literal"
-	BehaviorTabsAsContent           CCLBehavior = "tabs_as_content"
-	BehaviorTabsAsWhitespace        CCLBehavior = "tabs_as_whitespace"
 	BehaviorIndentSpaces            CCLBehavior = "indent_spaces"
 	BehaviorIndentTabs              CCLBehavior = "indent_tabs"
 	BehaviorBooleanStrict           CCLBehavior = "boolean_strict"
 	BehaviorBooleanLenient          CCLBehavior = "boolean_lenient"
 	BehaviorListCoercionOn          CCLBehavior = "list_coercion_enabled"
 	BehaviorListCoercionOff         CCLBehavior = "list_coercion_disabled"
-	BehaviorToplevelIndentStrip     CCLBehavior = "toplevel_indent_strip"
-	BehaviorToplevelIndentPreserve  CCLBehavior = "toplevel_indent_preserve"
 	BehaviorDelimiterFirstEquals    CCLBehavior = "delimiter_first_equals"
 	BehaviorDelimiterPreferSpaced   CCLBehavior = "delimiter_prefer_spaced"
 	BehaviorArrayOrderInsertion     CCLBehavior = "array_order_insertion"
@@ -119,14 +121,12 @@ const (
 // GetBehaviorConflicts returns mutually exclusive behavior groups
 func GetBehaviorConflicts() map[string][]CCLBehavior {
 	return map[string][]CCLBehavior{
-		"crlf_handling":   {BehaviorCRLFNormalize, BehaviorCRLFPreserve},
-		"tab_handling":    {BehaviorTabsAsContent, BehaviorTabsAsWhitespace},
-		"indent_output":   {BehaviorIndentSpaces, BehaviorIndentTabs},
-		"boolean":         {BehaviorBooleanStrict, BehaviorBooleanLenient},
-		"list_coercion":   {BehaviorListCoercionOn, BehaviorListCoercionOff},
-		"toplevel_indent": {BehaviorToplevelIndentStrip, BehaviorToplevelIndentPreserve},
-		"delimiter":       {BehaviorDelimiterFirstEquals, BehaviorDelimiterPreferSpaced},
-		"array_ordering":  {BehaviorArrayOrderInsertion, BehaviorArrayOrderLexicographic},
+		"crlf_handling":  {BehaviorCRLFNormalize, BehaviorCRLFPreserve},
+		"indent_output":  {BehaviorIndentSpaces, BehaviorIndentTabs},
+		"boolean":        {BehaviorBooleanStrict, BehaviorBooleanLenient},
+		"list_coercion":  {BehaviorListCoercionOn, BehaviorListCoercionOff},
+		"delimiter":      {BehaviorDelimiterFirstEquals, BehaviorDelimiterPreferSpaced},
+		"array_ordering": {BehaviorArrayOrderInsertion, BehaviorArrayOrderLexicographic},
 	}
 }
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -111,6 +111,9 @@ func TestAllFeatures_Completeness(t *testing.T) {
 		FeatureMultilineKeys,
 		FeatureUnicode,
 		FeatureWhitespace,
+		FeatureTabInValuePreserved,
+		FeatureContinuationTabToSpace,
+		FeatureToplevelIndentStrip,
 	}
 
 	if len(features) != len(expectedFeatures) {
@@ -164,7 +167,6 @@ func TestGetBehaviorConflicts_Structure(t *testing.T) {
 	// Verify expected conflict groups exist
 	expectedGroups := []string{
 		"crlf_handling",
-		"tab_handling",
 		"indent_output",
 		"boolean",
 		"list_coercion",
@@ -206,7 +208,7 @@ func TestImplementationConfig_IsValid_ValidConfig(t *testing.T) {
 		BehaviorChoices: []CCLBehavior{
 			BehaviorCRLFNormalize,
 			BehaviorBooleanLenient,
-			BehaviorTabsAsContent,
+			BehaviorIndentSpaces,
 		},
 		VariantChoice: VariantReference,
 	}
@@ -537,8 +539,6 @@ func TestCCLBehavior_StringValues(t *testing.T) {
 	}{
 		{BehaviorCRLFNormalize, "crlf_normalize_to_lf"},
 		{BehaviorCRLFPreserve, "crlf_preserve_literal"},
-		{BehaviorTabsAsContent, "tabs_as_content"},
-		{BehaviorTabsAsWhitespace, "tabs_as_whitespace"},
 		{BehaviorIndentSpaces, "indent_spaces"},
 		{BehaviorIndentTabs, "indent_tabs"},
 		{BehaviorBooleanStrict, "boolean_strict"},

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -112,7 +112,6 @@ func TestAllFeatures_Completeness(t *testing.T) {
 		FeatureUnicode,
 		FeatureWhitespace,
 		FeatureTabInValuePreserved,
-		FeatureContinuationTabToSpace,
 		FeatureToplevelIndentStrip,
 	}
 

--- a/docs/implementing-ccl.md
+++ b/docs/implementing-ccl.md
@@ -27,25 +27,7 @@ Implementation guide for CCL parsers using the comprehensive test suite.
 
 ### parse vs parse_indented
 
-The distinction between these functions depends on which baseline behavior you implement:
-
-#### With `toplevel_indent_preserve` (simpler)
-
-| Function | Use Case | Baseline N |
-|----------|----------|------------|
-| `parse` | All contexts | N = indentation of first content line |
-
-No distinction needed—one algorithm works everywhere:
-
-```pseudocode
-function parse(text):
-    baseline = find_first_line_indent(text)
-    return parse_with_baseline(text, baseline)
-```
-
-This is simpler to implement but differs from the OCaml reference behavior.
-
-#### With `toplevel_indent_strip` (OCaml reference)
+Per the OCaml reference, these two functions use different baselines:
 
 | Function | Use Case | Baseline N |
 |----------|----------|------------|
@@ -102,15 +84,15 @@ Result: [{key: "host", value: "localhost"}, {key: "port", value: "8080"}]
 
 #### Why This Matters
 
-**With `toplevel_indent_preserve`:** No context detection needed. The same algorithm (use first line's indent as N) works for both top-level and nested parsing.
-
-**With `toplevel_indent_strip`:** Context detection is critical. If you always use N=0:
+Context detection is critical. If you always use N=0:
 - Top-level parsing works correctly
 - But nested values like `"\n  host = localhost\n  port = 8080"` would parse as ONE entry (since both lines have indent > 0)
 
 The OCaml reference implementation handles this with two functions:
 - `kvs_p` - top-level, uses `key_val 0`
 - `nested_kvs_p` - determines prefix from first content line, uses `key_val prefix_len`
+
+Leading whitespace on top-level keys is stripped (`String.trim`) before parsing. In the test suite, tests that exercise this carry the `toplevel_indent_strip` feature annotation.
 
 ### Typed Access (17 tests)
 **Functions**: `get_string()`, `get_int()`, `get_bool()`, `get_float()`, `get_list()`
@@ -218,27 +200,24 @@ for test in test_data {
 
 ## Continuation Behavior
 
-How continuation is determined depends on the baseline behavior:
+Per the OCaml reference:
 
-### With `toplevel_indent_preserve`
+- **Top-level parsing (`parse`)** uses **N = 0**: lines with 0 leading whitespace are new entries, any indented line is a continuation.
+- **Nested-value parsing (`parse_indented`)** uses **N = indentation of first content line**: lines with exactly N leading whitespace are new entries in that scope, lines with more are continuations.
+- **Top-level keys** have leading whitespace stripped (`String.trim`) before baseline determination.
 
-Uses the **first key's indentation** as N:
+## Tab and Indent Handling
 
-- Lines with **same indent as first key** → new entry
-- Lines with **greater indent** → continuation of previous value
+The OCaml reference implementation encodes the canonical rules. The test suite carries `features` annotations indicating which rule a test exercises:
 
-This means indenting your whole document doesn't change parsing semantics.
+| Feature | Meaning |
+|---|---|
+| `tab_in_value_preserved` | Tabs that appear inside a value (between non-whitespace content) are preserved verbatim. Boundary tabs immediately after `=` are always trimmed as whitespace (this is untagged — it is the universal default). |
+| `continuation_tab_to_space` | On multiline continuation lines, each leading `\t` normalizes 1:1 to a single space during `parse`. Example: `"section =\n\t\tfoo"` → value `"\n  foo"`. |
+| `canonical_indent_two_spaces` | `canonical_format` emits exactly two spaces per nesting level; tabs are never emitted as indentation. |
+| `toplevel_indent_strip` | Leading whitespace on top-level keys is stripped (per OCaml: `String.trim`). |
 
-### With `toplevel_indent_strip` (OCaml reference)
-
-Uses **N = 0** as the baseline for top-level parsing:
-
-- Lines with **0 spaces** → new entry
-- Lines with **> 0 spaces** → continuation of previous value
-
-This means any indented line after the first key becomes a continuation, regardless of how much the first key was indented in the original input.
-
-See the test suite's `behaviors` field for declaring which behavior your implementation uses.
+These are feature annotations, not divergence switches — every conformant implementation follows all four rules. The annotations exist so test runners can filter by what a given test exercises and report feature-coverage gaps.
 
 ## API Guidelines
 

--- a/docs/implementing-ccl.md
+++ b/docs/implementing-ccl.md
@@ -208,16 +208,23 @@ Per the OCaml reference:
 
 ## Tab and Indent Handling
 
-The OCaml reference implementation encodes the canonical rules. The test suite carries `features` annotations indicating which rule a test exercises:
+The test suite uses two kinds of tags for tab/indent rules:
+
+**Features** — annotations for universal OCaml-canonical rules. Every conformant implementation follows these.
 
 | Feature | Meaning |
 |---|---|
 | `tab_in_value_preserved` | Tabs that appear inside a value (between non-whitespace content) are preserved verbatim. Boundary tabs immediately after `=` are always trimmed as whitespace (this is untagged — it is the universal default). |
-| `continuation_tab_to_space` | On multiline continuation lines, each leading `\t` normalizes 1:1 to a single space during `parse`. Example: `"section =\n\t\tfoo"` → value `"\n  foo"`. |
-| `canonical_indent_two_spaces` | `canonical_format` emits exactly two spaces per nesting level; tabs are never emitted as indentation. |
 | `toplevel_indent_strip` | Leading whitespace on top-level keys is stripped (per OCaml: `String.trim`). |
 
-These are feature annotations, not divergence switches — every conformant implementation follows all four rules. The annotations exist so test runners can filter by what a given test exercises and report feature-coverage gaps.
+**Behaviors** — implementation choices. Implementations declare their choice per group; tests are filtered to compatible choices.
+
+| Group | Option | Meaning |
+|---|---|---|
+| continuation_tab_handling | `continuation_tab_to_space` | On multiline continuation lines, each leading `\t` normalizes 1:1 to a single space during `parse`. Example: `"section =\n\t\tfoo"` → value `"\n  foo"`. (OCaml reference) |
+| continuation_tab_handling | `continuation_tab_preserve` | Continuation-line leading tabs preserved verbatim during `parse`. |
+| indent_output | `indent_spaces` | `canonical_format` emits 2 spaces per nesting level. (OCaml reference) |
+| indent_output | `indent_tabs` | `canonical_format` emits tab characters for indentation. |
 
 ## API Guidelines
 

--- a/generated_tests/api_core_ccl_parsing.json
+++ b/generated_tests/api_core_ccl_parsing.json
@@ -346,14 +346,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "toplevel_indent_strip"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_preserve"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -364,7 +357,8 @@
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse"
@@ -405,42 +399,6 @@
       ],
       "name": "leading_whitespace_multiple_entries_parse",
       "source_test": "leading_whitespace_multiple_entries",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_strip"
-        ]
-      },
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value"
-          },
-          {
-            "key": "second",
-            "value": "entry"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "  key = value\n  second = entry"
-      ],
-      "name": "leading_whitespace_toplevel_indent_preserve_parse",
-      "source_test": "leading_whitespace_toplevel_indent_preserve",
       "validation": "parse",
       "variants": []
     }

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -375,46 +375,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "\tvalue"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "\tkey\t=\tvalue"
-      ],
-      "name": "key_with_tabs_parse",
-      "source_test": "key_with_tabs",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -464,70 +425,6 @@
       "name": "whitespace_only_value_parse",
       "source_test": "whitespace_only_value",
       "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "text",
-            "value": "First\n   four spaces\n\ttab preserved"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
-      ],
-      "name": "spaces_vs_tabs_continuation_parse_indented",
-      "source_test": "spaces_vs_tabs_continuation",
-      "validation": "parse_indented",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "text",
-            "value": "First\n   four spaces\n\ttab preserved"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
-      ],
-      "name": "spaces_vs_tabs_continuation_ocaml_reference_parse_indented",
-      "source_test": "spaces_vs_tabs_continuation_ocaml_reference",
-      "validation": "parse_indented",
       "variants": []
     },
     {

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -1031,35 +1031,6 @@
     },
     {
       "behaviors": [
-        "tabs_as_content",
-        "indent_spaces"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "indent_tabs",
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "value_with_tabs =\n  text\t\twith\ttabs =\n"
-      },
-      "features": [],
-      "functions": [
-        "parse",
-        "print",
-        "canonical_format"
-      ],
-      "inputs": [
-        "value_with_tabs = text\t\twith\ttabs\t"
-      ],
-      "name": "canonical_format_tab_preservation_ocaml_reference_canonical_format",
-      "source_test": "canonical_format_tab_preservation_ocaml_reference",
-      "validation": "canonical_format",
-      "variants": []
-    },
-    {
-      "behaviors": [
         "indent_spaces"
       ],
       "conflicts": {

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -2,167 +2,7 @@
   "$schema": "http://json-schema.org/draft-07/schema#",
   "tests": [
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "\tvalue\twith\ttabs"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_parse",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "object": {
-          "key": "\tvalue\twith\ttabs"
-        }
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "build_hierarchy"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_build_hierarchy",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "build_hierarchy",
-      "variants": []
-    },
-    {
-      "args": [
-        "key"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "\tvalue\twith\ttabs"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "get_string"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "name": "tabs_as_content_in_value_get_string",
-      "source_test": "tabs_as_content_in_value",
-      "validation": "get_string",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "key",
-            "value": "\tindented"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ],
-      "name": "tabs_as_content_leading_tab_parse",
-      "source_test": "tabs_as_content_leading_tab",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "args": [
-        "key"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "\tindented"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "get_string"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ],
-      "name": "tabs_as_content_leading_tab_get_string",
-      "source_test": "tabs_as_content_leading_tab",
-      "validation": "get_string",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -173,7 +13,8 @@
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse"
@@ -187,14 +28,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "object": {
@@ -202,7 +36,8 @@
         }
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "build_hierarchy"
@@ -225,7 +60,8 @@
         "value": "value\twith\ttabs"
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "get_string"
@@ -239,14 +75,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -294,14 +123,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -327,60 +149,21 @@
     },
     {
       "behaviors": [
-        "tabs_as_content",
         "multiline_values"
       ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
       "expected": {
         "count": 1,
         "entries": [
           {
             "key": "section",
-            "value": "\n \tindented_with_tabs\n \tanother_line"
+            "value": "\n  indented_with_tabs\n  another_line"
           }
         ]
       },
       "features": [
         "whitespace",
-        "multiline_continuation"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "section =\n \tindented_with_tabs\n \tanother_line"
-      ],
-      "name": "tabs_as_content_multiline_parse",
-      "source_test": "tabs_as_content_multiline",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace",
-        "multiline_values"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "entries": [
-          {
-            "key": "section",
-            "value": "\nindented_with_tabs\nanother_line"
-          }
-        ]
-      },
-      "features": [
-        "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "functions": [
         "parse"
@@ -395,26 +178,21 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
         "multiline_values"
       ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
       "expected": {
         "count": 1,
         "entries": [
           {
             "key": "section",
-            "value": "\nmixed_indent\nanother_line"
+            "value": "\n  mixed_indent\n  another_line"
           }
         ]
       },
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "functions": [
         "parse"
@@ -428,43 +206,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": "key = \tvalue"
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse",
-        "print",
-        "canonical_format"
-      ],
-      "inputs": [
-        "key = \tvalue"
-      ],
-      "name": "tabs_canonical_format_as_content_canonical_format",
-      "source_test": "tabs_canonical_format_as_content",
-      "validation": "canonical_format",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "value": "key = value"
@@ -487,14 +229,12 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
         "indent_spaces",
         "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
-          "indent_tabs",
-          "tabs_as_content"
+          "indent_tabs"
         ]
       },
       "expected": {
@@ -503,7 +243,8 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "functions": [
         "parse",
@@ -519,20 +260,14 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "tabs_as_content"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "value": "key = value\twith\ttabs"
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse",
@@ -787,14 +522,12 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
         "indent_tabs",
         "multiline_values"
       ],
       "conflicts": {
         "behaviors": [
-          "indent_spaces",
-          "tabs_as_content"
+          "indent_spaces"
         ]
       },
       "expected": {
@@ -803,7 +536,8 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "functions": [
         "parse",
@@ -1768,13 +1502,11 @@
     },
     {
       "behaviors": [
-        "tabs_as_whitespace",
         "crlf_normalize_to_lf"
       ],
       "conflicts": {
         "behaviors": [
-          "crlf_preserve_literal",
-          "tabs_as_content"
+          "crlf_preserve_literal"
         ]
       },
       "expected": {
@@ -1782,12 +1514,13 @@
         "entries": [
           {
             "key": "key",
-            "value": "value with tabs"
+            "value": "value\twith\ttabs"
           }
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "functions": [
         "parse"
@@ -1797,44 +1530,6 @@
       ],
       "name": "behavior_combo_tabs_and_crlf_parse",
       "source_test": "behavior_combo_tabs_and_crlf",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "tabs_as_content",
-        "crlf_normalize_to_lf"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "crlf_preserve_literal",
-          "tabs_as_whitespace"
-        ]
-      },
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key1",
-            "value": "\tvalue1"
-          },
-          {
-            "key": "key2",
-            "value": "\tvalue2"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
-      ],
-      "name": "behavior_combo_content_tabs_crlf_parse",
-      "source_test": "behavior_combo_content_tabs_crlf",
       "validation": "parse",
       "variants": []
     }

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -149,8 +149,14 @@
     },
     {
       "behaviors": [
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
+      "conflicts": {
+        "behaviors": [
+          "continuation_tab_preserve"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -162,8 +168,7 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -178,8 +183,14 @@
     },
     {
       "behaviors": [
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
+      "conflicts": {
+        "behaviors": [
+          "continuation_tab_preserve"
+        ]
+      },
       "expected": {
         "count": 1,
         "entries": [
@@ -191,8 +202,7 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "functions": [
         "parse"
@@ -230,10 +240,12 @@
     {
       "behaviors": [
         "indent_spaces",
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "conflicts": {
         "behaviors": [
+          "continuation_tab_preserve",
           "indent_tabs"
         ]
       },
@@ -243,8 +255,7 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",
@@ -523,10 +534,12 @@
     {
       "behaviors": [
         "indent_tabs",
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "conflicts": {
         "behaviors": [
+          "continuation_tab_preserve",
           "indent_spaces"
         ]
       },
@@ -536,8 +549,7 @@
       },
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "functions": [
         "parse",

--- a/generated_tests/property_round_trip.json
+++ b/generated_tests/property_round_trip.json
@@ -66,14 +66,7 @@
       "variants": []
     },
     {
-      "behaviors": [
-        "toplevel_indent_strip"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_preserve"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "entries": [
@@ -84,7 +77,8 @@
         ]
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse"
@@ -100,20 +94,14 @@
       ]
     },
     {
-      "behaviors": [
-        "toplevel_indent_strip"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_preserve"
-        ]
-      },
+      "behaviors": [],
       "expected": {
         "count": 1,
         "value": true
       },
       "features": [
-        "whitespace"
+        "whitespace",
+        "toplevel_indent_strip"
       ],
       "functions": [
         "parse",
@@ -128,70 +116,6 @@
       "variants": [
         "reference_compliant"
       ]
-    },
-    {
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_strip"
-        ]
-      },
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key",
-            "value": "value"
-          },
-          {
-            "key": "nested",
-            "value": "\n    sub  =  val"
-          }
-        ]
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse"
-      ],
-      "inputs": [
-        "  key  =  value  \n  nested  = \n    sub  =  val  "
-      ],
-      "name": "round_trip_whitespace_normalization_toplevel_indent_preserve_parse",
-      "source_test": "round_trip_whitespace_normalization_toplevel_indent_preserve",
-      "validation": "parse",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "conflicts": {
-        "behaviors": [
-          "toplevel_indent_strip"
-        ]
-      },
-      "expected": {
-        "count": 1,
-        "value": true
-      },
-      "features": [
-        "whitespace"
-      ],
-      "functions": [
-        "parse",
-        "print"
-      ],
-      "inputs": [
-        "  key  =  value  \n  nested  = \n    sub  =  val  "
-      ],
-      "name": "round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip",
-      "source_test": "round_trip_whitespace_normalization_toplevel_indent_preserve",
-      "validation": "round_trip",
-      "variants": []
     },
     {
       "behaviors": [],

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -279,8 +279,8 @@ func (fg *FlatGenerator) TransformSourceToFlat(sourceTest types.TestCase) ([]typ
 // For example, round_trip validation requires both parse and print functions.
 var compositeFunctionMap = map[string][]string{
 	"round_trip":          {"parse", "print"},
-	"load":               {"parse", "build_hierarchy"},
-	"canonical_format":   {"parse", "print", "canonical_format"},
+	"load":                {"parse", "build_hierarchy"},
+	"canonical_format":    {"parse", "print", "canonical_format"},
 	"compose_associative": {"parse", "compose"},
 	"identity_left":       {"parse", "compose"},
 	"identity_right":      {"parse", "compose"},

--- a/go_tests/parsing/api_core_ccl_parsing_test.go
+++ b/go_tests/parsing/api_core_ccl_parsing_test.go
@@ -242,7 +242,7 @@ func TestEmptyInputPrint(t *testing.T) {
 }
 
 
-// leading_whitespace_baseline_zero_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
+// leading_whitespace_baseline_zero_parse - function:parse feature:whitespace feature:toplevel_indent_strip variant:reference_compliant
 func TestLeadingWhitespaceBaselineZeroParse(t *testing.T) {
 	
 
@@ -285,12 +285,6 @@ key2 = value2`
 	expected := []mock.Entry{mock.Entry{Key: "key1", Value: "value1"}, mock.Entry{Key: "key2", Value: "value2"}}
 	assert.Equal(t, expected, parseResult)
 
-}
-
-
-// leading_whitespace_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
-func TestLeadingWhitespaceToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
 }
 
 

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -317,15 +317,25 @@ key2 = val2`
 }
 
 
-// key_with_tabs_parse - function:parse feature:whitespace behavior:tabs_as_content
-func TestKeyWithTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
-// key_with_tabs_ocaml_reference_parse - function:parse feature:whitespace behavior:tabs_as_whitespace variant:reference_compliant
+// key_with_tabs_ocaml_reference_parse - function:parse feature:whitespace variant:reference_compliant
 func TestKeyWithTabsOcamlReferenceParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `	key	=	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
@@ -351,18 +361,6 @@ func TestWhitespaceOnlyValueParse(t *testing.T) {
 }
 
 
-// spaces_vs_tabs_continuation_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
-func TestSpacesVsTabsContinuationParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// spaces_vs_tabs_continuation_ocaml_reference_parse_indented - function:parse_indented feature:whitespace behavior:tabs_as_content
-func TestSpacesVsTabsContinuationOcamlReferenceParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
 // multiple_empty_equality_parse - function:parse feature:empty_keys feature:whitespace
 func TestMultipleEmptyEqualityParse(t *testing.T) {
 	
@@ -385,7 +383,7 @@ func TestMultipleEmptyEqualityParse(t *testing.T) {
 }
 
 
-// key_with_newline_before_equals_parse - function:parse feature:multiline feature:whitespace
+// key_with_newline_before_equals_parse - function:parse feature:multiline_keys feature:whitespace
 func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 	
 
@@ -409,7 +407,7 @@ func TestKeyWithNewlineBeforeEqualsParse(t *testing.T) {
 }
 
 
-// complex_multi_newline_whitespace_parse - function:parse feature:multiline feature:whitespace
+// complex_multi_newline_whitespace_parse - function:parse feature:multiline_keys feature:whitespace
 func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
 	
 
@@ -418,6 +416,149 @@ func TestComplexMultiNewlineWhitespaceParse(t *testing.T) {
  key  
 =  val  
 `
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_with_spaces_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyWithSpacesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `my
+ key
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "my key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_three_lines_parse - function:parse feature:multiline_keys
+func TestMultilineKeyThreeLinesParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `a
+ b
+ c
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "a b c", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_empty_value_parse - function:parse feature:multiline_keys feature:empty_keys
+func TestMultilineKeyEmptyValueParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+=`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: ""}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_with_regular_entry_parse - function:parse feature:multiline_keys
+func TestMultilineKeyWithRegularEntryParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `first = val1
+key
+= val2`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "first", Value: "val1"}, mock.Entry{Key: "key", Value: "val2"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_blank_lines_between_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyBlankLinesBetweenParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+
+= val`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// multiline_key_tabs_in_continuation_parse - function:parse feature:multiline_keys feature:whitespace
+func TestMultilineKeyTabsInContinuationParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key
+	= val`
 	
 	// Declare variables for reuse across validations
 	
@@ -1692,140 +1833,3 @@ func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
 }
 
 
-
-// multiline_key_with_spaces_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyWithSpacesParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `my
- key
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "my key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_three_lines_parse - function:parse feature:multiline_keys
-func TestMultilineKeyThreeLinesParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `a
- b
- c
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "a b c", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_empty_value_parse - function:parse feature:multiline_keys feature:empty_keys
-func TestMultilineKeyEmptyValueParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-=`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: ""}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_with_regular_entry_parse - function:parse feature:multiline_keys
-func TestMultilineKeyWithRegularEntryParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `first = val1
-key
-= val2`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "first", Value: "val1"}, mock.Entry{Key: "key", Value: "val2"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_blank_lines_between_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyBlankLinesBetweenParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-
-= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}
-
-// multiline_key_tabs_in_continuation_parse - function:parse feature:multiline_keys feature:whitespace
-func TestMultilineKeyTabsInContinuationParse(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key
-	= val`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// Parse validation
-	parseResult, err := ccl.Parse(input)
-	require.NoError(t, err)
-	expected := []mock.Entry{mock.Entry{Key: "key", Value: "val"}}
-	assert.Equal(t, expected, parseResult)
-
-}

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -434,12 +434,6 @@ func TestCanonicalFormatEmptyValuesOcamlReferenceCanonicalFormat(t *testing.T) {
 }
 
 
-// canonical_format_tab_preservation_ocaml_reference_canonical_format - function:parse function:print function:canonical_format behavior:tabs_as_content behavior:indent_spaces
-func TestCanonicalFormatTabPreservationOcamlReferenceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
 // canonical_format_unicode_ocaml_reference_canonical_format - function:parse function:print function:canonical_format feature:unicode behavior:indent_spaces
 func TestCanonicalFormatUnicodeOcamlReferenceCanonicalFormat(t *testing.T) {
 	

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -14,57 +14,59 @@ import (
 
 
 
-// tabs_as_content_in_value_parse - function:parse feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
-// tabs_as_content_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentInValueBuildHierarchy(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// tabs_as_content_in_value_get_string - function:get_string feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentInValueGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// tabs_as_content_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
-// tabs_as_content_leading_tab_get_string - function:get_string feature:whitespace behavior:tabs_as_content
-func TestTabsAsContentLeadingTabGetString(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// tabs_as_whitespace_in_value_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+// tabs_as_whitespace_in_value_parse - function:parse feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceInValueParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
-// tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace behavior:tabs_as_whitespace
+// tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace
+// tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+// tabs_as_whitespace_leading_tab_parse - function:parse feature:whitespace
 func TestTabsAsWhitespaceLeadingTabParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	indented`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "indented"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
@@ -74,51 +76,138 @@ func TestTabsAsWhitespaceLeadingTabGetString(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace behavior:tabs_as_whitespace
+// tabs_as_whitespace_multiple_tabs_parse - function:parse feature:whitespace
 func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 			three_tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "three_tabs"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
-// tabs_as_content_multiline_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_content behavior:multiline_values
-func TestTabsAsContentMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
-// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:multiline_values
+// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:multiline_values
 func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented_with_tabs
+		another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\n  indented_with_tabs\n  another_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
-// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:multiline_values
+// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:multiline_values
 func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+ 	mixed_indent
+	 another_line`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "section", Value: "\n  mixed_indent\n  another_line"}}
+	assert.Equal(t, expected, parseResult)
+
 }
 
 
-// tabs_canonical_format_as_content_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:tabs_as_content
-func TestTabsCanonicalFormatAsContentCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
-}
-
-
-// tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:tabs_as_whitespace
+// tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print function:canonical_format feature:whitespace
 func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:indent_spaces behavior:multiline_values
+// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:indent_spaces behavior:multiline_values
 func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `section =
+		indented
+		another`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
-// tabs_as_whitespace_round_trip_round_trip - function:parse function:print feature:whitespace behavior:tabs_as_whitespace
+// tabs_as_whitespace_round_trip_round_trip - function:parse function:print feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceRoundTripRoundTrip(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	
+
+	ccl := mock.New()
+	input := `key = 	value	with	tabs`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
 }
 
 
@@ -207,106 +296,31 @@ func TestPrintMixedFlatAndNestedIndentTabsPrint(t *testing.T) {
 
 // canonical_format_deterministic_indent_tabs_canonical_format - function:parse function:print function:canonical_format behavior:indent_tabs
 func TestCanonicalFormatDeterministicIndentTabsCanonicalFormat(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `z = last
-a = first
-m = middle`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// TODO: Implement canonical_format validation
-	_ = ccl // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err // Prevent unused variable warning
-
+	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }
 
 
 // canonical_format_consistent_spacing_indent_tabs_canonical_format - function:parse function:print function:canonical_format behavior:indent_tabs
 func TestCanonicalFormatConsistentSpacingIndentTabsCanonicalFormat(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `key1=value1
-key2  =  value2
-key3	=	value3`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// TODO: Implement canonical_format validation
-	_ = ccl // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err // Prevent unused variable warning
-
+	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }
 
 
-// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:tabs_as_whitespace behavior:indent_tabs behavior:multiline_values
+// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:indent_tabs behavior:multiline_values
 func TestTabsAsWhitespaceMultilineCanonicalIndentTabsCanonicalFormat(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
+	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }
 
 
 // nested_bare_list_indentation_tabs_canonical_format - function:parse function:print function:canonical_format feature:empty_keys feature:whitespace behavior:indent_tabs
 func TestNestedBareListIndentationTabsCanonicalFormat(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `package =
-	= brew
-	= scoop
-	= nix`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// TODO: Implement canonical_format validation
-	_ = ccl // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err // Prevent unused variable warning
-
+	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }
 
 
 // deeply_nested_bare_list_indentation_tabs_canonical_format - function:parse function:print function:canonical_format feature:empty_keys feature:whitespace behavior:indent_tabs
 func TestDeeplyNestedBareListIndentationTabsCanonicalFormat(t *testing.T) {
-	
-
-	ccl := mock.New()
-	input := `app =
-	= item1
-	config =
-		= nested1
-		= nested2
-		deep =
-			= level3a
-			= level3b
-	= item2`
-	
-	// Declare variables for reuse across validations
-	
-	
-	
-	var err error
-	
-	// TODO: Implement canonical_format validation
-	_ = ccl // Prevent unused variable warning
-	_ = input // Prevent unused variable warning
-	_ = err // Prevent unused variable warning
-
+	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }
 
 
@@ -572,15 +586,25 @@ func TestCrlfPreserveMultipleCommentsFilter(t *testing.T) {
 }
 
 
-// behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace behavior:tabs_as_whitespace behavior:crlf_normalize_to_lf
+// behavior_combo_tabs_and_crlf_parse - function:parse feature:whitespace feature:tab_in_value_preserved behavior:crlf_normalize_to_lf
 func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_whitespace")
-}
+	
 
+	ccl := mock.New()
+	input := "key = \tvalue\twith\ttabs\r\n"
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value\twith\ttabs"}}
+	assert.Equal(t, expected, parseResult)
 
-// behavior_combo_content_tabs_crlf_parse - function:parse feature:whitespace behavior:tabs_as_content behavior:crlf_normalize_to_lf
-func TestBehaviorComboContentTabsCrlfParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:tabs_as_content")
 }
 
 

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -98,7 +98,7 @@ func TestTabsAsWhitespaceMultipleTabsParse(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:multiline_values
+// tabs_as_whitespace_multiline_parse - function:parse feature:whitespace feature:multiline_continuation behavior:multiline_values behavior:continuation_tab_to_space
 func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
 	
 
@@ -122,7 +122,7 @@ func TestTabsAsWhitespaceMultilineParse(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:multiline_values
+// tabs_as_whitespace_mixed_indent_parse - function:parse feature:whitespace feature:multiline_continuation behavior:multiline_values behavior:continuation_tab_to_space
 func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
 	
 
@@ -167,7 +167,7 @@ func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:indent_spaces behavior:multiline_values
+// tabs_as_whitespace_multiline_print_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:indent_spaces behavior:multiline_values behavior:continuation_tab_to_space
 func TestTabsAsWhitespaceMultilinePrintCanonicalFormat(t *testing.T) {
 	
 
@@ -306,7 +306,7 @@ func TestCanonicalFormatConsistentSpacingIndentTabsCanonicalFormat(t *testing.T)
 }
 
 
-// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation feature:continuation_tab_to_space behavior:indent_tabs behavior:multiline_values
+// tabs_as_whitespace_multiline_canonical_indent_tabs_canonical_format - function:parse function:print function:canonical_format feature:whitespace feature:multiline_continuation behavior:indent_tabs behavior:multiline_values behavior:continuation_tab_to_space
 func TestTabsAsWhitespaceMultilineCanonicalIndentTabsCanonicalFormat(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:indent_tabs")
 }

--- a/go_tests/parsing/property_round_trip_test.go
+++ b/go_tests/parsing/property_round_trip_test.go
@@ -67,7 +67,7 @@ nested =
 }
 
 
-// round_trip_whitespace_normalization_parse - function:parse feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
+// round_trip_whitespace_normalization_parse - function:parse feature:whitespace feature:toplevel_indent_strip variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
 	
 
@@ -91,7 +91,7 @@ func TestRoundTripWhitespaceNormalizationParse(t *testing.T) {
 }
 
 
-// round_trip_whitespace_normalization_round_trip - function:parse function:print feature:whitespace behavior:toplevel_indent_strip variant:reference_compliant
+// round_trip_whitespace_normalization_round_trip - function:parse function:print feature:whitespace feature:toplevel_indent_strip variant:reference_compliant
 func TestRoundTripWhitespaceNormalizationRoundTrip(t *testing.T) {
 	
 
@@ -111,18 +111,6 @@ func TestRoundTripWhitespaceNormalizationRoundTrip(t *testing.T) {
 	_ = input // Prevent unused variable warning
 	_ = err // Prevent unused variable warning
 
-}
-
-
-// round_trip_whitespace_normalization_toplevel_indent_preserve_parse - function:parse feature:whitespace behavior:toplevel_indent_preserve
-func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveParse(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
-}
-
-
-// round_trip_whitespace_normalization_toplevel_indent_preserve_round_trip - function:parse function:print feature:whitespace behavior:toplevel_indent_preserve
-func TestRoundTripWhitespaceNormalizationToplevelIndentPreserveRoundTrip(t *testing.T) {
-	t.Skip("Test skipped due to tag filter: behavior:toplevel_indent_preserve")
 }
 
 

--- a/internal/config/runner_config.go
+++ b/internal/config/runner_config.go
@@ -29,10 +29,11 @@ type ImplementationSettings struct {
 // BehaviorChoices contains REQUIRED mutually exclusive behavioral choices
 // All fields must be explicitly set - no defaults allowed
 type BehaviorChoices struct {
-	CRLFHandling *config.CCLBehavior `json:"crlf_handling"` // REQUIRED: crlf_normalize_to_lf | crlf_preserve_literal
-	IndentOutput *config.CCLBehavior `json:"indent_output"` // REQUIRED: indent_spaces | indent_tabs
-	Boolean      *config.CCLBehavior `json:"boolean"`       // REQUIRED: boolean_strict | boolean_lenient
-	ListCoercion *config.CCLBehavior `json:"list_coercion"` // REQUIRED: list_coercion_enabled | list_coercion_disabled
+	CRLFHandling            *config.CCLBehavior `json:"crlf_handling"`             // REQUIRED: crlf_normalize_to_lf | crlf_preserve_literal
+	IndentOutput            *config.CCLBehavior `json:"indent_output"`             // REQUIRED: indent_spaces | indent_tabs
+	ContinuationTabHandling *config.CCLBehavior `json:"continuation_tab_handling"` // REQUIRED: continuation_tab_to_space | continuation_tab_preserve
+	Boolean                 *config.CCLBehavior `json:"boolean"`                   // REQUIRED: boolean_strict | boolean_lenient
+	ListCoercion            *config.CCLBehavior `json:"list_coercion"`             // REQUIRED: list_coercion_enabled | list_coercion_disabled
 }
 
 // VariantChoice contains REQUIRED specification variant choice
@@ -53,6 +54,7 @@ type TestFilteringOptions struct {
 func DefaultConfig() *RunnerConfig {
 	crlf := config.BehaviorCRLFNormalize // Normalize CRLF to LF for consistent line endings
 	indent := config.BehaviorIndentSpaces
+	continuationTab := config.BehaviorContinuationTabToSpace // Match OCaml reference
 	boolean := config.BehaviorBooleanLenient
 	listCoercion := config.BehaviorListCoercionOff
 	variant := config.VariantReference
@@ -78,15 +80,15 @@ func DefaultConfig() *RunnerConfig {
 				config.FeatureExperimentalDottedKeys,
 				config.FeatureUnicode,
 				config.FeatureTabInValuePreserved,
-				config.FeatureContinuationTabToSpace,
 				config.FeatureToplevelIndentStrip,
 			},
 		},
 		Behaviors: BehaviorChoices{
-			CRLFHandling: &crlf,
-			IndentOutput: &indent,
-			Boolean:      &boolean,
-			ListCoercion: &listCoercion,
+			CRLFHandling:            &crlf,
+			IndentOutput:            &indent,
+			ContinuationTabHandling: &continuationTab,
+			Boolean:                 &boolean,
+			ListCoercion:            &listCoercion,
 		},
 		Variant: VariantChoice{
 			Specification: &variant,
@@ -139,6 +141,9 @@ func (rc *RunnerConfig) Validate() error {
 	if rc.Behaviors.IndentOutput == nil {
 		errors = append(errors, "Indent output choice is required (indent_spaces | indent_tabs)")
 	}
+	if rc.Behaviors.ContinuationTabHandling == nil {
+		errors = append(errors, "Continuation tab handling choice is required (continuation_tab_to_space | continuation_tab_preserve)")
+	}
 	if rc.Behaviors.Boolean == nil {
 		errors = append(errors, "Boolean parsing choice is required (boolean_strict | boolean_lenient)")
 	}
@@ -159,6 +164,11 @@ func (rc *RunnerConfig) Validate() error {
 	}
 	if rc.Behaviors.IndentOutput != nil {
 		if err := rc.validateBehaviorInGroup(*rc.Behaviors.IndentOutput, "indent_output"); err != nil {
+			errors = append(errors, err.Error())
+		}
+	}
+	if rc.Behaviors.ContinuationTabHandling != nil {
+		if err := rc.validateBehaviorInGroup(*rc.Behaviors.ContinuationTabHandling, "continuation_tab_handling"); err != nil {
 			errors = append(errors, err.Error())
 		}
 	}
@@ -214,6 +224,9 @@ func (rc *RunnerConfig) ToImplementationConfig() config.ImplementationConfig {
 	if rc.Behaviors.IndentOutput != nil {
 		behaviorChoices = append(behaviorChoices, *rc.Behaviors.IndentOutput)
 	}
+	if rc.Behaviors.ContinuationTabHandling != nil {
+		behaviorChoices = append(behaviorChoices, *rc.Behaviors.ContinuationTabHandling)
+	}
 	if rc.Behaviors.Boolean != nil {
 		behaviorChoices = append(behaviorChoices, *rc.Behaviors.Boolean)
 	}
@@ -266,6 +279,7 @@ func (rc *RunnerConfig) GetConflictingTags() []string {
 func (rc *RunnerConfig) isBehaviorChosen(behavior config.CCLBehavior) bool {
 	return (rc.Behaviors.CRLFHandling != nil && *rc.Behaviors.CRLFHandling == behavior) ||
 		(rc.Behaviors.IndentOutput != nil && *rc.Behaviors.IndentOutput == behavior) ||
+		(rc.Behaviors.ContinuationTabHandling != nil && *rc.Behaviors.ContinuationTabHandling == behavior) ||
 		(rc.Behaviors.Boolean != nil && *rc.Behaviors.Boolean == behavior) ||
 		(rc.Behaviors.ListCoercion != nil && *rc.Behaviors.ListCoercion == behavior)
 }

--- a/internal/config/runner_config.go
+++ b/internal/config/runner_config.go
@@ -29,12 +29,10 @@ type ImplementationSettings struct {
 // BehaviorChoices contains REQUIRED mutually exclusive behavioral choices
 // All fields must be explicitly set - no defaults allowed
 type BehaviorChoices struct {
-	CRLFHandling   *config.CCLBehavior `json:"crlf_handling"`   // REQUIRED: crlf_normalize_to_lf | crlf_preserve_literal
-	TabHandling    *config.CCLBehavior `json:"tab_handling"`    // REQUIRED: tabs_as_content | tabs_as_whitespace
-	IndentOutput   *config.CCLBehavior `json:"indent_output"`   // REQUIRED: indent_spaces | indent_tabs
-	Boolean        *config.CCLBehavior `json:"boolean"`         // REQUIRED: boolean_strict | boolean_lenient
-	ListCoercion   *config.CCLBehavior `json:"list_coercion"`   // REQUIRED: list_coercion_enabled | list_coercion_disabled
-	ToplevelIndent *config.CCLBehavior `json:"toplevel_indent"` // REQUIRED: toplevel_indent_strip | toplevel_indent_preserve
+	CRLFHandling *config.CCLBehavior `json:"crlf_handling"` // REQUIRED: crlf_normalize_to_lf | crlf_preserve_literal
+	IndentOutput *config.CCLBehavior `json:"indent_output"` // REQUIRED: indent_spaces | indent_tabs
+	Boolean      *config.CCLBehavior `json:"boolean"`       // REQUIRED: boolean_strict | boolean_lenient
+	ListCoercion *config.CCLBehavior `json:"list_coercion"` // REQUIRED: list_coercion_enabled | list_coercion_disabled
 }
 
 // VariantChoice contains REQUIRED specification variant choice
@@ -53,12 +51,10 @@ type TestFilteringOptions struct {
 // DefaultConfig returns the default configuration for the CCL test runner
 // NOTE: This configuration makes explicit behavioral choices for the mock implementation
 func DefaultConfig() *RunnerConfig {
-	crlf := config.BehaviorCRLFNormalize    // Normalize CRLF to LF for consistent line endings
-	tabs := config.BehaviorTabsAsWhitespace // Tabs are whitespace (count for indentation, get trimmed)
-	indent := config.BehaviorIndentSpaces   // Use spaces for printed indentation
+	crlf := config.BehaviorCRLFNormalize // Normalize CRLF to LF for consistent line endings
+	indent := config.BehaviorIndentSpaces
 	boolean := config.BehaviorBooleanLenient
 	listCoercion := config.BehaviorListCoercionOff
-	toplevelIndent := config.BehaviorToplevelIndentStrip // Strip leading indent at top-level (matches OCaml reference)
 	variant := config.VariantReference
 
 	return &RunnerConfig{
@@ -81,22 +77,23 @@ func DefaultConfig() *RunnerConfig {
 				config.FeatureComments,
 				config.FeatureExperimentalDottedKeys,
 				config.FeatureUnicode,
+				config.FeatureTabInValuePreserved,
+				config.FeatureContinuationTabToSpace,
+				config.FeatureToplevelIndentStrip,
 			},
 		},
 		Behaviors: BehaviorChoices{
-			CRLFHandling:   &crlf,
-			TabHandling:    &tabs,
-			IndentOutput:   &indent,
-			Boolean:        &boolean,
-			ListCoercion:   &listCoercion,
-			ToplevelIndent: &toplevelIndent,
+			CRLFHandling: &crlf,
+			IndentOutput: &indent,
+			Boolean:      &boolean,
+			ListCoercion: &listCoercion,
 		},
 		Variant: VariantChoice{
 			Specification: &variant,
 		},
 		TestFiltering: TestFilteringOptions{
 			RunOnlyFunctions: []string{"parse", "get-string", "get-int", "get-bool", "get-float", "get-list"}, // Basic functions only
-			SkipTags:         []string{"behavior:crlf_normalize_to_lf", "behavior:tabs_as_content"},           // Skip conflicting behaviors
+			SkipTags:         []string{"behavior:crlf_normalize_to_lf"},                                       // Skip conflicting behaviors
 			SkipTestsByName: []string{
 				// Indentation-aware parsing (requires multiline value preservation)
 				"deep_nested_objects", "nested_duplicate_keys", "round_trip_deeply_nested",
@@ -139,9 +136,6 @@ func (rc *RunnerConfig) Validate() error {
 	if rc.Behaviors.CRLFHandling == nil {
 		errors = append(errors, "CRLF handling choice is required (crlf_normalize_to_lf | crlf_preserve_literal)")
 	}
-	if rc.Behaviors.TabHandling == nil {
-		errors = append(errors, "Tab handling choice is required (tabs_as_content | tabs_as_whitespace)")
-	}
 	if rc.Behaviors.IndentOutput == nil {
 		errors = append(errors, "Indent output choice is required (indent_spaces | indent_tabs)")
 	}
@@ -150,9 +144,6 @@ func (rc *RunnerConfig) Validate() error {
 	}
 	if rc.Behaviors.ListCoercion == nil {
 		errors = append(errors, "List coercion choice is required (list_coercion_enabled | list_coercion_disabled)")
-	}
-	if rc.Behaviors.ToplevelIndent == nil {
-		errors = append(errors, "Toplevel indent choice is required (toplevel_indent_strip | toplevel_indent_preserve)")
 	}
 
 	// Validate required variant choice is made
@@ -163,11 +154,6 @@ func (rc *RunnerConfig) Validate() error {
 	// Validate behavioral choices are from valid conflict groups
 	if rc.Behaviors.CRLFHandling != nil {
 		if err := rc.validateBehaviorInGroup(*rc.Behaviors.CRLFHandling, "crlf_handling"); err != nil {
-			errors = append(errors, err.Error())
-		}
-	}
-	if rc.Behaviors.TabHandling != nil {
-		if err := rc.validateBehaviorInGroup(*rc.Behaviors.TabHandling, "tab_handling"); err != nil {
 			errors = append(errors, err.Error())
 		}
 	}
@@ -183,11 +169,6 @@ func (rc *RunnerConfig) Validate() error {
 	}
 	if rc.Behaviors.ListCoercion != nil {
 		if err := rc.validateBehaviorInGroup(*rc.Behaviors.ListCoercion, "list_coercion"); err != nil {
-			errors = append(errors, err.Error())
-		}
-	}
-	if rc.Behaviors.ToplevelIndent != nil {
-		if err := rc.validateBehaviorInGroup(*rc.Behaviors.ToplevelIndent, "toplevel_indent"); err != nil {
 			errors = append(errors, err.Error())
 		}
 	}
@@ -230,9 +211,6 @@ func (rc *RunnerConfig) ToImplementationConfig() config.ImplementationConfig {
 	if rc.Behaviors.CRLFHandling != nil {
 		behaviorChoices = append(behaviorChoices, *rc.Behaviors.CRLFHandling)
 	}
-	if rc.Behaviors.TabHandling != nil {
-		behaviorChoices = append(behaviorChoices, *rc.Behaviors.TabHandling)
-	}
 	if rc.Behaviors.IndentOutput != nil {
 		behaviorChoices = append(behaviorChoices, *rc.Behaviors.IndentOutput)
 	}
@@ -241,9 +219,6 @@ func (rc *RunnerConfig) ToImplementationConfig() config.ImplementationConfig {
 	}
 	if rc.Behaviors.ListCoercion != nil {
 		behaviorChoices = append(behaviorChoices, *rc.Behaviors.ListCoercion)
-	}
-	if rc.Behaviors.ToplevelIndent != nil {
-		behaviorChoices = append(behaviorChoices, *rc.Behaviors.ToplevelIndent)
 	}
 
 	var variantChoice config.CCLVariant
@@ -290,9 +265,7 @@ func (rc *RunnerConfig) GetConflictingTags() []string {
 // isBehaviorChosen checks if a specific behavior was chosen in our configuration
 func (rc *RunnerConfig) isBehaviorChosen(behavior config.CCLBehavior) bool {
 	return (rc.Behaviors.CRLFHandling != nil && *rc.Behaviors.CRLFHandling == behavior) ||
-		(rc.Behaviors.TabHandling != nil && *rc.Behaviors.TabHandling == behavior) ||
 		(rc.Behaviors.IndentOutput != nil && *rc.Behaviors.IndentOutput == behavior) ||
 		(rc.Behaviors.Boolean != nil && *rc.Behaviors.Boolean == behavior) ||
-		(rc.Behaviors.ListCoercion != nil && *rc.Behaviors.ListCoercion == behavior) ||
-		(rc.Behaviors.ToplevelIndent != nil && *rc.Behaviors.ToplevelIndent == behavior)
+		(rc.Behaviors.ListCoercion != nil && *rc.Behaviors.ListCoercion == behavior)
 }

--- a/internal/config/simple_config.go
+++ b/internal/config/simple_config.go
@@ -45,7 +45,6 @@ var ValidFeatures = []string{
 	"empty_keys",
 	"optional_typed_accessors",
 	"tab_in_value_preserved",
-	"continuation_tab_to_space",
 	"toplevel_indent_strip",
 }
 
@@ -57,6 +56,8 @@ var ValidBehaviors = []string{
 	"crlf_normalize_to_lf",
 	"indent_spaces",
 	"indent_tabs",
+	"continuation_tab_to_space",
+	"continuation_tab_preserve",
 	"list_coercion_enabled",
 	"list_coercion_disabled",
 	"array_order_insertion",
@@ -73,6 +74,7 @@ var ConflictingBehaviors = [][]string{
 	{"boolean_strict", "boolean_lenient"},
 	{"crlf_preserve_literal", "crlf_normalize_to_lf"},
 	{"indent_spaces", "indent_tabs"},
+	{"continuation_tab_to_space", "continuation_tab_preserve"},
 	{"list_coercion_enabled", "list_coercion_disabled"},
 	{"array_order_insertion", "array_order_lexicographic"},
 }
@@ -205,8 +207,6 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 			supportedFeatures = append(supportedFeatures, config.FeatureEmptyKeys)
 		case "tab_in_value_preserved":
 			supportedFeatures = append(supportedFeatures, config.FeatureTabInValuePreserved)
-		case "continuation_tab_to_space":
-			supportedFeatures = append(supportedFeatures, config.FeatureContinuationTabToSpace)
 		case "toplevel_indent_strip":
 			supportedFeatures = append(supportedFeatures, config.FeatureToplevelIndentStrip)
 		case "optional_typed_accessors":
@@ -239,6 +239,12 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 		case "indent_tabs":
 			tabs := config.BehaviorIndentTabs
 			behaviors.IndentOutput = &tabs
+		case "continuation_tab_to_space":
+			c := config.BehaviorContinuationTabToSpace
+			behaviors.ContinuationTabHandling = &c
+		case "continuation_tab_preserve":
+			c := config.BehaviorContinuationTabPreserve
+			behaviors.ContinuationTabHandling = &c
 		case "list_coercion_enabled":
 			enabled := config.BehaviorListCoercionOn
 			behaviors.ListCoercion = &enabled
@@ -260,6 +266,10 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 	if behaviors.IndentOutput == nil {
 		spaces := config.BehaviorIndentSpaces
 		behaviors.IndentOutput = &spaces
+	}
+	if behaviors.ContinuationTabHandling == nil {
+		c := config.BehaviorContinuationTabToSpace
+		behaviors.ContinuationTabHandling = &c
 	}
 	if behaviors.ListCoercion == nil {
 		disabled := config.BehaviorListCoercionOff

--- a/internal/config/simple_config.go
+++ b/internal/config/simple_config.go
@@ -44,14 +44,15 @@ var ValidFeatures = []string{
 	"whitespace",
 	"empty_keys",
 	"optional_typed_accessors",
+	"tab_in_value_preserved",
+	"continuation_tab_to_space",
+	"toplevel_indent_strip",
 }
 
 // ValidBehaviors defines all supported behavioral choices
 var ValidBehaviors = []string{
 	"boolean_strict",
 	"boolean_lenient",
-	"tabs_as_content",
-	"tabs_as_whitespace",
 	"crlf_preserve_literal",
 	"crlf_normalize_to_lf",
 	"indent_spaces",
@@ -70,7 +71,6 @@ var ValidVariants = []string{
 // ConflictingBehaviors defines mutually exclusive behavioral choices
 var ConflictingBehaviors = [][]string{
 	{"boolean_strict", "boolean_lenient"},
-	{"tabs_as_content", "tabs_as_whitespace"},
 	{"crlf_preserve_literal", "crlf_normalize_to_lf"},
 	{"indent_spaces", "indent_tabs"},
 	{"list_coercion_enabled", "list_coercion_disabled"},
@@ -203,6 +203,12 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 			supportedFeatures = append(supportedFeatures, config.FeatureWhitespace)
 		case "empty_keys":
 			supportedFeatures = append(supportedFeatures, config.FeatureEmptyKeys)
+		case "tab_in_value_preserved":
+			supportedFeatures = append(supportedFeatures, config.FeatureTabInValuePreserved)
+		case "continuation_tab_to_space":
+			supportedFeatures = append(supportedFeatures, config.FeatureContinuationTabToSpace)
+		case "toplevel_indent_strip":
+			supportedFeatures = append(supportedFeatures, config.FeatureToplevelIndentStrip)
 		case "optional_typed_accessors":
 			// Handle optional typed accessors feature - this might need a new enum value
 			// For now, we'll need to check if this enum exists in ccl-test-lib
@@ -221,12 +227,6 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 		case "boolean_lenient":
 			lenient := config.BehaviorBooleanLenient
 			behaviors.Boolean = &lenient
-		case "tabs_as_content":
-			asContent := config.BehaviorTabsAsContent
-			behaviors.TabHandling = &asContent
-		case "tabs_as_whitespace":
-			asWhitespace := config.BehaviorTabsAsWhitespace
-			behaviors.TabHandling = &asWhitespace
 		case "crlf_preserve_literal":
 			preserve := config.BehaviorCRLFPreserve
 			behaviors.CRLFHandling = &preserve
@@ -252,10 +252,6 @@ func (c *SimpleConfig) ToRunnerConfig() (*RunnerConfig, error) {
 	if behaviors.Boolean == nil {
 		lenient := config.BehaviorBooleanLenient
 		behaviors.Boolean = &lenient
-	}
-	if behaviors.TabHandling == nil {
-		asWhitespace := config.BehaviorTabsAsWhitespace
-		behaviors.TabHandling = &asWhitespace
 	}
 	if behaviors.CRLFHandling == nil {
 		normalize := config.BehaviorCRLFNormalize

--- a/internal/mock/ccl.go
+++ b/internal/mock/ccl.go
@@ -104,7 +104,14 @@ func (c *CCL) Parse(input string) ([]Entry, error) {
 
 						// If line starts with whitespace (indented), it belongs to this key
 						if len(nextLine) > 0 && (nextLine[0] == ' ' || nextLine[0] == '\t') {
-							multilineValue = append(multilineValue, nextLine)
+							// Normalize leading tabs on continuation lines 1:1 to spaces
+							// per OCaml reference (feature: continuation_tab_to_space).
+							k := 0
+							for k < len(nextLine) && (nextLine[k] == ' ' || nextLine[k] == '\t') {
+								k++
+							}
+							leading := strings.ReplaceAll(nextLine[:k], "\t", " ")
+							multilineValue = append(multilineValue, leading+nextLine[k:])
 							j++
 						} else if strings.TrimSpace(nextLine) == "" {
 							// Skip empty lines within multiline content
@@ -138,11 +145,10 @@ func (c *CCL) Parse(input string) ([]Entry, error) {
 	return entries, nil
 }
 
-// ParseIndented implements entry processing with indentation normalization
-// It calculates the common leading whitespace prefix and strips it from all lines
+// ParseIndented implements entry processing with indentation normalization.
+// Delegates to Parse. Continuation-line tab-to-space normalization is handled
+// in Parse per the OCaml reference (1:1 substitution).
 func (c *CCL) ParseIndented(input string) ([]Entry, error) {
-	// For mock purposes, same as Parse
-	// A full implementation would dedent the input first
 	return c.Parse(input)
 }
 

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ default:
 # Generate test files from source JSON
 build:
     go run ./cmd/ccl-test-runner generate-flat --source ./source_tests/core --validate
-    go run ./cmd/ccl-test-runner generate --run-only function:parse --skip-tags behavior:crlf_preserve_literal,behavior:tabs_as_content,behavior:tabs_as_whitespace,behavior:toplevel_indent_preserve,behavior:delimiter_prefer_spaced
+    go run ./cmd/ccl-test-runner generate --run-only function:parse --skip-tags behavior:crlf_preserve_literal,behavior:indent_tabs,behavior:delimiter_prefer_spaced
 
 # Run tests
 test:

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -151,11 +151,9 @@
           "enum": [
             "boolean_strict", "boolean_lenient",
             "crlf_preserve_literal", "crlf_normalize_to_lf",
-            "tabs_as_content", "tabs_as_whitespace",
             "indent_spaces", "indent_tabs",
             "list_coercion_enabled", "list_coercion_disabled",
             "array_order_insertion", "array_order_lexicographic",
-            "toplevel_indent_strip", "toplevel_indent_preserve",
             "delimiter_first_equals", "delimiter_prefer_spaced",
             "path_traversal",
             "multiline_values"
@@ -181,7 +179,9 @@
             {
               "enum": [
                 "comments", "empty_keys",
-                "multiline_continuation", "multiline_keys", "unicode", "whitespace"
+                "multiline_continuation", "multiline_keys", "unicode", "whitespace",
+                "tab_in_value_preserved", "continuation_tab_to_space",
+                "toplevel_indent_strip"
               ]
             },
             {

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -152,6 +152,7 @@
             "boolean_strict", "boolean_lenient",
             "crlf_preserve_literal", "crlf_normalize_to_lf",
             "indent_spaces", "indent_tabs",
+            "continuation_tab_to_space", "continuation_tab_preserve",
             "list_coercion_enabled", "list_coercion_disabled",
             "array_order_insertion", "array_order_lexicographic",
             "delimiter_first_equals", "delimiter_prefer_spaced",
@@ -180,7 +181,7 @@
               "enum": [
                 "comments", "empty_keys",
                 "multiline_continuation", "multiline_keys", "unicode", "whitespace",
-                "tab_in_value_preserved", "continuation_tab_to_space",
+                "tab_in_value_preserved",
                 "toplevel_indent_strip"
               ]
             },

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -43,26 +43,10 @@
             "mutuallyExclusiveWith": { "const": ["crlf_normalize_to_lf"] }
           }
         },
-        "tabs_as_content": {
-          "type": "object",
-          "properties": {
-            "description": { "const": "Treat tab characters as content, not whitespace. Tabs in values are preserved literally." },
-            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy", "get_string", "canonical_format"] },
-            "mutuallyExclusiveWith": { "const": ["tabs_as_whitespace"] }
-          }
-        },
-        "tabs_as_whitespace": {
-          "type": "object",
-          "properties": {
-            "description": { "const": "Treat tab characters as whitespace for indentation purposes." },
-            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy", "canonical_format"] },
-            "mutuallyExclusiveWith": { "const": ["tabs_as_content"] }
-          }
-        },
         "indent_spaces": {
           "type": "object",
           "properties": {
-            "description": { "const": "Use spaces for indentation in formatted output." },
+            "description": { "const": "Use spaces for indentation in formatted output (canonical_format emits 2 spaces per nesting level per OCaml reference)." },
             "affectedFunctions": { "const": ["canonical_format", "print", "round_trip"] },
             "mutuallyExclusiveWith": { "const": ["indent_tabs"] }
           }
@@ -107,22 +91,6 @@
             "mutuallyExclusiveWith": { "const": ["array_order_insertion"] }
           }
         },
-        "toplevel_indent_strip": {
-          "type": "object",
-          "properties": {
-            "description": { "const": "Strip common leading indentation from top-level values (like Python's textwrap.dedent)." },
-            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy"] },
-            "mutuallyExclusiveWith": { "const": ["toplevel_indent_preserve"] }
-          }
-        },
-        "toplevel_indent_preserve": {
-          "type": "object",
-          "properties": {
-            "description": { "const": "Preserve indentation of top-level values exactly as written." },
-            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy"] },
-            "mutuallyExclusiveWith": { "const": ["toplevel_indent_strip"] }
-          }
-        },
         "delimiter_first_equals": {
           "type": "object",
           "properties": {
@@ -146,11 +114,9 @@
       "enum": [
         "boolean_strict", "boolean_lenient",
         "crlf_preserve_literal", "crlf_normalize_to_lf",
-        "tabs_as_content", "tabs_as_whitespace",
         "indent_spaces", "indent_tabs",
         "list_coercion_enabled", "list_coercion_disabled",
         "array_order_insertion", "array_order_lexicographic",
-        "toplevel_indent_strip", "toplevel_indent_preserve",
         "delimiter_first_equals", "delimiter_prefer_spaced",
         "path_traversal",
         "multiline_values"
@@ -169,7 +135,17 @@
       "type": "string",
       "oneOf": [
         {
-          "enum": ["comments", "empty_keys", "multiline_continuation", "multiline_keys", "unicode", "whitespace"]
+          "enum": [
+            "comments",
+            "empty_keys",
+            "multiline_continuation",
+            "multiline_keys",
+            "unicode",
+            "whitespace",
+            "tab_in_value_preserved",
+            "continuation_tab_to_space",
+            "toplevel_indent_strip"
+          ]
         },
         { "pattern": "^experimental_" },
         { "pattern": "^optional_" }
@@ -371,18 +347,8 @@
         "affectedFunctions": ["parse", "parse_indented", "build_hierarchy", "filter", "canonical_format", "load", "round_trip"],
         "mutuallyExclusiveWith": ["crlf_normalize_to_lf"]
       },
-      "tabs_as_content": {
-        "description": "Treat tab characters as content, not whitespace. Tabs in values are preserved literally.",
-        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy", "get_string", "canonical_format"],
-        "mutuallyExclusiveWith": ["tabs_as_whitespace"]
-      },
-      "tabs_as_whitespace": {
-        "description": "Treat tab characters as whitespace for indentation purposes.",
-        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy", "canonical_format"],
-        "mutuallyExclusiveWith": ["tabs_as_content"]
-      },
       "indent_spaces": {
-        "description": "Use spaces for indentation in formatted output.",
+        "description": "Use spaces for indentation in formatted output (canonical_format emits 2 spaces per nesting level per OCaml reference).",
         "affectedFunctions": ["canonical_format", "print", "round_trip"],
         "mutuallyExclusiveWith": ["indent_tabs"]
       },
@@ -410,16 +376,6 @@
         "description": "Arrays/lists are sorted lexicographically when building hierarchy.",
         "affectedFunctions": ["build_hierarchy", "get_list"],
         "mutuallyExclusiveWith": ["array_order_insertion"]
-      },
-      "toplevel_indent_strip": {
-        "description": "Strip common leading indentation from top-level values (like Python's textwrap.dedent).",
-        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy"],
-        "mutuallyExclusiveWith": ["toplevel_indent_preserve"]
-      },
-      "toplevel_indent_preserve": {
-        "description": "Preserve indentation of top-level values exactly as written.",
-        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy"],
-        "mutuallyExclusiveWith": ["toplevel_indent_strip"]
       },
       "delimiter_first_equals": {
         "description": "Always split on the first '=' character. Keys cannot contain '='.",

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -59,6 +59,22 @@
             "mutuallyExclusiveWith": { "const": ["indent_spaces"] }
           }
         },
+        "continuation_tab_to_space": {
+          "type": "object",
+          "properties": {
+            "description": { "const": "During parse, normalize leading tabs on multiline continuation lines 1:1 to spaces (OCaml reference). Each leading '\\t' becomes a single space." },
+            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy"] },
+            "mutuallyExclusiveWith": { "const": ["continuation_tab_preserve"] }
+          }
+        },
+        "continuation_tab_preserve": {
+          "type": "object",
+          "properties": {
+            "description": { "const": "During parse, preserve leading tabs on multiline continuation lines verbatim. Alternative to the OCaml 1:1 tab-to-space normalization." },
+            "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy"] },
+            "mutuallyExclusiveWith": { "const": ["continuation_tab_to_space"] }
+          }
+        },
         "list_coercion_enabled": {
           "type": "object",
           "properties": {
@@ -115,6 +131,7 @@
         "boolean_strict", "boolean_lenient",
         "crlf_preserve_literal", "crlf_normalize_to_lf",
         "indent_spaces", "indent_tabs",
+        "continuation_tab_to_space", "continuation_tab_preserve",
         "list_coercion_enabled", "list_coercion_disabled",
         "array_order_insertion", "array_order_lexicographic",
         "delimiter_first_equals", "delimiter_prefer_spaced",
@@ -143,7 +160,6 @@
             "unicode",
             "whitespace",
             "tab_in_value_preserved",
-            "continuation_tab_to_space",
             "toplevel_indent_strip"
           ]
         },
@@ -356,6 +372,16 @@
         "description": "Use tabs for indentation in formatted output.",
         "affectedFunctions": ["canonical_format", "print", "round_trip"],
         "mutuallyExclusiveWith": ["indent_spaces"]
+      },
+      "continuation_tab_to_space": {
+        "description": "During parse, normalize leading tabs on multiline continuation lines 1:1 to spaces (OCaml reference). Each leading '\\t' becomes a single space.",
+        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy"],
+        "mutuallyExclusiveWith": ["continuation_tab_preserve"]
+      },
+      "continuation_tab_preserve": {
+        "description": "During parse, preserve leading tabs on multiline continuation lines verbatim. Alternative to the OCaml 1:1 tab-to-space normalization.",
+        "affectedFunctions": ["parse", "parse_indented", "build_hierarchy"],
+        "mutuallyExclusiveWith": ["continuation_tab_to_space"]
       },
       "list_coercion_enabled": {
         "description": "Single values are coerced to single-element lists when accessed via get_list.",

--- a/source_tests/core/api_core_ccl_parsing.json
+++ b/source_tests/core/api_core_ccl_parsing.json
@@ -213,9 +213,7 @@
         }
       ],
       "features": [
-        "whitespace"
-      ],
-      "behaviors": [
+        "whitespace",
         "toplevel_indent_strip"
       ],
       "variants": [
@@ -247,33 +245,6 @@
       ],
       "inputs": [
         "  key1 = value1\nkey2 = value2"
-      ]
-    },
-    {
-      "name": "leading_whitespace_toplevel_indent_preserve",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "value"
-            },
-            {
-              "key": "second",
-              "value": "entry"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "behaviors": [
-        "toplevel_indent_preserve"
-      ],
-      "inputs": [
-        "  key = value\n  second = entry"
       ]
     }
   ]

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -296,29 +296,6 @@
       ]
     },
     {
-      "name": "key_with_tabs",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "\tvalue"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "inputs": [
-        "\tkey\t=\tvalue"
-      ]
-    },
-    {
       "name": "key_with_tabs_ocaml_reference",
       "tests": [
         {
@@ -333,9 +310,6 @@
       ],
       "features": [
         "whitespace"
-      ],
-      "behaviors": [
-        "tabs_as_whitespace"
       ],
       "variants": [
         "reference_compliant"
@@ -363,52 +337,6 @@
       ],
       "inputs": [
         "onlyspaces =     "
-      ]
-    },
-    {
-      "name": "spaces_vs_tabs_continuation",
-      "tests": [
-        {
-          "function": "parse_indented",
-          "expect": [
-            {
-              "key": "text",
-              "value": "First\n   four spaces\n\ttab preserved"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
-      ]
-    },
-    {
-      "name": "spaces_vs_tabs_continuation_ocaml_reference",
-      "tests": [
-        {
-          "function": "parse_indented",
-          "expect": [
-            {
-              "key": "text",
-              "value": "First\n   four spaces\n\ttab preserved"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "inputs": [
-        "text = First\n    four spaces\n \ttab preserved"
       ]
     },
     {

--- a/source_tests/core/api_reference_compliant.json
+++ b/source_tests/core/api_reference_compliant.json
@@ -587,22 +587,6 @@
       ]
     },
     {
-      "name": "canonical_format_tab_preservation_ocaml_reference",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "value_with_tabs =\n  text\t\twith\ttabs =\n"
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content",
-        "indent_spaces"
-      ],
-      "inputs": [
-        "value_with_tabs = text\t\twith\ttabs\t"
-      ]
-    },
-    {
       "name": "canonical_format_unicode_ocaml_reference",
       "tests": [
         {

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -2,72 +2,6 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
-      "name": "tabs_as_content_in_value",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "\tvalue\twith\ttabs"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "key": "\tvalue\twith\ttabs"
-          }
-        },
-        {
-          "function": "get_string",
-          "args": [
-            "key"
-          ],
-          "expect": "\tvalue\twith\ttabs"
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ]
-    },
-    {
-      "name": "tabs_as_content_leading_tab",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "\tindented"
-            }
-          ]
-        },
-        {
-          "function": "get_string",
-          "args": [
-            "key"
-          ],
-          "expect": "\tindented"
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ]
-    },
-    {
       "name": "tabs_as_whitespace_in_value",
       "tests": [
         {
@@ -93,11 +27,9 @@
           "expect": "value\twith\ttabs"
         }
       ],
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "inputs": [
         "key = \tvalue\twith\ttabs"
@@ -123,9 +55,6 @@
           "expect": "indented"
         }
       ],
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
       "features": [
         "whitespace"
       ],
@@ -146,39 +75,11 @@
           ]
         }
       ],
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
       "features": [
         "whitespace"
       ],
       "inputs": [
         "key = \t\t\tthree_tabs"
-      ]
-    },
-    {
-      "name": "tabs_as_content_multiline",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "section",
-              "value": "\n \tindented_with_tabs\n \tanother_line"
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content",
-        "multiline_values"
-      ],
-      "features": [
-        "whitespace",
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "section =\n \tindented_with_tabs\n \tanother_line"
       ]
     },
     {
@@ -189,18 +90,18 @@
           "expect": [
             {
               "key": "section",
-              "value": "\nindented_with_tabs\nanother_line"
+              "value": "\n  indented_with_tabs\n  another_line"
             }
           ]
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace",
         "multiline_values"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "inputs": [
         "section =\n\t\tindented_with_tabs\n\t\tanother_line"
@@ -214,39 +115,21 @@
           "expect": [
             {
               "key": "section",
-              "value": "\nmixed_indent\nanother_line"
+              "value": "\n  mixed_indent\n  another_line"
             }
           ]
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace",
         "multiline_values"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "inputs": [
         "section =\n \tmixed_indent\n\t another_line"
-      ]
-    },
-    {
-      "name": "tabs_canonical_format_as_content",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "key = \tvalue"
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = \tvalue"
       ]
     },
     {
@@ -256,9 +139,6 @@
           "function": "canonical_format",
           "expect": "key = value"
         }
-      ],
-      "behaviors": [
-        "tabs_as_whitespace"
       ],
       "features": [
         "whitespace"
@@ -276,13 +156,13 @@
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace",
         "indent_spaces",
         "multiline_values"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -296,11 +176,9 @@
           "expect": "key = value\twith\ttabs"
         }
       ],
-      "behaviors": [
-        "tabs_as_whitespace"
-      ],
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "inputs": [
         "key = \tvalue\twith\ttabs"
@@ -458,13 +336,13 @@
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace",
         "indent_tabs",
         "multiline_values"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation"
+        "multiline_continuation",
+        "continuation_tab_to_space"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -735,7 +613,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": []
         }
       ],
@@ -764,7 +646,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": []
         }
       ],
@@ -805,7 +691,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": [
             {
               "key": "host",
@@ -866,7 +756,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": [
             {
               "key": "host",
@@ -923,7 +817,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": []
         }
       ],
@@ -960,7 +858,11 @@
         },
         {
           "function": "filter",
-          "predicate": { "field": "key", "op": "!=", "value": "/" },
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          },
           "expect": []
         }
       ],
@@ -983,48 +885,20 @@
           "expect": [
             {
               "key": "key",
-              "value": "value with tabs"
+              "value": "value\twith\ttabs"
             }
           ]
         }
       ],
       "behaviors": [
-        "tabs_as_whitespace",
         "crlf_normalize_to_lf"
       ],
       "features": [
-        "whitespace"
+        "whitespace",
+        "tab_in_value_preserved"
       ],
       "inputs": [
         "key = \tvalue\twith\ttabs\r\n"
-      ]
-    },
-    {
-      "name": "behavior_combo_content_tabs_crlf",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key1",
-              "value": "\tvalue1"
-            },
-            {
-              "key": "key2",
-              "value": "\tvalue2"
-            }
-          ]
-        }
-      ],
-      "behaviors": [
-        "tabs_as_content",
-        "crlf_normalize_to_lf"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key1 = \tvalue1\r\nkey2 = \tvalue2\r\n"
       ]
     }
   ]

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -96,12 +96,12 @@
         }
       ],
       "behaviors": [
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented_with_tabs\n\t\tanother_line"
@@ -121,12 +121,12 @@
         }
       ],
       "behaviors": [
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n \tmixed_indent\n\t another_line"
@@ -157,12 +157,12 @@
       ],
       "behaviors": [
         "indent_spaces",
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
@@ -337,12 +337,12 @@
       ],
       "behaviors": [
         "indent_tabs",
-        "multiline_values"
+        "multiline_values",
+        "continuation_tab_to_space"
       ],
       "features": [
         "whitespace",
-        "multiline_continuation",
-        "continuation_tab_to_space"
+        "multiline_continuation"
       ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"

--- a/source_tests/core/property_round_trip.json
+++ b/source_tests/core/property_round_trip.json
@@ -48,44 +48,11 @@
         }
       ],
       "features": [
-        "whitespace"
-      ],
-      "behaviors": [
+        "whitespace",
         "toplevel_indent_strip"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "  key  =  value  \n  nested  = \n    sub  =  val  "
-      ]
-    },
-    {
-      "name": "round_trip_whitespace_normalization_toplevel_indent_preserve",
-      "tests": [
-        {
-          "function": "round_trip",
-          "expect": true
-        },
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "value"
-            },
-            {
-              "key": "nested",
-              "value": "\n    sub  =  val"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "behaviors": [
-        "toplevel_indent_preserve"
       ],
       "inputs": [
         "  key  =  value  \n  nested  = \n    sub  =  val  "

--- a/types/structured.go
+++ b/types/structured.go
@@ -127,9 +127,8 @@ const (
 	FeatureExperimentalDottedKeys Feature = "experimental_dotted_keys"
 	FeatureUnicode                Feature = "unicode"
 	FeatureWhitespace             Feature = "whitespace"
-	FeatureTabInValuePreserved    Feature = "tab_in_value_preserved"
-	FeatureContinuationTabToSpace Feature = "continuation_tab_to_space"
-	FeatureToplevelIndentStrip    Feature = "toplevel_indent_strip"
+	FeatureTabInValuePreserved Feature = "tab_in_value_preserved"
+	FeatureToplevelIndentStrip Feature = "toplevel_indent_strip"
 )
 
 // Variant represents specification variants

--- a/types/structured.go
+++ b/types/structured.go
@@ -114,10 +114,6 @@ const (
 	BehaviorBooleanLenient       Behavior = "boolean_lenient"
 	BehaviorCrlfPreserveLiteral  Behavior = "crlf_preserve_literal"
 	BehaviorCrlfNormalizeToLf    Behavior = "crlf_normalize_to_lf"
-	BehaviorTabsAsContent        Behavior = "tabs_as_content"
-	BehaviorTabsAsWhitespace     Behavior = "tabs_as_whitespace"
-	BehaviorIndentSpaces         Behavior = "indent_spaces"
-	BehaviorIndentTabs           Behavior = "indent_tabs"
 	BehaviorListCoercionEnabled  Behavior = "list_coercion_enabled"
 	BehaviorListCoercionDisabled Behavior = "list_coercion_disabled"
 )
@@ -126,11 +122,14 @@ const (
 type Feature string
 
 const (
-	FeatureComments               Feature = "comments"
-	FeatureEmptyKeys              Feature = "empty_keys"
-	FeatureExperimentalDottedKeys Feature = "experimental_dotted_keys"
-	FeatureUnicode                Feature = "unicode"
-	FeatureWhitespace             Feature = "whitespace"
+	FeatureComments                 Feature = "comments"
+	FeatureEmptyKeys                Feature = "empty_keys"
+	FeatureExperimentalDottedKeys   Feature = "experimental_dotted_keys"
+	FeatureUnicode                  Feature = "unicode"
+	FeatureWhitespace               Feature = "whitespace"
+	FeatureTabInValuePreserved    Feature = "tab_in_value_preserved"
+	FeatureContinuationTabToSpace Feature = "continuation_tab_to_space"
+	FeatureToplevelIndentStrip    Feature = "toplevel_indent_strip"
 )
 
 // Variant represents specification variants

--- a/types/structured.go
+++ b/types/structured.go
@@ -122,11 +122,11 @@ const (
 type Feature string
 
 const (
-	FeatureComments                 Feature = "comments"
-	FeatureEmptyKeys                Feature = "empty_keys"
-	FeatureExperimentalDottedKeys   Feature = "experimental_dotted_keys"
-	FeatureUnicode                  Feature = "unicode"
-	FeatureWhitespace               Feature = "whitespace"
+	FeatureComments               Feature = "comments"
+	FeatureEmptyKeys              Feature = "empty_keys"
+	FeatureExperimentalDottedKeys Feature = "experimental_dotted_keys"
+	FeatureUnicode                Feature = "unicode"
+	FeatureWhitespace             Feature = "whitespace"
 	FeatureTabInValuePreserved    Feature = "tab_in_value_preserved"
 	FeatureContinuationTabToSpace Feature = "continuation_tab_to_space"
 	FeatureToplevelIndentStrip    Feature = "toplevel_indent_strip"


### PR DESCRIPTION
Refactors the tab/indent flag taxonomy to OCaml-canonical semantics. Closes #122, addresses #129.

## Taxonomy changes

**Removed behaviors** (non-OCaml alternatives):
- `tabs_as_content`, `tabs_as_whitespace`, `toplevel_indent_preserve`
- `toplevel_indent_strip` (reclassified as a feature)

**Retained behaviors** (genuine implementation choice):
- `indent_spaces` / `indent_tabs` — canonical_format output style

**New features** (always-on OCaml rules that tests annotate):
- `tab_in_value_preserved`
- `continuation_tab_to_space`
- `toplevel_indent_strip`

## Expected-value corrections (#122)
- `behavior_combo_tabs_and_crlf`: tabs preserved inside values
- `tabs_as_whitespace_multiline` / `_mixed_indent`: continuation tabs normalized to 2 spaces

## Implementation
- `internal/mock/ccl.go::Parse()`: continuation-line leading tabs now normalize 1:1 to spaces, matching OCaml.
- Schemas, Go config (`config/`, `internal/config/`), and docs updated to the new vocabulary.
- Source fixtures: 11 deleted, 13 retagged, 3 expected-value fixes. Generated tests: 919 → 904.

## Breaking change
Behavior names `tabs_as_content`, `tabs_as_whitespace`, `toplevel_indent_strip`, `toplevel_indent_preserve` are removed from the schema. Downstream fixtures tagged with these must migrate.

Closes #122
Addresses #129