### PR TITLE
test(ci): verify validate-tags CI check fails on undocumented tag

### DIFF
--- a/source_tests/core/api_core_ccl_parsing.json
+++ b/source_tests/core/api_core_ccl_parsing.json
@@ -28,6 +28,9 @@
       "functions": [
         "parse",
         "print"
+      ],
+      "features": [
+        "experimental_ci_verification_undocumented"
       ]
     },
     {


### PR DESCRIPTION
## ⚠️ DO NOT MERGE

This PR deliberately breaks the tag-URL contract to verify that the `Validate tag-URL contract` CI step (introduced in #135) actually catches the failure.

## What's broken

One test in `source_tests/core/api_core_ccl_parsing.json` has a fabricated feature tag `experimental_ci_verification_undocumented` that:

- **Passes schema validation** — the name matches the schema's `^experimental_` pattern in `#/$defs/featureName`, so `just validate` is happy.
- **Fails the tag-URL contract** — the tag is not in <https://ccl.tylerbutler.com/tag-index.json>, so `just validate-tags` must exit non-zero.

## Expected CI outcome

```
✓ Validate           (just validate)
✗ Validate tag-URL contract   (just validate-tags)
    FAIL: 1 tag(s) used in tests have no canonical documentation URL:
      feature:experimental_ci_verification_undocumented
```

Subsequent steps (build, lint, test, build-readme) will not run.

## After verification

Close this PR without merging. Delete the branch.