### PR TITLE
fix(tests): build_hierarchy requires parse_indented

### DIFF
--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -39,6 +39,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -108,6 +109,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -181,6 +183,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -248,6 +251,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -322,6 +326,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -395,6 +400,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -473,6 +479,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_core_ccl_integration.json
+++ b/generated_tests/api_core_ccl_integration.json
@@ -39,6 +39,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -104,6 +105,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -181,6 +183,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -265,6 +268,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -349,6 +353,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -428,6 +433,7 @@
         "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -535,6 +541,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -971,6 +971,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1041,6 +1042,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1111,6 +1113,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1157,6 +1160,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1203,6 +1207,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1249,6 +1254,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1295,6 +1301,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1341,6 +1348,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1387,6 +1395,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1434,6 +1443,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1480,6 +1490,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1523,6 +1534,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1566,6 +1578,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1609,6 +1622,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1652,6 +1666,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1695,6 +1710,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1762,6 +1778,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1832,6 +1849,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1880,6 +1898,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1953,6 +1972,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2029,6 +2049,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2105,6 +2126,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2173,6 +2195,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2237,6 +2260,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2280,6 +2304,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2323,6 +2348,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2390,6 +2416,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2467,6 +2494,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2550,6 +2578,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2607,6 +2636,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2664,6 +2694,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2721,6 +2752,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2778,6 +2810,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2835,6 +2868,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2892,6 +2926,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2935,6 +2970,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_fuzz_special_chars_seed1.json
+++ b/generated_tests/api_fuzz_special_chars_seed1.json
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -913,6 +914,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -983,6 +985,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1053,6 +1056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1123,6 +1127,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1198,6 +1203,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1273,6 +1279,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1348,6 +1355,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1423,6 +1431,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1498,6 +1507,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1573,6 +1583,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1648,6 +1659,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1723,6 +1735,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1798,6 +1811,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1873,6 +1887,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_fuzz_special_chars_seed42.json
+++ b/generated_tests/api_fuzz_special_chars_seed42.json
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -913,6 +914,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -983,6 +985,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1053,6 +1056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1123,6 +1127,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1198,6 +1203,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1273,6 +1279,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1348,6 +1355,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1423,6 +1431,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1498,6 +1507,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1573,6 +1583,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1648,6 +1659,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1723,6 +1735,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1798,6 +1811,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1873,6 +1887,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_fuzz_special_chars_seed49.json
+++ b/generated_tests/api_fuzz_special_chars_seed49.json
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -913,6 +914,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -983,6 +985,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1053,6 +1056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1123,6 +1127,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1198,6 +1203,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1273,6 +1279,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1348,6 +1355,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1423,6 +1431,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1498,6 +1507,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1573,6 +1583,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1648,6 +1659,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1723,6 +1735,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1798,6 +1811,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1873,6 +1887,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_fuzz_special_chars_seed99.json
+++ b/generated_tests/api_fuzz_special_chars_seed99.json
@@ -843,6 +843,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -913,6 +914,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -983,6 +985,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1053,6 +1056,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1123,6 +1127,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1198,6 +1203,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1273,6 +1279,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1348,6 +1355,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1423,6 +1431,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1498,6 +1507,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1573,6 +1583,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1648,6 +1659,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1723,6 +1735,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1798,6 +1811,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1873,6 +1887,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -46,6 +46,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -218,6 +219,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -345,6 +347,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -459,6 +462,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -538,6 +542,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -603,6 +608,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -667,6 +673,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -723,6 +730,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -796,6 +804,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -885,6 +894,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -983,6 +993,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1082,6 +1093,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1180,6 +1192,7 @@
         "comments"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1281,6 +1294,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1385,6 +1399,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1479,6 +1494,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1553,6 +1569,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1640,6 +1657,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1726,6 +1744,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1810,6 +1829,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1872,6 +1892,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1935,6 +1956,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -116,6 +116,7 @@
         "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -220,6 +221,7 @@
         "empty_keys"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -263,6 +265,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -355,6 +358,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -436,6 +440,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -518,6 +523,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -617,6 +623,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -719,6 +726,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -825,6 +833,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -933,6 +942,7 @@
         "unicode"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1037,6 +1047,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1146,6 +1157,7 @@
         "multiline_continuation"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1290,6 +1302,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1368,6 +1381,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1441,6 +1455,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -36,6 +36,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -129,6 +130,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -209,6 +211,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -287,6 +290,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -378,6 +382,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -474,6 +479,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -576,6 +582,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -679,6 +686,7 @@
         "unicode"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -772,6 +780,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -846,6 +855,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -921,6 +931,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -997,6 +1008,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_typed_access.json
