### PR TITLE
fix(release): exclude docs commits from version bumps

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -24,6 +24,10 @@ tag_format = "v{version}"
 parse_squash_commits = true
 ignore_merge_commits = true
 
+# Commit types the parser recognizes. Omitting "docs" means doc-only commits
+# (including "docs!:") are ignored for version bumping.
+allowed_tags = ["feat", "fix", "perf", "refactor", "style", "test", "ci", "build", "chore"]
+
 # Define which commit types trigger version bumps
 minor_tags = ["feat"]
 patch_tags = ["fix", "perf"]


### PR DESCRIPTION
## Summary
- The `docs!:` commit in #135 caused `just release-check` to report a 2.0.0 bump — the conventional parser's default `allowed_tags` includes `docs`, so a breaking-marker on a docs commit triggers major.
- Explicitly set `allowed_tags` without `docs` so doc-only commits (including breaking ones) are ignored for version bumping.
- `exclude_commit_patterns` only filters the changelog output; it does not affect version bumps.

## Verification
With this change, `semantic-release version --print` against main's commit range reports **1.0.1** (from the `fix(tests)` commit in #140) instead of 2.0.0.

## Test plan
- [ ] Confirm `just release-check` reports `1.0.1` on main after merge
- [ ] Confirm a future `docs:` or `docs!:` commit does not trigger a release