### PR TITLE
fix(tests): align parse_indented expectations with OCaml canonical (#134)

### DIFF
--- a/generated_tests/api_errors.json
+++ b/generated_tests/api_errors.json
@@ -110,6 +110,27 @@
       "source_test": "multiline_plain_nested_error",
       "validation": "parse",
       "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented"
+      ],
+      "inputs": [
+        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
+      ],
+      "name": "mixed_indentation_levels_error_parse_indented",
+      "source_test": "mixed_indentation_levels_error",
+      "validation": "parse_indented",
+      "variants": [
+        "reference_compliant"
+      ]
     }
   ]
 }

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -43,13 +43,14 @@
             "value": "= Section Header ="
           },
           {
-            "key": "key",
+            "key": "This continues the header\nkey",
             "value": "value"
           }
         ]
       },
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "multiline_keys"
       ],
       "functions": [
         "parse_indented"
@@ -160,63 +161,6 @@
       "name": "indented_line_is_continuation_get_list",
       "source_test": "indented_line_is_continuation",
       "validation": "get_list",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "multiline_values"
-      ],
-      "expected": {
-        "count": 2,
-        "entries": [
-          {
-            "key": "key1",
-            "value": "value1\n  indented continuation"
-          },
-          {
-            "key": "key2",
-            "value": "value2"
-          }
-        ]
-      },
-      "features": [
-        "multiline_continuation"
-      ],
-      "functions": [
-        "parse_indented"
-      ],
-      "inputs": [
-        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
-      ],
-      "name": "mixed_indentation_levels_parse_indented",
-      "source_test": "mixed_indentation_levels",
-      "validation": "parse_indented",
-      "variants": []
-    },
-    {
-      "behaviors": [
-        "multiline_values"
-      ],
-      "expected": {
-        "count": 1,
-        "object": {
-          "key1": "value1\n  indented continuation",
-          "key2": "value2"
-        }
-      },
-      "features": [
-        "multiline_continuation"
-      ],
-      "functions": [
-        "parse_indented",
-        "build_hierarchy"
-      ],
-      "inputs": [
-        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
-      ],
-      "name": "mixed_indentation_levels_build_hierarchy",
-      "source_test": "mixed_indentation_levels",
-      "validation": "build_hierarchy",
       "variants": []
     },
     {

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -61,7 +61,9 @@
       "name": "unindented_line_does_not_continue_value_parse_indented",
       "source_test": "unindented_line_does_not_continue_value",
       "validation": "parse_indented",
-      "variants": []
+      "variants": [
+        "reference_compliant"
+      ]
     },
     {
       "behaviors": [

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -40,7 +40,7 @@
         "entries": [
           {
             "key": "",
-            "value": "= Section Header =\nThis continues the header"
+            "value": "= Section Header ="
           },
           {
             "key": "key",
@@ -57,8 +57,8 @@
       "inputs": [
         "== Section Header =\nThis continues the header\nkey = value"
       ],
-      "name": "unindented_multiline_becomes_continuation_parse_indented",
-      "source_test": "unindented_multiline_becomes_continuation",
+      "name": "unindented_line_does_not_continue_value_parse_indented",
+      "source_test": "unindented_line_does_not_continue_value",
       "validation": "parse_indented",
       "variants": []
     },
@@ -167,7 +167,7 @@
         "multiline_values"
       ],
       "expected": {
-        "count": 4,
+        "count": 2,
         "entries": [
           {
             "key": "key1",
@@ -176,20 +176,11 @@
           {
             "key": "key2",
             "value": "value2"
-          },
-          {
-            "key": "not indented key",
-            "value": ""
-          },
-          {
-            "key": "indented for not indented",
-            "value": ""
           }
         ]
       },
       "features": [
-        "multiline_continuation",
-        "empty_keys"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented"
@@ -210,15 +201,11 @@
         "count": 1,
         "object": {
           "key1": "value1\n  indented continuation",
-          "key2": "value2",
-          "not indented key": {
-            "indented for not indented": ""
-          }
+          "key2": "value2"
         }
       },
       "features": [
-        "multiline_continuation",
-        "empty_keys"
+        "multiline_continuation"
       ],
       "functions": [
         "parse_indented",
@@ -1207,39 +1194,11 @@
     {
       "behaviors": [],
       "expected": {
-        "count": 11,
+        "count": 4,
         "entries": [
           {
             "key": "config",
-            "value": ""
-          },
-          {
-            "key": "servers",
-            "value": "web1"
-          },
-          {
-            "key": "servers",
-            "value": "web2"
-          },
-          {
-            "key": "database",
-            "value": ""
-          },
-          {
-            "key": "hosts",
-            "value": "primary"
-          },
-          {
-            "key": "hosts",
-            "value": "backup"
-          },
-          {
-            "key": "port",
-            "value": "5432"
-          },
-          {
-            "key": "cache",
-            "value": "redis"
+            "value": "\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis"
           },
           {
             "key": "features",

--- a/go_tests/parsing/api_errors_test.go
+++ b/go_tests/parsing/api_errors_test.go
@@ -149,3 +149,9 @@ val
 }
 
 
+// mixed_indentation_levels_error_parse_indented - function:parse_indented feature:multiline_continuation variant:reference_compliant
+func TestMixedIndentationLevelsErrorParseIndented(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -20,7 +20,7 @@ func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
 }
 
 
-// unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys
+// unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline_keys
 func TestUnindentedLineDoesNotContinueValueParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
@@ -40,18 +40,6 @@ func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 
 // indented_line_is_continuation_get_list - function:get_list feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline_continuation behavior:multiline_values
-func TestMixedIndentationLevelsParseIndented(t *testing.T) {
-	t.Skip("Test does not match run-only filter: [function:parse]")
-}
-
-
-// mixed_indentation_levels_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:multiline_values
-func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -20,8 +20,8 @@ func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
 }
 
 
-// unindented_multiline_becomes_continuation_parse_indented - function:parse_indented feature:empty_keys
-func TestUnindentedMultilineBecomesContinuationParseIndented(t *testing.T) {
+// unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys
+func TestUnindentedLineDoesNotContinueValueParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -44,13 +44,13 @@ func TestIndentedLineIsContinuationGetList(t *testing.T) {
 }
 
 
-// mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline_continuation feature:empty_keys behavior:multiline_values
+// mixed_indentation_levels_parse_indented - function:parse_indented feature:multiline_continuation behavior:multiline_values
 func TestMixedIndentationLevelsParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
 
-// mixed_indentation_levels_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation feature:empty_keys behavior:multiline_values
+// mixed_indentation_levels_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:multiline_values
 func TestMixedIndentationLevelsBuildHierarchy(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -20,7 +20,7 @@ func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
 }
 
 
-// unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline_keys
+// unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline_keys variant:reference_compliant
 func TestUnindentedLineDoesNotContinueValueParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }

--- a/internal/config/runner_config.go
+++ b/internal/config/runner_config.go
@@ -105,7 +105,7 @@ func DefaultConfig() *RunnerConfig {
 				"canonical_format_consistent_spacing", "canonical_format_line_endings_proposed",
 				"canonical_format_tab_preservation", "key_with_tabs",
 				// Multiline tests that require advanced parsing
-				"multiline_section_header_value", "unindented_multiline_becomes_continuation",
+				"multiline_section_header_value", "unindented_line_does_not_continue_value",
 				"multiline_values", "nested_multi_line", "nested_single_line", "complex_multi_newline_whitespace",
 				"key_with_newline_before_equals", "round_trip_multiline_values", "round_trip_whitespace_normalization",
 				// Complex nested structure tests requiring hierarchy support

--- a/internal/config/runner_config.go
+++ b/internal/config/runner_config.go
@@ -106,6 +106,8 @@ func DefaultConfig() *RunnerConfig {
 				"canonical_format_tab_preservation", "key_with_tabs",
 				// Multiline tests that require advanced parsing
 				"multiline_section_header_value", "unindented_line_does_not_continue_value",
+				// Reference-compliant error tests the mock doesn't enforce (silently drops no-= lines)
+				"mixed_indentation_levels_error",
 				"multiline_values", "nested_multi_line", "nested_single_line", "complex_multi_newline_whitespace",
 				"key_with_newline_before_equals", "round_trip_multiline_values", "round_trip_whitespace_normalization",
 				// Complex nested structure tests requiring hierarchy support

--- a/source_tests/core/api_errors.json
+++ b/source_tests/core/api_errors.json
@@ -102,6 +102,27 @@
       "functions": [
         "parse"
       ]
+    },
+    {
+      "name": "mixed_indentation_levels_error",
+      "tests": [
+        {
+          "function": "parse_indented",
+          "expect": null
+        }
+      ],
+      "features": [
+        "multiline_continuation"
+      ],
+      "variants": [
+        "reference_compliant"
+      ],
+      "inputs": [
+        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
+      ],
+      "functions": [
+        "parse_indented"
+      ]
     }
   ]
 }

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -33,14 +33,14 @@
       ]
     },
     {
-      "name": "unindented_multiline_becomes_continuation",
+      "name": "unindented_line_does_not_continue_value",
       "tests": [
         {
           "function": "parse_indented",
           "expect": [
             {
               "key": "",
-              "value": "= Section Header =\nThis continues the header"
+              "value": "= Section Header ="
             },
             {
               "key": "key",
@@ -125,14 +125,6 @@
             {
               "key": "key2",
               "value": "value2"
-            },
-            {
-              "key": "not indented key",
-              "value": ""
-            },
-            {
-              "key": "indented for not indented",
-              "value": ""
             }
           ]
         },
@@ -140,10 +132,7 @@
           "function": "build_hierarchy",
           "expect": {
             "key1": "value1\n  indented continuation",
-            "key2": "value2",
-            "not indented key": {
-              "indented for not indented": ""
-            }
+            "key2": "value2"
           }
         }
       ],
@@ -151,8 +140,7 @@
         "multiline_values"
       ],
       "features": [
-        "multiline_continuation",
-        "empty_keys"
+        "multiline_continuation"
       ],
       "inputs": [
         "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
@@ -792,35 +780,7 @@
           "expect": [
             {
               "key": "config",
-              "value": ""
-            },
-            {
-              "key": "servers",
-              "value": "web1"
-            },
-            {
-              "key": "servers",
-              "value": "web2"
-            },
-            {
-              "key": "database",
-              "value": ""
-            },
-            {
-              "key": "hosts",
-              "value": "primary"
-            },
-            {
-              "key": "hosts",
-              "value": "backup"
-            },
-            {
-              "key": "port",
-              "value": "5432"
-            },
-            {
-              "key": "cache",
-              "value": "redis"
+              "value": "\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis"
             },
             {
               "key": "features",

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -43,14 +43,15 @@
               "value": "= Section Header ="
             },
             {
-              "key": "key",
+              "key": "This continues the header\nkey",
               "value": "value"
             }
           ]
         }
       ],
       "features": [
-        "empty_keys"
+        "empty_keys",
+        "multiline_keys"
       ],
       "inputs": [
         "== Section Header =\nThis continues the header\nkey = value"
@@ -109,44 +110,6 @@
       "functions": [
         "build_hierarchy",
         "get_list",
-        "parse_indented"
-      ]
-    },
-    {
-      "name": "mixed_indentation_levels",
-      "tests": [
-        {
-          "function": "parse_indented",
-          "expect": [
-            {
-              "key": "key1",
-              "value": "value1\n  indented continuation"
-            },
-            {
-              "key": "key2",
-              "value": "value2"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "key1": "value1\n  indented continuation",
-            "key2": "value2"
-          }
-        }
-      ],
-      "behaviors": [
-        "multiline_values"
-      ],
-      "features": [
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "key1 = value1\n  indented continuation\nkey2 = value2\nnot indented key\n  indented for not indented"
-      ],
-      "functions": [
-        "build_hierarchy",
         "parse_indented"
       ]
     },

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -53,6 +53,9 @@
         "empty_keys",
         "multiline_keys"
       ],
+      "variants": [
+        "reference_compliant"
+      ],
       "inputs": [
         "== Section Header =\nThis continues the header\nkey = value"
       ],


### PR DESCRIPTION
Fixes #134.

Three `parse_indented` expectations in `api_proposed_behavior.json` contradicted OCaml canonical semantics and their own `build_hierarchy` siblings. Each corrected expectation was verified by running the input through the OCaml reference parser.

## Changes

**`complex_mixed_list_scenarios`** — `parse_indented` corrected from 11 flat entries to 4 (indented block collected as multiline value on `config`). `build_hierarchy` unchanged. No variant tag: output is universal.

**`mixed_indentation_levels` → `mixed_indentation_levels_error`** — moved to `api_errors.json`. OCaml parse-errors on this input; the Go mock silently drops no-`=` lines. Tagged `variants: [reference_compliant]`; added to mock's `SkipTestsByName`.

**`unindented_multiline_becomes_continuation` → `unindented_line_does_not_continue_value`** — renamed and corrected. OCaml's greedy key parser absorbs the unindented line into the next key, producing a multi-line key `"This continues the header\nkey"`. Tagged `variants: [reference_compliant]` + `features: [multiline_keys]`; stays in mock's `SkipTestsByName`.

## Test plan
- [x] `just reset` passes
- [x] `just validate` passes
- [x] `just test-all` failure delta is -1, no new failures
- [x] Each expected output verified against `ccl-ocaml` reference parser