+++ b/generated_tests/api_typed_access.json
@@ -38,6 +38,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -108,6 +109,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -178,6 +180,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -257,6 +260,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -334,6 +338,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -410,6 +415,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -485,6 +491,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -553,6 +560,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -635,6 +643,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -773,6 +782,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -928,6 +938,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1058,6 +1069,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1177,6 +1189,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1343,6 +1356,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1496,6 +1510,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1606,6 +1621,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1699,6 +1715,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1768,6 +1785,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1837,6 +1855,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1909,6 +1928,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2267,6 +2287,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2440,6 +2461,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2544,6 +2566,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2624,6 +2647,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2702,6 +2726,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2782,6 +2807,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2860,6 +2886,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -2948,6 +2975,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -3030,6 +3058,7 @@
       },
       "features": [],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -3106,6 +3135,7 @@
         "optional_typed_accessors"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -40,6 +40,7 @@
         "tab_in_value_preserved"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -680,6 +681,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -746,6 +748,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -918,6 +921,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -982,6 +986,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1234,6 +1239,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [
@@ -1356,6 +1362,7 @@
         "whitespace"
       ],
       "functions": [
+        "parse_indented",
         "build_hierarchy"
       ],
       "inputs": [

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -277,9 +277,14 @@ func (fg *FlatGenerator) TransformSourceToFlat(sourceTest types.TestCase) ([]typ
 
 // compositeFunctionMap defines validations that require multiple underlying functions.
 // For example, round_trip validation requires both parse and print functions.
+//
+// build_hierarchy depends on parse_indented (not parse) because parse rejects lines
+// without `=` delimiters, while parse_indented handles the indentation-based nesting
+// that build_hierarchy needs to construct its input entries. See issue #114.
 var compositeFunctionMap = map[string][]string{
 	"round_trip":          {"parse", "print"},
-	"load":                {"parse", "build_hierarchy"},
+	"build_hierarchy":     {"parse_indented", "build_hierarchy"},
+	"load":                {"parse_indented", "build_hierarchy"},
 	"canonical_format":    {"parse", "print", "canonical_format"},
 	"compose_associative": {"parse", "compose"},
 	"identity_left":       {"parse", "compose"},

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -37,7 +37,7 @@ age = 42`
 }
 
 
-// basic_object_construction_build_hierarchy - function:build_hierarchy
+// basic_object_construction_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBasicObjectConstructionBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -76,7 +76,7 @@ func TestDeepNestedObjectsParse(t *testing.T) {
 }
 
 
-// deep_nested_objects_build_hierarchy - function:build_hierarchy
+// deep_nested_objects_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDeepNestedObjectsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -112,7 +112,7 @@ item = third`
 }
 
 
-// duplicate_keys_to_lists_build_hierarchy - function:build_hierarchy
+// duplicate_keys_to_lists_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDuplicateKeysToListsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -149,7 +149,7 @@ func TestNestedDuplicateKeysParse(t *testing.T) {
 }
 
 
-// nested_duplicate_keys_build_hierarchy - function:build_hierarchy
+// nested_duplicate_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestNestedDuplicateKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -187,7 +187,7 @@ version = 1.0`
 }
 
 
-// mixed_flat_and_nested_build_hierarchy - function:build_hierarchy
+// mixed_flat_and_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestMixedFlatAndNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -228,7 +228,7 @@ func TestNestedObjectsWithListsParse(t *testing.T) {
 }
 
 
-// nested_objects_with_lists_build_hierarchy - function:build_hierarchy
+// nested_objects_with_lists_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestNestedObjectsWithListsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -267,7 +267,7 @@ func TestDeeplyNestedListParse(t *testing.T) {
 }
 
 
-// deeply_nested_list_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// deeply_nested_list_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -37,7 +37,7 @@ age = 42`
 }
 
 
-// complete_basic_workflow_build_hierarchy - function:build_hierarchy
+// complete_basic_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestCompleteBasicWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -74,7 +74,7 @@ func TestCompleteNestedWorkflowParse(t *testing.T) {
 }
 
 
-// complete_nested_workflow_build_hierarchy - function:build_hierarchy
+// complete_nested_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestCompleteNestedWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -114,7 +114,7 @@ config =
 }
 
 
-// complete_mixed_workflow_build_hierarchy - function:build_hierarchy
+// complete_mixed_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestCompleteMixedWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -154,7 +154,7 @@ ports =
 }
 
 
-// complete_lists_workflow_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// complete_lists_workflow_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestCompleteListsWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -194,7 +194,7 @@ ports =
 }
 
 
-// complete_lists_workflow_lexicographic_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// complete_lists_workflow_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestCompleteListsWorkflowLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -234,7 +234,7 @@ config =
 }
 
 
-// complete_multiline_workflow_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:multiline_values
+// complete_multiline_workflow_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:multiline_values
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -288,7 +288,7 @@ features =
 }
 
 
-// real_world_complete_workflow_build_hierarchy - function:build_hierarchy
+// real_world_complete_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRealWorldCompleteWorkflowBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -790,7 +790,7 @@ user =
 }
 
 
-// ocaml_stress_test_original_build_hierarchy - function:build_hierarchy feature:comments feature:empty_keys
+// ocaml_stress_test_original_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -826,7 +826,7 @@ func TestForwardSlashesInMapKeysParse(t *testing.T) {
 }
 
 
-// forward_slashes_in_map_keys_build_hierarchy - function:build_hierarchy
+// forward_slashes_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestForwardSlashesInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -862,7 +862,7 @@ func TestBackslashesInMapKeysParse(t *testing.T) {
 }
 
 
-// backslashes_in_map_keys_build_hierarchy - function:build_hierarchy
+// backslashes_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBackslashesInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -892,7 +892,7 @@ func TestColonsInMapKeysParse(t *testing.T) {
 }
 
 
-// colons_in_map_keys_build_hierarchy - function:build_hierarchy
+// colons_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestColonsInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -922,7 +922,7 @@ func TestHyphensInMapKeysParse(t *testing.T) {
 }
 
 
-// hyphens_in_map_keys_build_hierarchy - function:build_hierarchy
+// hyphens_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestHyphensInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -952,7 +952,7 @@ func TestAtSignsInMapKeysParse(t *testing.T) {
 }
 
 
-// at_signs_in_map_keys_build_hierarchy - function:build_hierarchy
+// at_signs_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestAtSignsInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -982,7 +982,7 @@ func TestHashInMapKeysParse(t *testing.T) {
 }
 
 
-// hash_in_map_keys_build_hierarchy - function:build_hierarchy
+// hash_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestHashInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1012,7 +1012,7 @@ func TestBracketsInMapKeysParse(t *testing.T) {
 }
 
 
-// brackets_in_map_keys_build_hierarchy - function:build_hierarchy
+// brackets_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBracketsInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1042,7 +1042,7 @@ func TestParenthesesInMapKeysParse(t *testing.T) {
 }
 
 
-// parentheses_in_map_keys_build_hierarchy - function:build_hierarchy
+// parentheses_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParenthesesInMapKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1073,7 +1073,7 @@ func TestMixedSpecialCharsInKeysParse(t *testing.T) {
 }
 
 
-// mixed_special_chars_in_keys_build_hierarchy - function:build_hierarchy
+// mixed_special_chars_in_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestMixedSpecialCharsInKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1103,7 +1103,7 @@ func TestUrlLikeKeysParse(t *testing.T) {
 }
 
 
-// url_like_keys_build_hierarchy - function:build_hierarchy
+// url_like_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlLikeKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1131,7 +1131,7 @@ func TestRelativePathParentParentParse(t *testing.T) {
 }
 
 
-// relative_path_parent_parent_build_hierarchy - function:build_hierarchy
+// relative_path_parent_parent_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathParentParentBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1159,7 +1159,7 @@ func TestRelativePathParentParse(t *testing.T) {
 }
 
 
-// relative_path_parent_build_hierarchy - function:build_hierarchy
+// relative_path_parent_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathParentBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1187,7 +1187,7 @@ func TestRelativePathSingleDotParse(t *testing.T) {
 }
 
 
-// relative_path_single_dot_build_hierarchy - function:build_hierarchy
+// relative_path_single_dot_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathSingleDotBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1215,7 +1215,7 @@ func TestDoubleSlashParse(t *testing.T) {
 }
 
 
-// double_slash_build_hierarchy - function:build_hierarchy
+// double_slash_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDoubleSlashBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1243,7 +1243,7 @@ func TestRelativePathInValueParse(t *testing.T) {
 }
 
 
-// relative_path_in_value_build_hierarchy - function:build_hierarchy
+// relative_path_in_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathInValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1279,7 +1279,7 @@ func TestRelativePathInNestedValueParse(t *testing.T) {
 }
 
 
-// relative_path_in_nested_value_build_hierarchy - function:build_hierarchy
+// relative_path_in_nested_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathInNestedValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1315,7 +1315,7 @@ func TestDoubleSlashInNestedParse(t *testing.T) {
 }
 
 
-// double_slash_in_nested_build_hierarchy - function:build_hierarchy
+// double_slash_in_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDoubleSlashInNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1346,7 +1346,7 @@ func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 }
 
 
-// relative_paths_deeply_nested_build_hierarchy - function:build_hierarchy
+// relative_paths_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathsDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1383,7 +1383,7 @@ func TestRelativePathsAsNestedKeysParse(t *testing.T) {
 }
 
 
-// relative_paths_as_nested_keys_build_hierarchy - function:build_hierarchy
+// relative_paths_as_nested_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathsAsNestedKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1422,7 +1422,7 @@ func TestMixedRelativeAndAbsoluteNestedParse(t *testing.T) {
 }
 
 
-// mixed_relative_and_absolute_nested_build_hierarchy - function:build_hierarchy
+// mixed_relative_and_absolute_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestMixedRelativeAndAbsoluteNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1461,7 +1461,7 @@ func TestDoubleSlashDeeplyNestedParse(t *testing.T) {
 }
 
 
-// double_slash_deeply_nested_build_hierarchy - function:build_hierarchy
+// double_slash_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDoubleSlashDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1495,7 +1495,7 @@ func TestUrlAsKeyParse(t *testing.T) {
 }
 
 
-// url_as_key_build_hierarchy - function:build_hierarchy
+// url_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlAsKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1529,7 +1529,7 @@ func TestUrlWithPortAsKeyParse(t *testing.T) {
 }
 
 
-// url_with_port_as_key_build_hierarchy - function:build_hierarchy
+// url_with_port_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlWithPortAsKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1557,7 +1557,7 @@ func TestUrlWithPathAsKeyParse(t *testing.T) {
 }
 
 
-// url_with_path_as_key_build_hierarchy - function:build_hierarchy
+// url_with_path_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlWithPathAsKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1585,7 +1585,7 @@ func TestUrlInValueParse(t *testing.T) {
 }
 
 
-// url_in_value_build_hierarchy - function:build_hierarchy
+// url_in_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlInValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1621,7 +1621,7 @@ func TestUrlsAsNestedKeysAndValuesParse(t *testing.T) {
 }
 
 
-// urls_as_nested_keys_and_values_build_hierarchy - function:build_hierarchy
+// urls_as_nested_keys_and_values_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlsAsNestedKeysAndValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1661,7 +1661,7 @@ func TestUrlsDeeplyNestedParse(t *testing.T) {
 }
 
 
-// urls_deeply_nested_build_hierarchy - function:build_hierarchy
+// urls_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlsDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1679,7 +1679,7 @@ func TestUrlWithQueryParamsAsKeyParse(t *testing.T) {
 }
 
 
-// url_with_query_params_as_key_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
+// url_with_query_params_as_key_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestUrlWithQueryParamsAsKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1707,7 +1707,7 @@ func TestDelimiterFirstUrlWithQueryParamsParse(t *testing.T) {
 }
 
 
-// delimiter_first_url_with_query_params_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
+// delimiter_first_url_with_query_params_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstUrlWithQueryParamsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1735,7 +1735,7 @@ func TestDelimiterFirstMultipleEqualsParse(t *testing.T) {
 }
 
 
-// delimiter_first_multiple_equals_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
+// delimiter_first_multiple_equals_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstMultipleEqualsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1763,7 +1763,7 @@ func TestDelimiterFirstEmptyValueParse(t *testing.T) {
 }
 
 
-// delimiter_first_empty_value_build_hierarchy - function:build_hierarchy behavior:delimiter_first_equals
+// delimiter_first_empty_value_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstEmptyValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1775,7 +1775,7 @@ func TestDelimiterSpacedMultipleEqualsParse(t *testing.T) {
 }
 
 
-// delimiter_spaced_multiple_equals_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
+// delimiter_spaced_multiple_equals_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedMultipleEqualsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1787,7 +1787,7 @@ func TestDelimiterSpacedFallbackNoSpaceParse(t *testing.T) {
 }
 
 
-// delimiter_spaced_fallback_no_space_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
+// delimiter_spaced_fallback_no_space_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedFallbackNoSpaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1799,7 +1799,7 @@ func TestDelimiterSpacedEmptyValueParse(t *testing.T) {
 }
 
 
-// delimiter_spaced_empty_value_build_hierarchy - function:build_hierarchy behavior:delimiter_prefer_spaced
+// delimiter_spaced_empty_value_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedEmptyValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1827,7 +1827,7 @@ func TestUrlWithFragmentAsKeyParse(t *testing.T) {
 }
 
 
-// url_with_fragment_as_key_build_hierarchy - function:build_hierarchy
+// url_with_fragment_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
@@ -806,7 +806,7 @@ func TestS1FuzzValName0Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_val_name_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_val_name_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -840,7 +840,7 @@ func TestS1FuzzValData1Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_val_data_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_val_data_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValData1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -874,7 +874,7 @@ func TestS1FuzzValMode2Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_val_mode_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_val_mode_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValMode2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -908,7 +908,7 @@ func TestS1FuzzValName3Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_val_name_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_val_name_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValName3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -942,7 +942,7 @@ func TestS1FuzzValUser4Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_val_user_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_val_user_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValUser4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -977,7 +977,7 @@ func TestS1FuzzNestedAmpersandRbrace0Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_ampersand_rbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_ampersand_rbrace_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1012,7 +1012,7 @@ func TestS1FuzzNestedQuestionRbracket1Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_question_rbracket_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_question_rbracket_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1047,7 +1047,7 @@ func TestS1FuzzNestedPlusSlash2Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_plus_slash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_plus_slash_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1082,7 +1082,7 @@ $port = deep486`
 }
 
 
-// s1_fuzz_nested_ampersand_dollar_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_ampersand_dollar_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1117,7 +1117,7 @@ func TestS1FuzzNestedTildeSquote4Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_tilde_squote_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_tilde_squote_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1152,7 +1152,7 @@ func TestS1FuzzNestedHyphenAmpersand5Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1187,7 +1187,7 @@ func TestS1FuzzNestedDollarAsterisk6Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_dollar_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_dollar_asterisk_6_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1222,7 +1222,7 @@ func TestS1FuzzNestedUnderscoreSemicolon7Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_underscore_semicolon_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_underscore_semicolon_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1257,7 +1257,7 @@ func TestS1FuzzNestedAtRparen8Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_at_rparen_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_at_rparen_8_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1292,7 +1292,7 @@ func TestS1FuzzNestedRbraceTilde9Parse(t *testing.T) {
 }
 
 
-// s1_fuzz_nested_rbrace_tilde_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s1_fuzz_nested_rbrace_tilde_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
@@ -806,7 +806,7 @@ func TestS42FuzzValData0Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_val_data_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_val_data_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValData0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -840,7 +840,7 @@ func TestS42FuzzValBeta1Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_val_beta_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_val_beta_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValBeta1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -874,7 +874,7 @@ func TestS42FuzzValName2Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_val_name_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -908,7 +908,7 @@ func TestS42FuzzValPath3Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_val_path_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValPath3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -942,7 +942,7 @@ func TestS42FuzzValName4Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_val_name_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_val_name_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -977,7 +977,7 @@ func TestS42FuzzNestedLbraceRbracket0Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_lbrace_rbracket_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_lbrace_rbracket_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1012,7 +1012,7 @@ func TestS42FuzzNestedLbraceRbrace1Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1047,7 +1047,7 @@ func TestS42FuzzNestedAmpersandPercent2Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_ampersand_percent_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_ampersand_percent_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1082,7 +1082,7 @@ func TestS42FuzzNestedDquoteGt3Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_dquote_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_dquote_gt_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1117,7 +1117,7 @@ $path = deep65`
 }
 
 
-// s42_fuzz_nested_percent_dollar_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_percent_dollar_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1152,7 +1152,7 @@ func TestS42FuzzNestedDquoteRbracket5Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_dquote_rbracket_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_dquote_rbracket_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1187,7 +1187,7 @@ func TestS42FuzzNestedLbraceAmpersand6Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_lbrace_ampersand_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_lbrace_ampersand_6_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1222,7 +1222,7 @@ func TestS42FuzzNestedSemicolonHyphen7Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1257,7 +1257,7 @@ func TestS42FuzzNestedLbraceRbrace8Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_lbrace_rbrace_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_lbrace_rbrace_8_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1292,7 +1292,7 @@ func TestS42FuzzNestedTildeAmpersand9Parse(t *testing.T) {
 }
 
 
-// s42_fuzz_nested_tilde_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s42_fuzz_nested_tilde_ampersand_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
@@ -806,7 +806,7 @@ func TestS49FuzzValEpsilon0Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_val_epsilon_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_val_epsilon_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -840,7 +840,7 @@ func TestS49FuzzValConfig1Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_val_config_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_val_config_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValConfig1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -874,7 +874,7 @@ func TestS49FuzzValName2Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_val_name_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_val_name_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValName2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -908,7 +908,7 @@ func TestS49FuzzValMode3Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_val_mode_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_val_mode_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValMode3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -942,7 +942,7 @@ func TestS49FuzzValServer4Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_val_server_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_val_server_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValServer4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -977,7 +977,7 @@ func TestS49FuzzNestedSquoteLbrace0Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_squote_lbrace_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_squote_lbrace_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1012,7 +1012,7 @@ _user = deep650`
 }
 
 
-// s49_fuzz_nested_at_underscore_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_at_underscore_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1047,7 +1047,7 @@ func TestS49FuzzNestedRparenBackslash2Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_rparen_backslash_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_rparen_backslash_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1082,7 +1082,7 @@ func TestS49FuzzNestedDollarGt3Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_dollar_gt_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_dollar_gt_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1117,7 +1117,7 @@ func TestS49FuzzNestedDquoteLbrace4Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_dquote_lbrace_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_dquote_lbrace_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1152,7 +1152,7 @@ func TestS49FuzzNestedSemicolonAsterisk5Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1187,7 +1187,7 @@ func TestS49FuzzNestedQuestionAsterisk6Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_question_asterisk_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_question_asterisk_6_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1222,7 +1222,7 @@ func TestS49FuzzNestedPlusAmpersand7Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_plus_ampersand_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_plus_ampersand_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1257,7 +1257,7 @@ func TestS49FuzzNestedAsteriskDquote8Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_asterisk_dquote_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_asterisk_dquote_8_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1292,7 +1292,7 @@ func TestS49FuzzNestedRbraceSlash9Parse(t *testing.T) {
 }
 
 
-// s49_fuzz_nested_rbrace_slash_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s49_fuzz_nested_rbrace_slash_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
@@ -806,7 +806,7 @@ func TestS99FuzzValPath0Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_val_path_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_val_path_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -840,7 +840,7 @@ func TestS99FuzzValItem1Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_val_item_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_val_item_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValItem1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -874,7 +874,7 @@ func TestS99FuzzValServer2Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_val_server_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_val_server_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValServer2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -908,7 +908,7 @@ func TestS99FuzzValPath3Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_val_path_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_val_path_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValPath3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -942,7 +942,7 @@ func TestS99FuzzValAlpha4Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_val_alpha_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_val_alpha_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValAlpha4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -977,7 +977,7 @@ func TestS99FuzzNestedSlashRparen0Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_slash_rparen_0_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_slash_rparen_0_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1012,7 +1012,7 @@ func TestS99FuzzNestedLtPercent1Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_lt_percent_1_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_lt_percent_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1047,7 +1047,7 @@ func TestS99FuzzNestedSlashLbrace2Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_slash_lbrace_2_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_slash_lbrace_2_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1082,7 +1082,7 @@ func TestS99FuzzNestedDquoteLbracket3Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_dquote_lbracket_3_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_dquote_lbracket_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1117,7 +1117,7 @@ func TestS99FuzzNestedBackslashBackslash4Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_backslash_backslash_4_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_backslash_backslash_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1152,7 +1152,7 @@ func TestS99FuzzNestedQuestionDquote5Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_question_dquote_5_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_question_dquote_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1187,7 +1187,7 @@ func TestS99FuzzNestedDquoteBackslash6Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_dquote_backslash_6_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_dquote_backslash_6_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1222,7 +1222,7 @@ func TestS99FuzzNestedRparenBackslash7Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_rparen_backslash_7_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_rparen_backslash_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1257,7 +1257,7 @@ $gamma = deep225`
 }
 
 
-// s99_fuzz_nested_rbrace_dollar_8_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_rbrace_dollar_8_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1292,7 +1292,7 @@ func TestS99FuzzNestedPercentAmpersand9Parse(t *testing.T) {
 }
 
 
-// s99_fuzz_nested_percent_ampersand_9_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// s99_fuzz_nested_percent_ampersand_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9BuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -38,7 +38,7 @@ servers = web3`
 }
 
 
-// basic_list_from_duplicates_build_hierarchy - function:build_hierarchy
+// basic_list_from_duplicates_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -91,7 +91,7 @@ items = item20`
 }
 
 
-// large_list_build_hierarchy - function:build_hierarchy
+// large_list_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestLargeListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -129,7 +129,7 @@ servers = web3
 }
 
 
-// list_with_comments_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_insertion
+// list_with_comments_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments behavior:array_order_insertion
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -167,7 +167,7 @@ servers = web3
 }
 
 
-// list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:comments behavior:array_order_lexicographic
+// list_with_comments_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -201,7 +201,7 @@ func TestListErrorMissingKeyParse(t *testing.T) {
 }
 
 
-// list_error_missing_key_build_hierarchy - function:build_hierarchy
+// list_error_missing_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListErrorMissingKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -236,7 +236,7 @@ func TestListErrorNestedMissingKeyParse(t *testing.T) {
 }
 
 
-// list_error_nested_missing_key_build_hierarchy - function:build_hierarchy
+// list_error_nested_missing_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListErrorNestedMissingKeyBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -270,7 +270,7 @@ func TestListErrorNonObjectPathParse(t *testing.T) {
 }
 
 
-// list_error_non_object_path_build_hierarchy - function:build_hierarchy
+// list_error_non_object_path_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListErrorNonObjectPathBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -304,7 +304,7 @@ func TestListEdgeCaseZeroLengthParse(t *testing.T) {
 }
 
 
-// list_edge_case_zero_length_build_hierarchy - function:build_hierarchy
+// list_edge_case_zero_length_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListEdgeCaseZeroLengthBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -341,7 +341,7 @@ func TestBareListBasicParse(t *testing.T) {
 }
 
 
-// bare_list_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListBasicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -379,7 +379,7 @@ func TestBareListNestedParse(t *testing.T) {
 }
 
 
-// bare_list_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
+// bare_list_nested_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -417,7 +417,7 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 }
 
 
-// bare_list_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
+// bare_list_nested_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -455,7 +455,7 @@ func TestBareListWithCommentsParse(t *testing.T) {
 }
 
 
-// bare_list_with_comments_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_insertion
+// bare_list_with_comments_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -493,7 +493,7 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
 }
 
 
-// bare_list_with_comments_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
+// bare_list_with_comments_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -533,7 +533,7 @@ func TestBareListDeeplyNestedParse(t *testing.T) {
 }
 
 
-// bare_list_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
+// bare_list_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -573,7 +573,7 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 }
 
 
-// bare_list_deeply_nested_lexicographic_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
+// bare_list_deeply_nested_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -612,7 +612,7 @@ func TestBareListMixedWithOtherKeysParse(t *testing.T) {
 }
 
 
-// bare_list_mixed_with_other_keys_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_mixed_with_other_keys_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -647,7 +647,7 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 }
 
 
-// bare_list_error_not_a_list_build_hierarchy - function:build_hierarchy
+// bare_list_error_not_a_list_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -687,7 +687,7 @@ func TestBareListNestedObjectsBasicParse(t *testing.T) {
 }
 
 
-// bare_list_nested_objects_basic_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_nested_objects_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsBasicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -724,7 +724,7 @@ func TestBareListNestedObjectsSingleItemParse(t *testing.T) {
 }
 
 
-// bare_list_nested_objects_single_item_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_nested_objects_single_item_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsSingleItemBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -762,7 +762,7 @@ func TestBareListNestedObjectsMinimalParse(t *testing.T) {
 }
 
 
-// bare_list_nested_objects_minimal_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_nested_objects_minimal_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsMinimalBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -798,7 +798,7 @@ func TestBareListNestedObjectsDeeplyNestedParse(t *testing.T) {
 }
 
 
-// bare_list_nested_objects_deeply_nested_build_hierarchy - function:build_hierarchy feature:empty_keys
+// bare_list_nested_objects_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListNestedObjectsDeeplyNestedBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -831,7 +831,7 @@ func TestBareListNestedObjectsMixedWithStringsParse(t *testing.T) {
 }
 
 
-// bare_list_nested_objects_mixed_with_strings_build_hierarchy - function:build_hierarchy feature:empty_keys behavior:array_order_insertion
+// bare_list_nested_objects_mixed_with_strings_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_insertion
 func TestBareListNestedObjectsMixedWithStringsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -32,7 +32,7 @@ func TestIndentedLineIsContinuationParseIndented(t *testing.T) {
 }
 
 
-// indented_line_is_continuation_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
+// indented_line_is_continuation_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
 func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -50,7 +50,7 @@ func TestMixedIndentationLevelsParseIndented(t *testing.T) {
 }
 
 
-// mixed_indentation_levels_build_hierarchy - function:build_hierarchy feature:multiline_continuation feature:empty_keys behavior:multiline_values
+// mixed_indentation_levels_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation feature:empty_keys behavior:multiline_values
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -78,7 +78,7 @@ func TestSingleItemAsListParse(t *testing.T) {
 }
 
 
-// single_item_as_list_build_hierarchy - function:build_hierarchy
+// single_item_as_list_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestSingleItemAsListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -114,7 +114,7 @@ host = localhost`
 }
 
 
-// mixed_duplicate_single_keys_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// mixed_duplicate_single_keys_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -151,7 +151,7 @@ func TestNestedListAccessParse(t *testing.T) {
 }
 
 
-// nested_list_access_build_hierarchy - function:build_hierarchy
+// nested_list_access_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestNestedListAccessBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -185,7 +185,7 @@ func TestEmptyListParse(t *testing.T) {
 }
 
 
-// empty_list_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// empty_list_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestEmptyListBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -222,7 +222,7 @@ numbers = 0`
 }
 
 
-// list_with_numbers_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// list_with_numbers_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestListWithNumbersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -259,7 +259,7 @@ flags = no`
 }
 
 
-// list_with_booleans_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// list_with_booleans_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -296,7 +296,7 @@ items =   `
 }
 
 
-// list_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace behavior:array_order_insertion
+// list_with_whitespace_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:array_order_insertion
 func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -333,7 +333,7 @@ names = العربية`
 }
 
 
-// list_with_unicode_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_insertion
+// list_with_unicode_build_hierarchy - function:parse_indented function:build_hierarchy feature:unicode behavior:array_order_insertion
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -370,7 +370,7 @@ symbols = <>=+`
 }
 
 
-// list_with_special_characters_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// list_with_special_characters_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -388,7 +388,7 @@ func TestListMultilineValuesParseIndented(t *testing.T) {
 }
 
 
-// list_multiline_values_build_hierarchy - function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
+// list_multiline_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:array_order_insertion behavior:multiline_values
 func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -406,7 +406,7 @@ func TestComplexMixedListScenariosParseIndented(t *testing.T) {
 }
 
 
-// complex_mixed_list_scenarios_build_hierarchy - function:build_hierarchy behavior:array_order_insertion
+// complex_mixed_list_scenarios_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -440,7 +440,7 @@ func TestListPathTraversalProtectionParse(t *testing.T) {
 }
 
 
-// list_path_traversal_protection_build_hierarchy - function:build_hierarchy
+// list_path_traversal_protection_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListPathTraversalProtectionBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -474,7 +474,7 @@ func TestParseEmptyValueParse(t *testing.T) {
 }
 
 
-// parse_empty_value_build_hierarchy - function:build_hierarchy
+// parse_empty_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParseEmptyValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -36,7 +36,7 @@ func TestSingleItemAsListReferenceParse(t *testing.T) {
 }
 
 
-// single_item_as_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// single_item_as_list_reference_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestSingleItemAsListReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -72,7 +72,7 @@ host = localhost`
 }
 
 
-// mixed_duplicate_single_keys_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// mixed_duplicate_single_keys_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -109,7 +109,7 @@ func TestNestedListAccessReferenceParse(t *testing.T) {
 }
 
 
-// nested_list_access_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// nested_list_access_reference_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -143,7 +143,7 @@ func TestEmptyListReferenceParse(t *testing.T) {
 }
 
 
-// empty_list_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// empty_list_reference_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestEmptyListReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -180,7 +180,7 @@ numbers = 0`
 }
 
 
-// list_with_numbers_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// list_with_numbers_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithNumbersReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -217,7 +217,7 @@ flags = no`
 }
 
 
-// list_with_booleans_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// list_with_booleans_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithBooleansReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -254,7 +254,7 @@ items =   `
 }
 
 
-// list_with_whitespace_reference_build_hierarchy - function:build_hierarchy feature:empty_keys feature:whitespace behavior:array_order_lexicographic
+// list_with_whitespace_reference_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:whitespace behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -291,7 +291,7 @@ names = العربية`
 }
 
 
-// list_with_unicode_reference_build_hierarchy - function:build_hierarchy feature:unicode behavior:array_order_lexicographic
+// list_with_unicode_reference_build_hierarchy - function:parse_indented function:build_hierarchy feature:unicode behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -327,7 +327,7 @@ symbols = []{}|`
 }
 
 
-// list_with_special_characters_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// list_with_special_characters_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -339,7 +339,7 @@ func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
 }
 
 
-// complex_mixed_list_scenarios_reference_build_hierarchy - function:build_hierarchy behavior:array_order_lexicographic
+// complex_mixed_list_scenarios_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -373,7 +373,7 @@ func TestListPathTraversalProtectionReferenceParse(t *testing.T) {
 }
 
 
-// list_path_traversal_protection_reference_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// list_path_traversal_protection_reference_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestListPathTraversalProtectionReferenceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -407,7 +407,7 @@ func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
 }
 
 
-// empty_value_reference_behavior_build_hierarchy - function:build_hierarchy variant:reference_compliant
+// empty_value_reference_behavior_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestEmptyValueReferenceBehaviorBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -36,7 +36,7 @@ func TestParseBasicIntegerParse(t *testing.T) {
 }
 
 
-// parse_basic_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_basic_integer_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicIntegerBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -70,7 +70,7 @@ func TestParseBasicFloatParse(t *testing.T) {
 }
 
 
-// parse_basic_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_basic_float_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicFloatBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -104,7 +104,7 @@ func TestParseBooleanTrueParse(t *testing.T) {
 }
 
 
-// parse_boolean_true_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_true_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanTrueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -138,7 +138,7 @@ func TestParseBooleanYesParse(t *testing.T) {
 }
 
 
-// parse_boolean_yes_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_yes_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -172,7 +172,7 @@ func TestParseBooleanYesStrictLiteralParse(t *testing.T) {
 }
 
 
-// parse_boolean_yes_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_yes_strict_literal_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesStrictLiteralBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -206,7 +206,7 @@ func TestParseBooleanFalseParse(t *testing.T) {
 }
 
 
-// parse_boolean_false_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_false_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanFalseBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -240,7 +240,7 @@ func TestParseStringFallbackParse(t *testing.T) {
 }
 
 
-// parse_string_fallback_build_hierarchy - function:build_hierarchy
+// parse_string_fallback_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParseStringFallbackBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -274,7 +274,7 @@ func TestParseNegativeIntegerParse(t *testing.T) {
 }
 
 
-// parse_negative_integer_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_negative_integer_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseNegativeIntegerBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -310,7 +310,7 @@ disabled = no`
 }
 
 
-// parse_zero_values_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
+// parse_zero_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -358,7 +358,7 @@ disabled = no`
 }
 
 
-// parse_zero_values_strict_literal_build_hierarchy - function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
+// parse_zero_values_strict_literal_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -410,7 +410,7 @@ flag7 = 0`
 }
 
 
-// parse_boolean_variants_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_variants_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -456,7 +456,7 @@ flag7 = 0`
 }
 
 
-// parse_boolean_variants_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_variants_strict_literal_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -500,7 +500,7 @@ debug = off`
 }
 
 
-// parse_mixed_types_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_mixed_types_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -556,7 +556,7 @@ debug = off`
 }
 
 
-// parse_mixed_types_strict_literal_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_mixed_types_strict_literal_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -609,7 +609,7 @@ flag =  true  `
 }
 
 
-// parse_with_whitespace_build_hierarchy - function:build_hierarchy feature:whitespace feature:optional_typed_accessors
+// parse_with_whitespace_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -652,7 +652,7 @@ text = hello`
 }
 
 
-// parse_with_conservative_options_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_with_conservative_options_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseWithConservativeOptionsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -692,7 +692,7 @@ func TestParseIntegerErrorParse(t *testing.T) {
 }
 
 
-// parse_integer_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_integer_error_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseIntegerErrorBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -726,7 +726,7 @@ func TestParseFloatErrorParse(t *testing.T) {
 }
 
 
-// parse_float_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_float_error_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseFloatErrorBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -760,7 +760,7 @@ func TestParseBooleanErrorParse(t *testing.T) {
 }
 
 
-// parse_boolean_error_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// parse_boolean_error_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanErrorBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -794,7 +794,7 @@ func TestParseMissingPathErrorParse(t *testing.T) {
 }
 
 
-// parse_missing_path_error_build_hierarchy - function:build_hierarchy
+// parse_missing_path_error_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -956,7 +956,7 @@ func TestBooleanWithWhitespaceGetBool(t *testing.T) {
 }
 
 
-// boolean_nested_object_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// boolean_nested_object_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1046,7 +1046,7 @@ func TestTypeMismatchGetFloatOnBoolGetFloat(t *testing.T) {
 }
 
 
-// type_mismatch_nested_path_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// type_mismatch_nested_path_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1104,7 +1104,7 @@ func TestNestedGetIntParse(t *testing.T) {
 }
 
 
-// nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// nested_get_int_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedGetIntBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1142,7 +1142,7 @@ func TestDeeplyNestedGetIntParse(t *testing.T) {
 }
 
 
-// deeply_nested_get_int_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// deeply_nested_get_int_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestDeeplyNestedGetIntBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1178,7 +1178,7 @@ func TestNestedGetFloatParse(t *testing.T) {
 }
 
 
-// nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// nested_get_float_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedGetFloatBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1216,7 +1216,7 @@ func TestDeeplyNestedGetFloatParse(t *testing.T) {
 }
 
 
-// deeply_nested_get_float_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// deeply_nested_get_float_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestDeeplyNestedGetFloatBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1252,7 +1252,7 @@ func TestNestedGetBoolParse(t *testing.T) {
 }
 
 
-// nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// nested_get_bool_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedGetBoolBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1290,7 +1290,7 @@ func TestDeeplyNestedGetBoolParse(t *testing.T) {
 }
 
 
-// deeply_nested_get_bool_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// deeply_nested_get_bool_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestDeeplyNestedGetBoolBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1326,7 +1326,7 @@ func TestNestedGetStringBasicParse(t *testing.T) {
 }
 
 
-// nested_get_string_basic_build_hierarchy - function:build_hierarchy
+// nested_get_string_basic_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestNestedGetStringBasicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -1364,7 +1364,7 @@ func TestNestedMixedTypedAccessParse(t *testing.T) {
 }
 
 
-// nested_mixed_typed_access_build_hierarchy - function:build_hierarchy feature:optional_typed_accessors
+// nested_mixed_typed_access_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedMixedTypedAccessBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -36,7 +36,7 @@ func TestTabsAsWhitespaceInValueParse(t *testing.T) {
 }
 
 
-// tabs_as_whitespace_in_value_build_hierarchy - function:build_hierarchy feature:whitespace feature:tab_in_value_preserved
+// tabs_as_whitespace_in_value_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -346,7 +346,7 @@ func TestCrlfNormalizeToLfBasicParse(t *testing.T) {
 }
 
 
-// crlf_normalize_to_lf_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
+// crlf_normalize_to_lf_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -358,7 +358,7 @@ func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
 }
 
 
-// crlf_preserve_literal_basic_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
+// crlf_preserve_literal_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -436,7 +436,7 @@ func TestCrlfNestedStructureParse(t *testing.T) {
 }
 
 
-// crlf_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
+// crlf_nested_structure_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -448,7 +448,7 @@ func TestCrlfPreserveNestedStructureParse(t *testing.T) {
 }
 
 
-// crlf_preserve_nested_structure_build_hierarchy - function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
+// crlf_preserve_nested_structure_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -522,7 +522,7 @@ func TestCrlfNormalizeCommentsAndValuesFilter(t *testing.T) {
 }
 
 
-// crlf_normalize_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+// crlf_normalize_comments_and_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments feature:whitespace behavior:crlf_normalize_to_lf
 func TestCrlfNormalizeCommentsAndValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -540,7 +540,7 @@ func TestCrlfPreserveCommentsAndValuesFilter(t *testing.T) {
 }
 
 
-// crlf_preserve_comments_and_values_build_hierarchy - function:build_hierarchy feature:comments feature:whitespace behavior:crlf_preserve_literal
+// crlf_preserve_comments_and_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }


### PR DESCRIPTION
## Summary

Fixes the apparent contradiction reported in #114 between `mixed_indentation_levels_build_hierarchy` and the `multiline_plain_*_error_parse` error tests.

`build_hierarchy` consumes entries produced by `parse_indented`, not `parse`. `parse` correctly rejects lines without `=` delimiters, while `parse_indented` handles the indentation-based nesting that `build_hierarchy` needs. Implementations that declared `build_hierarchy` support but not `parse_indented` were being handed `build_hierarchy` tests (like `mixed_indentation_levels`) that they could not satisfy.

This PR encodes that dependency in the test generator:

- Adds `build_hierarchy` to `compositeFunctionMap` → `{parse_indented, build_hierarchy}`
- Updates `load` from `{parse, build_hierarchy}` → `{parse_indented, build_hierarchy}`
- Regenerates `generated_tests/` and `go_tests/` so every `build_hierarchy` validation now lists `parse_indented` in its required `functions`

Implementations that don't expose `parse_indented` will now correctly filter out `build_hierarchy` tests.

Closes #114. Builds on the documentation clarification added in #125.

## Test plan

- [x] `just lint`
- [x] `just reset`
- [x] `just validate`
- [ ] CI green