### PR TITLE
feat(tests): add build_model canonical model function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -46,3 +46,6 @@ bin
 test-reader
 .serena/
 cmd/test-reader/test-reader
+
+# Intermediate schema produced by cmd/simplify-schema for go-jsonschema codegen.
+schemas/generated-format-simple.json

--- a/.mise.toml
+++ b/.mise.toml
@@ -1,5 +1,6 @@
 [tools]
 go = "1.26.1"
+"github:omissis/go-jsonschema" = "latest"
 hk = "latest"
 just = "latest"
 # Node.js for running ESM scripts and commitlint

--- a/cmd/simplify-schema/main.go
+++ b/cmd/simplify-schema/main.go
@@ -1,0 +1,73 @@
+// simplify-schema strips JSON Schema constructs that go-jsonschema (omissis fork)
+// can't translate into useful Go types, producing a simplified schema suitable
+// for type generation. Runtime validation continues to use the original schema.
+//
+// Two transformations:
+//  1. Drop `properties.tests.items.allOf` (contains an `if/then` conditional that
+//     go-jsonschema ignores anyway, but its presence collapses the items type to
+//     interface{}).
+//  2. Replace `properties.tests.items.properties.features.items` (which uses a
+//     `oneOf` of [enum, ^experimental_, ^optional_] patterns) with a plain
+//     `{type: string}`. go-jsonschema can't synthesize a single Go type for
+//     "enum or two regex patterns", so the simplified version produces a plain
+//     []string field — runtime validation still enforces the patterns.
+//
+// Usage: simplify-schema <input.json> <output.json>
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+func main() {
+	if len(os.Args) != 3 {
+		fmt.Fprintln(os.Stderr, "usage: simplify-schema <input.json> <output.json>")
+		os.Exit(2)
+	}
+
+	in, err := os.ReadFile(os.Args[1])
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "read input: %v\n", err)
+		os.Exit(1)
+	}
+
+	var schema map[string]any
+	if err := json.Unmarshal(in, &schema); err != nil {
+		fmt.Fprintf(os.Stderr, "parse input: %v\n", err)
+		os.Exit(1)
+	}
+
+	items := nav(schema, "properties", "tests", "items")
+	if items == nil {
+		fmt.Fprintln(os.Stderr, "schema missing properties.tests.items")
+		os.Exit(1)
+	}
+	delete(items, "allOf")
+
+	if featItems := nav(items, "properties", "features", "items"); featItems != nil {
+		delete(featItems, "oneOf")
+	}
+
+	out, err := json.MarshalIndent(schema, "", "  ")
+	if err != nil {
+		fmt.Fprintf(os.Stderr, "marshal: %v\n", err)
+		os.Exit(1)
+	}
+	if err := os.WriteFile(os.Args[2], append(out, '\n'), 0o644); err != nil {
+		fmt.Fprintf(os.Stderr, "write output: %v\n", err)
+		os.Exit(1)
+	}
+}
+
+func nav(m map[string]any, keys ...string) map[string]any {
+	for _, k := range keys {
+		next, ok := m[k].(map[string]any)
+		if !ok {
+			return nil
+		}
+		m = next
+	}
+	return m
+}

--- a/config/config.go
+++ b/config/config.go
@@ -34,6 +34,7 @@ const (
 	FunctionCompose         CCLFunction = "compose"
 	FunctionExpandDotted    CCLFunction = "expand_dotted"
 	FunctionBuildHierarchy  CCLFunction = "build_hierarchy"
+	FunctionBuildModel      CCLFunction = "build_model"
 	FunctionGetString       CCLFunction = "get_string"
 	FunctionGetInt          CCLFunction = "get_int"
 	FunctionGetBool         CCLFunction = "get_bool"
@@ -54,6 +55,7 @@ func AllFunctions() []CCLFunction {
 		FunctionCompose,
 		FunctionExpandDotted,
 		FunctionBuildHierarchy,
+		FunctionBuildModel,
 		FunctionGetString,
 		FunctionGetInt,
 		FunctionGetBool,

--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -54,6 +54,32 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "age": {
+            "42": {}
+          },
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
+      "name": "basic_object_construction_build_model",
+      "source_test": "basic_object_construction",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "name = Alice\nage = 42"
       },
       "features": [],
@@ -118,6 +144,41 @@
       "name": "deep_nested_objects_build_hierarchy",
       "source_test": "deep_nested_objects",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "cache": {
+              "enabled": {
+                "true": {}
+              }
+            },
+            "database": {
+              "host": {
+                "localhost": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+      ],
+      "name": "deep_nested_objects_build_model",
+      "source_test": "deep_nested_objects",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -192,6 +253,31 @@
       "name": "duplicate_keys_to_lists_build_hierarchy",
       "source_test": "duplicate_keys_to_lists",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "first": {},
+            "second": {},
+            "third": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = first\nitem = second\nitem = third"
+      ],
+      "name": "duplicate_keys_to_lists_build_model",
+      "source_test": "duplicate_keys_to_lists",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_core_ccl_hierarchy.json
+++ b/generated_tests/api_core_ccl_hierarchy.json
@@ -352,6 +352,35 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "config": {
+            "port": {
+              "80": {}
+            },
+            "server": {
+              "web1": {},
+              "web2": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  server = web1\n  server = web2\n  port = 80"
+      ],
+      "name": "nested_duplicate_keys_build_model",
+      "source_test": "nested_duplicate_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "config =\n  server = web1\n  server = web2\n  port = 80"
       },
       "features": [],
@@ -421,6 +450,40 @@
       "name": "mixed_flat_and_nested_build_hierarchy",
       "source_test": "mixed_flat_and_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "timeout": {
+              "30": {}
+            }
+          },
+          "name": {
+            "Alice": {}
+          },
+          "version": {
+            "1.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
+      ],
+      "name": "mixed_flat_and_nested_build_model",
+      "source_test": "mixed_flat_and_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -501,6 +564,45 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "environments": {
+            "dev": {
+              "port": {
+                "3000": {}
+              },
+              "server": {
+                "localhost": {}
+              }
+            },
+            "prod": {
+              "port": {
+                "80": {}
+              },
+              "server": {
+                "web1": {},
+                "web2": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
+      ],
+      "name": "nested_objects_with_lists_build_model",
+      "source_test": "nested_objects_with_lists",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
       },
       "features": [],
@@ -574,6 +676,37 @@
       "name": "deeply_nested_list_build_hierarchy",
       "source_test": "deeply_nested_list",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "api1": {},
+                  "web1": {},
+                  "web2": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers = web1\n      servers = web2\n      servers = api1"
+      ],
+      "name": "deeply_nested_list_build_model",
+      "source_test": "deeply_nested_list",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_core_ccl_integration.json
+++ b/generated_tests/api_core_ccl_integration.json
@@ -54,6 +54,32 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "age": {
+            "42": {}
+          },
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
+      "name": "complete_basic_workflow_build_model",
+      "source_test": "complete_basic_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "name = Alice\nage = 42"
       },
       "features": [],
@@ -114,6 +140,37 @@
       "name": "complete_nested_workflow_build_hierarchy",
       "source_test": "complete_nested_workflow",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "enabled": {
+              "true": {}
+            },
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  enabled = true"
+      ],
+      "name": "complete_nested_workflow_build_model",
+      "source_test": "complete_nested_workflow",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -192,6 +249,45 @@
       "name": "complete_mixed_workflow_build_hierarchy",
       "source_test": "complete_mixed_workflow",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "app": {
+            "MyApp": {}
+          },
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "features": {
+              "feature1": {
+                "enabled": {}
+              },
+              "feature2": {
+                "disabled": {}
+              }
+            }
+          },
+          "version": {
+            "1.0.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
+      ],
+      "name": "complete_mixed_workflow_build_model",
+      "source_test": "complete_mixed_workflow",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -283,6 +379,39 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "ports": {
+            "port": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "servers": {
+            "server": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+      ],
+      "name": "complete_lists_workflow_build_model",
+      "source_test": "complete_lists_workflow",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
       },
       "features": [],
@@ -368,6 +497,39 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "ports": {
+            "port": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "servers": {
+            "server": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+      ],
+      "name": "complete_lists_workflow_lexicographic_build_model",
+      "source_test": "complete_lists_workflow_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "value": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
       },
       "features": [],
@@ -442,6 +604,43 @@
       "name": "complete_multiline_workflow_build_hierarchy",
       "source_test": "complete_multiline_workflow",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "settings": {
+              "value1": {
+                "one": {}
+              },
+              "value2": {
+                "two": {}
+              }
+            }
+          },
+          "description": {
+            "Welcome to our app\n  This is a multi-line description\n  With several lines": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
+      ],
+      "name": "complete_multiline_workflow_build_model",
+      "source_test": "complete_multiline_workflow",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -550,6 +749,79 @@
       "name": "real_world_complete_workflow_build_hierarchy",
       "source_test": "real_world_complete_workflow",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "credentials": {
+              "password": {
+                "secret123": {}
+              },
+              "user": {
+                "service_user": {}
+              }
+            },
+            "host": {
+              "db.example.com": {}
+            },
+            "pools": {
+              "read": {
+                "5": {}
+              },
+              "write": {
+                "2": {}
+              }
+            },
+            "port": {
+              "5432": {}
+            }
+          },
+          "features": {
+            "feature_a": {
+              "enabled": {}
+            },
+            "feature_b": {
+              "disabled": {}
+            },
+            "feature_c": {
+              "experimental": {}
+            }
+          },
+          "logging": {
+            "level": {
+              "info": {}
+            },
+            "outputs": {
+              "output": {
+                "console": {},
+                "file": {},
+                "syslog": {}
+              }
+            }
+          },
+          "service": {
+            "MyMicroservice": {}
+          },
+          "version": {
+            "2.1.0": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
+      ],
+      "name": "real_world_complete_workflow_build_model",
+      "source_test": "real_world_complete_workflow",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_core_ccl_model.json
+++ b/generated_tests/api_core_ccl_model.json
@@ -1,0 +1,246 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "tests": [
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "key",
+            "value": "value"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "name": "model_single_pair_parse",
+      "source_test": "model_single_pair",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "name": "model_single_pair_build_model",
+      "source_test": "model_single_pair",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "item",
+            "value": "first"
+          },
+          {
+            "key": "item",
+            "value": "second"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item = first\nitem = second"
+      ],
+      "name": "model_duplicate_keys_merge_to_multi_leaf_parse",
+      "source_test": "model_duplicate_keys_merge_to_multi_leaf",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "first": {},
+            "second": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = first\nitem = second"
+      ],
+      "name": "model_duplicate_keys_merge_to_multi_leaf_build_model",
+      "source_test": "model_duplicate_keys_merge_to_multi_leaf",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 3,
+        "entries": [
+          {
+            "key": "item",
+            "value": "a"
+          },
+          {
+            "key": "item",
+            "value": "b"
+          },
+          {
+            "key": "item",
+            "value": "a"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item = a\nitem = b\nitem = a"
+      ],
+      "name": "model_repeated_value_is_idempotent_parse",
+      "source_test": "model_repeated_value_is_idempotent",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "a": {},
+            "b": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = a\nitem = b\nitem = a"
+      ],
+      "name": "model_repeated_value_is_idempotent_build_model",
+      "source_test": "model_repeated_value_is_idempotent",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "host",
+            "value": "localhost"
+          },
+          {
+            "key": "port",
+            "value": "8080"
+          }
+        ]
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "model_multiple_distinct_keys_parse",
+      "source_test": "model_multiple_distinct_keys",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "name": "model_multiple_distinct_keys_build_model",
+      "source_test": "model_multiple_distinct_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 0
+      },
+      "features": [],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "model_empty_input_parse",
+      "source_test": "model_empty_input",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {}
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "model_empty_input_build_model",
+      "source_test": "model_empty_input",
+      "validation": "build_model",
+      "variants": []
+    }
+  ]
+}

--- a/generated_tests/api_edge_cases.json
+++ b/generated_tests/api_edge_cases.json
@@ -983,6 +983,66 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "This is a CCL document": {}
+          },
+          "database": {
+            "enabled": {
+              "true": {}
+            },
+            "limits": {
+              "cpu": {
+                "1500mi": {}
+              },
+              "memory": {
+                "10Gb": {}
+              }
+            },
+            "ports": {
+              "": {
+                "8000": {},
+                "8001": {},
+                "8002": {}
+              }
+            }
+          },
+          "title": {
+            "CCL Example": {}
+          },
+          "user": {
+            "createdAt": {
+              "2024-12-31": {}
+            },
+            "guestId": {
+              "42": {}
+            },
+            "login": {
+              "chshersh": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= This is a CCL document\ntitle = CCL Example\n\ndatabase =\n  enabled = true\n  ports =\n    = 8000\n    = 8001\n    = 8002\n  limits =\n    cpu = 1500mi\n    memory = 10Gb\n\nuser =\n  guestId = 42\n\nuser =\n  login = chshersh\n  createdAt = 2024-12-31"
+      ],
+      "name": "ocaml_stress_test_original_build_model",
+      "source_test": "ocaml_stress_test_original",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "title"
       ],
@@ -1051,6 +1111,34 @@
       "name": "forward_slashes_in_map_keys_build_hierarchy",
       "source_test": "forward_slashes_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "config/settings.json": {
+              ".vscode/settings.json": {}
+            },
+            "src/template.env": {
+              ".env": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
+      ],
+      "name": "forward_slashes_in_map_keys_build_model",
+      "source_test": "forward_slashes_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1128,6 +1216,34 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "paths": {
+            "C:\\Users\\config": {
+              "user_settings": {}
+            },
+            "D:\\data\\file.txt": {
+              "backup": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "paths =\n  C:\\Users\\config = user_settings\n  D:\\data\\file.txt = backup"
+      ],
+      "name": "backslashes_in_map_keys_build_model",
+      "source_test": "backslashes_in_map_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "timestamps",
@@ -1169,6 +1285,34 @@
       "name": "colons_in_map_keys_build_hierarchy",
       "source_test": "colons_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "timestamps": {
+            "12:30:45": {
+              "morning": {}
+            },
+            "23:59:59": {
+              "midnight": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "timestamps =\n  12:30:45 = morning\n  23:59:59 = midnight"
+      ],
+      "name": "colons_in_map_keys_build_model",
+      "source_test": "colons_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1222,6 +1366,34 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "packages": {
+            "another-lib": {
+              "2.3.4": {}
+            },
+            "my-package-name": {
+              "1.0.0": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "packages =\n  my-package-name = 1.0.0\n  another-lib = 2.3.4"
+      ],
+      "name": "hyphens_in_map_keys_build_model",
+      "source_test": "hyphens_in_map_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "emails",
@@ -1263,6 +1435,34 @@
       "name": "at_signs_in_map_keys_build_hierarchy",
       "source_test": "at_signs_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "emails": {
+            "admin@test.org": {
+              "secondary": {}
+            },
+            "user@example.com": {
+              "primary": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "emails =\n  user@example.com = primary\n  admin@test.org = secondary"
+      ],
+      "name": "at_signs_in_map_keys_build_model",
+      "source_test": "at_signs_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1316,6 +1516,34 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "issues": {
+            "bug#456": {
+              "closed": {}
+            },
+            "issue#123": {
+              "open": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "issues =\n  issue#123 = open\n  bug#456 = closed"
+      ],
+      "name": "hash_in_map_keys_build_model",
+      "source_test": "hash_in_map_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "arrays",
@@ -1363,6 +1591,34 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "arrays": {
+            "items[0]": {
+              "first": {}
+            },
+            "items[1]": {
+              "second": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "arrays =\n  items[0] = first\n  items[1] = second"
+      ],
+      "name": "brackets_in_map_keys_build_model",
+      "source_test": "brackets_in_map_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "functions",
@@ -1404,6 +1660,34 @@
       "name": "parentheses_in_map_keys_build_hierarchy",
       "source_test": "parentheses_in_map_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "functions": {
+            "init()": {
+              "setup": {}
+            },
+            "run(args)": {
+              "execute": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "functions =\n  init() = setup\n  run(args) = execute"
+      ],
+      "name": "parentheses_in_map_keys_build_model",
+      "source_test": "parentheses_in_map_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1458,6 +1742,37 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "complex": {
+            "file#v1.2.3": {
+              "release": {}
+            },
+            "path\\to\\[item]": {
+              "location": {}
+            },
+            "user@host:8080/api": {
+              "endpoint": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "complex =\n  user@host:8080/api = endpoint\n  file#v1.2.3 = release\n  path\\to\\[item] = location"
+      ],
+      "name": "mixed_special_chars_in_keys_build_model",
+      "source_test": "mixed_special_chars_in_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "endpoints",
@@ -1499,6 +1814,34 @@
       "name": "url_like_keys_build_hierarchy",
       "source_test": "url_like_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "endpoints": {
+            "http://localhost:3000/test": {
+              "development": {}
+            },
+            "https://api.example.com/v1": {
+              "production": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "endpoints =\n  https://api.example.com/v1 = production\n  http://localhost:3000/test = development"
+      ],
+      "name": "url_like_keys_build_model",
+      "source_test": "url_like_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1549,6 +1892,29 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "../..": {
+            "up_two_levels": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "../.. = up_two_levels"
+      ],
+      "name": "relative_path_parent_parent_build_model",
+      "source_test": "relative_path_parent_parent",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "../",
@@ -1587,6 +1953,29 @@
       "name": "relative_path_parent_build_hierarchy",
       "source_test": "relative_path_parent",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "../": {
+            "parent_dir": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "../ = parent_dir"
+      ],
+      "name": "relative_path_parent_build_model",
+      "source_test": "relative_path_parent",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1637,6 +2026,29 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          ".": {
+            "current_dir": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ". = current_dir"
+      ],
+      "name": "relative_path_single_dot_build_model",
+      "source_test": "relative_path_single_dot",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "//",
@@ -1681,6 +2093,29 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "//": {
+            "double_slash_value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "// = double_slash_value"
+      ],
+      "name": "double_slash_build_model",
+      "source_test": "double_slash",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "path",
@@ -1719,6 +2154,29 @@
       "name": "relative_path_in_value_build_hierarchy",
       "source_test": "relative_path_in_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "../../src": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = ../../src"
+      ],
+      "name": "relative_path_in_value_build_model",
+      "source_test": "relative_path_in_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1787,6 +2245,34 @@
       "name": "relative_path_in_nested_value_build_hierarchy",
       "source_test": "relative_path_in_nested_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "../../config": {
+              "../../data": {}
+            },
+            "../foo": {
+              "../bar": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  ../foo = ../bar\n  ../../config = ../../data"
+      ],
+      "name": "relative_path_in_nested_value_build_model",
+      "source_test": "relative_path_in_nested_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1864,6 +2350,34 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "urls": {
+            "//api": {
+              "//backup": {}
+            },
+            "//server": {
+              "/root": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "urls =\n  //api = //backup\n  //server = /root"
+      ],
+      "name": "double_slash_in_nested_build_model",
+      "source_test": "double_slash_in_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "config",
@@ -1907,6 +2421,36 @@
       "name": "relative_paths_deeply_nested_build_hierarchy",
       "source_test": "relative_paths_deeply_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "build": {
+              "cache": {
+                "../.cache": {}
+              },
+              "output": {
+                "../../dist": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  build = \n    output = ../../dist\n    cache = ../.cache"
+      ],
+      "name": "relative_paths_deeply_nested_build_model",
+      "source_test": "relative_paths_deeply_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1981,6 +2525,36 @@
       "name": "relative_paths_as_nested_keys_build_hierarchy",
       "source_test": "relative_paths_as_nested_keys",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "imports": {
+            "..": {
+              "main": {
+                "../src/main": {}
+              },
+              "test": {
+                "../tests": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "imports =\n  .. = \n    main = ../src/main\n    test = ../tests"
+      ],
+      "name": "relative_paths_as_nested_keys_build_model",
+      "source_test": "relative_paths_as_nested_keys",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2061,6 +2635,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "paths": {
+            "absolute": {
+              "root": {
+                "/": {}
+              }
+            },
+            "relative": {
+              "current": {
+                ".": {}
+              },
+              "up": {
+                "../../": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "paths =\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
+      ],
+      "name": "mixed_relative_and_absolute_nested_build_model",
+      "source_test": "mixed_relative_and_absolute_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "paths",
         "relative",
@@ -2138,6 +2747,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "primary": {
+              "api": {
+                "//api.example.com": {}
+              },
+              "cdn": {
+                "//cdn.example.com": {}
+              }
+            },
+            "secondary": {
+              "//internal": {
+                "//backup.example.com": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
+      ],
+      "name": "double_slash_deeply_nested_build_model",
+      "source_test": "double_slash_deeply_nested",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "servers",
         "primary",
@@ -2204,6 +2848,29 @@
       "name": "url_as_key_build_hierarchy",
       "source_test": "url_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com": {
+            "production": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com = production"
+      ],
+      "name": "url_as_key_build_model",
+      "source_test": "url_as_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2275,6 +2942,29 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "http://localhost:8080": {
+            "dev": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "http://localhost:8080 = dev"
+      ],
+      "name": "url_with_port_as_key_build_model",
+      "source_test": "url_with_port_as_key",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "https://api.example.com/v1/users",
@@ -2319,6 +3009,29 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "https://api.example.com/v1/users": {
+            "users_endpoint": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/v1/users = users_endpoint"
+      ],
+      "name": "url_with_path_as_key_build_model",
+      "source_test": "url_with_path_as_key",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "endpoint",
@@ -2357,6 +3070,29 @@
       "name": "url_in_value_build_hierarchy",
       "source_test": "url_in_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "endpoint": {
+            "https://api.example.com/v1/data": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "endpoint = https://api.example.com/v1/data"
+      ],
+      "name": "url_in_value_build_model",
+      "source_test": "url_in_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2425,6 +3161,34 @@
       "name": "urls_as_nested_keys_and_values_build_hierarchy",
       "source_test": "urls_as_nested_keys_and_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mappings": {
+            "https://api.example.com": {
+              "https://prod.example.com": {}
+            },
+            "https://staging.example.com": {
+              "https://stage.example.com": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mappings =\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
+      ],
+      "name": "urls_as_nested_keys_and_values_build_model",
+      "source_test": "urls_as_nested_keys_and_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2503,6 +3267,43 @@
       "name": "urls_deeply_nested_build_hierarchy",
       "source_test": "urls_deeply_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "services": {
+              "api": {
+                "backup": {
+                  "https://backup.example.com": {}
+                },
+                "url": {
+                  "https://api.example.com": {}
+                }
+              },
+              "cdn": {
+                "url": {
+                  "https://cdn.example.com": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
+      ],
+      "name": "urls_deeply_nested_build_model",
+      "source_test": "urls_deeply_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2591,6 +3392,36 @@
     },
     {
       "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com/search?q=test\u0026page=1": {
+            "search_results": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test\u0026page=1 = search_results"
+      ],
+      "name": "url_with_query_params_as_key_build_model",
+      "source_test": "url_with_query_params_as_key",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
         "delimiter_first_equals"
       ],
       "conflicts": {
@@ -2645,6 +3476,36 @@
       "name": "delimiter_first_url_with_query_params_build_hierarchy",
       "source_test": "delimiter_first_url_with_query_params",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://api.example.com/search?q": {
+            "test\u0026page=1 = search_results": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test\u0026page=1 = search_results"
+      ],
+      "name": "delimiter_first_url_with_query_params_build_model",
+      "source_test": "delimiter_first_url_with_query_params",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2716,6 +3577,36 @@
       },
       "expected": {
         "count": 1,
+        "object": {
+          "a": {
+            "b = c=d": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
+      "name": "delimiter_first_multiple_equals_build_model",
+      "source_test": "delimiter_first_multiple_equals",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "a",
@@ -2761,6 +3652,36 @@
       "name": "delimiter_first_empty_value_build_hierarchy",
       "source_test": "delimiter_first_empty_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_prefer_spaced"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a": {
+            "b =": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
+      "name": "delimiter_first_empty_value_build_model",
+      "source_test": "delimiter_first_empty_value",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2832,6 +3753,36 @@
       },
       "expected": {
         "count": 1,
+        "object": {
+          "a=b": {
+            "c=d": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
+      "name": "delimiter_spaced_multiple_equals_build_model",
+      "source_test": "delimiter_spaced_multiple_equals",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "key",
@@ -2877,6 +3828,36 @@
       "name": "delimiter_spaced_fallback_no_space_build_hierarchy",
       "source_test": "delimiter_spaced_fallback_no_space",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key=value"
+      ],
+      "name": "delimiter_spaced_fallback_no_space_build_model",
+      "source_test": "delimiter_spaced_fallback_no_space",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2938,6 +3919,36 @@
       "variants": []
     },
     {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "delimiter_first_equals"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "a=b": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
+      "name": "delimiter_spaced_empty_value_build_model",
+      "source_test": "delimiter_spaced_empty_value",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "behaviors": [],
       "expected": {
         "count": 1,
@@ -2979,6 +3990,29 @@
       "name": "url_with_fragment_as_key_build_hierarchy",
       "source_test": "url_with_fragment_as_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "https://docs.example.com/guide#section-1": {
+            "docs_section_1": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "https://docs.example.com/guide#section-1 = docs_section_1"
+      ],
+      "name": "url_with_fragment_as_key_build_model",
+      "source_test": "url_with_fragment_as_key",
+      "validation": "build_model",
       "variants": []
     }
   ]

--- a/generated_tests/api_fuzz_special_chars_seed1.json
+++ b/generated_tests/api_fuzz_special_chars_seed1.json
@@ -855,6 +855,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data?x77]x88": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data?x77]x88"
+      ],
+      "name": "s1_fuzz_val_name_0_build_model",
+      "source_test": "s1_fuzz_val_name_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "name"
       ],
@@ -923,6 +948,31 @@
       "name": "s1_fuzz_val_data_1_build_hierarchy",
       "source_test": "s1_fuzz_val_data_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "data": {
+            "data'x23!x22": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "data = data'x23!x22"
+      ],
+      "name": "s1_fuzz_val_data_1_build_model",
+      "source_test": "s1_fuzz_val_data_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -997,6 +1047,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mode": {
+            "data?x30\"x15~x73": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mode = data?x30\"x15~x73"
+      ],
+      "name": "s1_fuzz_val_mode_2_build_model",
+      "source_test": "s1_fuzz_val_mode_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "mode"
       ],
@@ -1068,6 +1143,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data$x23~x81@x41": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data$x23~x81@x41"
+      ],
+      "name": "s1_fuzz_val_name_3_build_model",
+      "source_test": "s1_fuzz_val_name_3",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "name"
       ],
@@ -1136,6 +1236,31 @@
       "name": "s1_fuzz_val_user_4_build_hierarchy",
       "source_test": "s1_fuzz_val_user_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "user": {
+            "data}x85$x2$x43": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "user = data}x85$x2$x43"
+      ],
+      "name": "s1_fuzz_val_user_4_build_model",
+      "source_test": "s1_fuzz_val_user_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1215,6 +1340,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\u0026alpha": {
+            "nested297": {}
+          },
+          "}gamma": {
+            "deep715": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\u0026alpha = nested297\n}gamma = deep715"
+      ],
+      "name": "s1_fuzz_nested_ampersand_rbrace_0_build_model",
+      "source_test": "s1_fuzz_nested_ampersand_rbrace_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "\u0026alpha"
       ],
@@ -1288,6 +1441,34 @@
       "name": "s1_fuzz_nested_question_rbracket_1_build_hierarchy",
       "source_test": "s1_fuzz_nested_question_rbracket_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "?port": {
+            "nested105": {}
+          },
+          "]name": {
+            "deep997": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?port = nested105\n]name = deep997"
+      ],
+      "name": "s1_fuzz_nested_question_rbracket_1_build_model",
+      "source_test": "s1_fuzz_nested_question_rbracket_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1367,6 +1548,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "+config": {
+            "nested427": {}
+          },
+          "/server": {
+            "deep329": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "+config = nested427\n/server = deep329"
+      ],
+      "name": "s1_fuzz_nested_plus_slash_2_build_model",
+      "source_test": "s1_fuzz_nested_plus_slash_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "+config"
       ],
@@ -1440,6 +1649,34 @@
       "name": "s1_fuzz_nested_ampersand_dollar_3_build_hierarchy",
       "source_test": "s1_fuzz_nested_ampersand_dollar_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$port": {
+            "deep486": {}
+          },
+          "\u0026name": {
+            "nested41": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\u0026name = nested41\n$port = deep486"
+      ],
+      "name": "s1_fuzz_nested_ampersand_dollar_3_build_model",
+      "source_test": "s1_fuzz_nested_ampersand_dollar_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1519,6 +1756,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "'beta": {
+            "deep158": {}
+          },
+          "~beta": {
+            "nested332": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "~beta = nested332\n'beta = deep158"
+      ],
+      "name": "s1_fuzz_nested_tilde_squote_4_build_model",
+      "source_test": "s1_fuzz_nested_tilde_squote_4",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "~beta"
       ],
@@ -1592,6 +1857,34 @@
       "name": "s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy",
       "source_test": "s1_fuzz_nested_hyphen_ampersand_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\u0026epsilon": {
+            "deep891": {}
+          },
+          "-config": {
+            "nested723": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "-config = nested723\n\u0026epsilon = deep891"
+      ],
+      "name": "s1_fuzz_nested_hyphen_ampersand_5_build_model",
+      "source_test": "s1_fuzz_nested_hyphen_ampersand_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1671,6 +1964,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$path": {
+            "nested884": {}
+          },
+          "*mode": {
+            "deep88": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "$path = nested884\n*mode = deep88"
+      ],
+      "name": "s1_fuzz_nested_dollar_asterisk_6_build_model",
+      "source_test": "s1_fuzz_nested_dollar_asterisk_6",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "$path"
       ],
@@ -1744,6 +2065,34 @@
       "name": "s1_fuzz_nested_underscore_semicolon_7_build_hierarchy",
       "source_test": "s1_fuzz_nested_underscore_semicolon_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ";alpha": {
+            "deep519": {}
+          },
+          "_path": {
+            "nested515": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "_path = nested515\n;alpha = deep519"
+      ],
+      "name": "s1_fuzz_nested_underscore_semicolon_7_build_model",
+      "source_test": "s1_fuzz_nested_underscore_semicolon_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1823,6 +2172,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")gamma": {
+            "deep475": {}
+          },
+          "@server": {
+            "nested286": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "@server = nested286\n)gamma = deep475"
+      ],
+      "name": "s1_fuzz_nested_at_rparen_8_build_model",
+      "source_test": "s1_fuzz_nested_at_rparen_8",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "@server"
       ],
@@ -1896,6 +2273,34 @@
       "name": "s1_fuzz_nested_rbrace_tilde_9_build_hierarchy",
       "source_test": "s1_fuzz_nested_rbrace_tilde_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "}beta": {
+            "nested295": {}
+          },
+          "~alpha": {
+            "deep415": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}beta = nested295\n~alpha = deep415"
+      ],
+      "name": "s1_fuzz_nested_rbrace_tilde_9_build_model",
+      "source_test": "s1_fuzz_nested_rbrace_tilde_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_fuzz_special_chars_seed42.json
+++ b/generated_tests/api_fuzz_special_chars_seed42.json
@@ -855,6 +855,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "data": {
+            "data|x58": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "data = data|x58"
+      ],
+      "name": "s42_fuzz_val_data_0_build_model",
+      "source_test": "s42_fuzz_val_data_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "data"
       ],
@@ -923,6 +948,31 @@
       "name": "s42_fuzz_val_beta_1_build_hierarchy",
       "source_test": "s42_fuzz_val_beta_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "beta": {
+            "data\\x12": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "beta = data\\x12"
+      ],
+      "name": "s42_fuzz_val_beta_1_build_model",
+      "source_test": "s42_fuzz_val_beta_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -997,6 +1047,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data\\x77\"x95_x85": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data\\x77\"x95_x85"
+      ],
+      "name": "s42_fuzz_val_name_2_build_model",
+      "source_test": "s42_fuzz_val_name_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "name"
       ],
@@ -1068,6 +1143,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data-x45": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data-x45"
+      ],
+      "name": "s42_fuzz_val_path_3_build_model",
+      "source_test": "s42_fuzz_val_path_3",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "path"
       ],
@@ -1136,6 +1236,31 @@
       "name": "s42_fuzz_val_name_4_build_hierarchy",
       "source_test": "s42_fuzz_val_name_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data{x49\"x55": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data{x49\"x55"
+      ],
+      "name": "s42_fuzz_val_name_4_build_model",
+      "source_test": "s42_fuzz_val_name_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1215,6 +1340,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "]name": {
+            "deep985": {}
+          },
+          "{host": {
+            "nested259": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{host = nested259\n]name = deep985"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbracket_0_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbracket_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "{host"
       ],
@@ -1288,6 +1441,34 @@
       "name": "s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy",
       "source_test": "s42_fuzz_nested_lbrace_rbrace_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "{port": {
+            "nested169": {}
+          },
+          "}mode": {
+            "deep270": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{port = nested169\n}mode = deep270"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbrace_1_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbrace_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1367,6 +1548,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%data": {
+            "deep952": {}
+          },
+          "\u0026delta": {
+            "nested56": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\u0026delta = nested56\n%data = deep952"
+      ],
+      "name": "s42_fuzz_nested_ampersand_percent_2_build_model",
+      "source_test": "s42_fuzz_nested_ampersand_percent_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "\u0026delta"
       ],
@@ -1440,6 +1649,34 @@
       "name": "s42_fuzz_nested_dquote_gt_3_build_hierarchy",
       "source_test": "s42_fuzz_nested_dquote_gt_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"epsilon": {
+            "nested885": {}
+          },
+          "\u003euser": {
+            "deep168": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"epsilon = nested885\n\u003euser = deep168"
+      ],
+      "name": "s42_fuzz_nested_dquote_gt_3_build_model",
+      "source_test": "s42_fuzz_nested_dquote_gt_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1519,6 +1756,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$path": {
+            "deep65": {}
+          },
+          "%alpha": {
+            "nested438": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "%alpha = nested438\n$path = deep65"
+      ],
+      "name": "s42_fuzz_nested_percent_dollar_4_build_model",
+      "source_test": "s42_fuzz_nested_percent_dollar_4",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "%alpha"
       ],
@@ -1592,6 +1857,34 @@
       "name": "s42_fuzz_nested_dquote_rbracket_5_build_hierarchy",
       "source_test": "s42_fuzz_nested_dquote_rbracket_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"gamma": {
+            "nested524": {}
+          },
+          "]mode": {
+            "deep57": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"gamma = nested524\n]mode = deep57"
+      ],
+      "name": "s42_fuzz_nested_dquote_rbracket_5_build_model",
+      "source_test": "s42_fuzz_nested_dquote_rbracket_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1671,6 +1964,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\u0026port": {
+            "deep22": {}
+          },
+          "{data": {
+            "nested474": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{data = nested474\n\u0026port = deep22"
+      ],
+      "name": "s42_fuzz_nested_lbrace_ampersand_6_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_ampersand_6",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "{data"
       ],
@@ -1744,6 +2065,34 @@
       "name": "s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy",
       "source_test": "s42_fuzz_nested_semicolon_hyphen_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "-server": {
+            "deep284": {}
+          },
+          ";data": {
+            "nested239": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ";data = nested239\n-server = deep284"
+      ],
+      "name": "s42_fuzz_nested_semicolon_hyphen_7_build_model",
+      "source_test": "s42_fuzz_nested_semicolon_hyphen_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1823,6 +2172,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "{host": {
+            "nested125": {}
+          },
+          "}user": {
+            "deep615": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "{host = nested125\n}user = deep615"
+      ],
+      "name": "s42_fuzz_nested_lbrace_rbrace_8_build_model",
+      "source_test": "s42_fuzz_nested_lbrace_rbrace_8",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "{host"
       ],
@@ -1896,6 +2273,34 @@
       "name": "s42_fuzz_nested_tilde_ampersand_9_build_hierarchy",
       "source_test": "s42_fuzz_nested_tilde_ampersand_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\u0026gamma": {
+            "deep966": {}
+          },
+          "~beta": {
+            "nested835": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "~beta = nested835\n\u0026gamma = deep966"
+      ],
+      "name": "s42_fuzz_nested_tilde_ampersand_9_build_model",
+      "source_test": "s42_fuzz_nested_tilde_ampersand_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_fuzz_special_chars_seed49.json
+++ b/generated_tests/api_fuzz_special_chars_seed49.json
@@ -855,6 +855,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "epsilon": {
+            "data;x5\u0026x96?x73": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "epsilon = data;x5\u0026x96?x73"
+      ],
+      "name": "s49_fuzz_val_epsilon_0_build_model",
+      "source_test": "s49_fuzz_val_epsilon_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "epsilon"
       ],
@@ -923,6 +948,31 @@
       "name": "s49_fuzz_val_config_1_build_hierarchy",
       "source_test": "s49_fuzz_val_config_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "data'x33": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config = data'x33"
+      ],
+      "name": "s49_fuzz_val_config_1_build_model",
+      "source_test": "s49_fuzz_val_config_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -997,6 +1047,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "data\u003cx71": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = data\u003cx71"
+      ],
+      "name": "s49_fuzz_val_name_2_build_model",
+      "source_test": "s49_fuzz_val_name_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "name"
       ],
@@ -1068,6 +1143,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "mode": {
+            "data+x19": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "mode = data+x19"
+      ],
+      "name": "s49_fuzz_val_mode_3_build_model",
+      "source_test": "s49_fuzz_val_mode_3",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "mode"
       ],
@@ -1136,6 +1236,31 @@
       "name": "s49_fuzz_val_server_4_build_hierarchy",
       "source_test": "s49_fuzz_val_server_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "data#x70-x10": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server = data#x70-x10"
+      ],
+      "name": "s49_fuzz_val_server_4_build_model",
+      "source_test": "s49_fuzz_val_server_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1215,6 +1340,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "'name": {
+            "nested330": {}
+          },
+          "{user": {
+            "deep34": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "'name = nested330\n{user = deep34"
+      ],
+      "name": "s49_fuzz_nested_squote_lbrace_0_build_model",
+      "source_test": "s49_fuzz_nested_squote_lbrace_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "'name"
       ],
@@ -1288,6 +1441,34 @@
       "name": "s49_fuzz_nested_at_underscore_1_build_hierarchy",
       "source_test": "s49_fuzz_nested_at_underscore_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "@name": {
+            "nested517": {}
+          },
+          "_user": {
+            "deep650": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "@name = nested517\n_user = deep650"
+      ],
+      "name": "s49_fuzz_nested_at_underscore_1_build_model",
+      "source_test": "s49_fuzz_nested_at_underscore_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1367,6 +1548,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")epsilon": {
+            "nested451": {}
+          },
+          "\\delta": {
+            "deep648": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ")epsilon = nested451\n\\delta = deep648"
+      ],
+      "name": "s49_fuzz_nested_rparen_backslash_2_build_model",
+      "source_test": "s49_fuzz_nested_rparen_backslash_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         ")epsilon"
       ],
@@ -1440,6 +1649,34 @@
       "name": "s49_fuzz_nested_dollar_gt_3_build_hierarchy",
       "source_test": "s49_fuzz_nested_dollar_gt_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$port": {
+            "nested76": {}
+          },
+          "\u003ehost": {
+            "deep444": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "$port = nested76\n\u003ehost = deep444"
+      ],
+      "name": "s49_fuzz_nested_dollar_gt_3_build_model",
+      "source_test": "s49_fuzz_nested_dollar_gt_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1519,6 +1756,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"host": {
+            "nested587": {}
+          },
+          "{gamma": {
+            "deep774": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"host = nested587\n{gamma = deep774"
+      ],
+      "name": "s49_fuzz_nested_dquote_lbrace_4_build_model",
+      "source_test": "s49_fuzz_nested_dquote_lbrace_4",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "\"host"
       ],
@@ -1592,6 +1857,34 @@
       "name": "s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy",
       "source_test": "s49_fuzz_nested_semicolon_asterisk_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "*item": {
+            "deep424": {}
+          },
+          ";host": {
+            "nested246": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ";host = nested246\n*item = deep424"
+      ],
+      "name": "s49_fuzz_nested_semicolon_asterisk_5_build_model",
+      "source_test": "s49_fuzz_nested_semicolon_asterisk_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1671,6 +1964,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "*delta": {
+            "deep689": {}
+          },
+          "?epsilon": {
+            "nested334": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?epsilon = nested334\n*delta = deep689"
+      ],
+      "name": "s49_fuzz_nested_question_asterisk_6_build_model",
+      "source_test": "s49_fuzz_nested_question_asterisk_6",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "?epsilon"
       ],
@@ -1744,6 +2065,34 @@
       "name": "s49_fuzz_nested_plus_ampersand_7_build_hierarchy",
       "source_test": "s49_fuzz_nested_plus_ampersand_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\u0026gamma": {
+            "deep440": {}
+          },
+          "+server": {
+            "nested496": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "+server = nested496\n\u0026gamma = deep440"
+      ],
+      "name": "s49_fuzz_nested_plus_ampersand_7_build_model",
+      "source_test": "s49_fuzz_nested_plus_ampersand_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1823,6 +2172,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"delta": {
+            "deep232": {}
+          },
+          "*item": {
+            "nested578": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "*item = nested578\n\"delta = deep232"
+      ],
+      "name": "s49_fuzz_nested_asterisk_dquote_8_build_model",
+      "source_test": "s49_fuzz_nested_asterisk_dquote_8",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "*item"
       ],
@@ -1896,6 +2273,34 @@
       "name": "s49_fuzz_nested_rbrace_slash_9_build_hierarchy",
       "source_test": "s49_fuzz_nested_rbrace_slash_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/delta": {
+            "deep756": {}
+          },
+          "}host": {
+            "nested668": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}host = nested668\n/delta = deep756"
+      ],
+      "name": "s49_fuzz_nested_rbrace_slash_9_build_model",
+      "source_test": "s49_fuzz_nested_rbrace_slash_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_fuzz_special_chars_seed99.json
+++ b/generated_tests/api_fuzz_special_chars_seed99.json
@@ -855,6 +855,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data'x66": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data'x66"
+      ],
+      "name": "s99_fuzz_val_path_0_build_model",
+      "source_test": "s99_fuzz_val_path_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "path"
       ],
@@ -923,6 +948,31 @@
       "name": "s99_fuzz_val_item_1_build_hierarchy",
       "source_test": "s99_fuzz_val_item_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "data]x41!x78": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = data]x41!x78"
+      ],
+      "name": "s99_fuzz_val_item_1_build_model",
+      "source_test": "s99_fuzz_val_item_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -997,6 +1047,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "data[x73;x54!x24": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server = data[x73;x54!x24"
+      ],
+      "name": "s99_fuzz_val_server_2_build_model",
+      "source_test": "s99_fuzz_val_server_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "server"
       ],
@@ -1068,6 +1143,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "path": {
+            "data~x4\u003ex82~x46": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "path = data~x4\u003ex82~x46"
+      ],
+      "name": "s99_fuzz_val_path_3_build_model",
+      "source_test": "s99_fuzz_val_path_3",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "path"
       ],
@@ -1136,6 +1236,31 @@
       "name": "s99_fuzz_val_alpha_4_build_hierarchy",
       "source_test": "s99_fuzz_val_alpha_4",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "alpha": {
+            "data\u003cx11[x43": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "alpha = data\u003cx11[x43"
+      ],
+      "name": "s99_fuzz_val_alpha_4_build_model",
+      "source_test": "s99_fuzz_val_alpha_4",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1215,6 +1340,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")item": {
+            "deep37": {}
+          },
+          "/data": {
+            "nested929": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/data = nested929\n)item = deep37"
+      ],
+      "name": "s99_fuzz_nested_slash_rparen_0_build_model",
+      "source_test": "s99_fuzz_nested_slash_rparen_0",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "/data"
       ],
@@ -1288,6 +1441,34 @@
       "name": "s99_fuzz_nested_lt_percent_1_build_hierarchy",
       "source_test": "s99_fuzz_nested_lt_percent_1",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%config": {
+            "deep795": {}
+          },
+          "\u003cport": {
+            "nested722": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\u003cport = nested722\n%config = deep795"
+      ],
+      "name": "s99_fuzz_nested_lt_percent_1_build_model",
+      "source_test": "s99_fuzz_nested_lt_percent_1",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1367,6 +1548,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/epsilon": {
+            "nested268": {}
+          },
+          "{server": {
+            "deep795": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/epsilon = nested268\n{server = deep795"
+      ],
+      "name": "s99_fuzz_nested_slash_lbrace_2_build_model",
+      "source_test": "s99_fuzz_nested_slash_lbrace_2",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "/epsilon"
       ],
@@ -1440,6 +1649,34 @@
       "name": "s99_fuzz_nested_dquote_lbracket_3_build_hierarchy",
       "source_test": "s99_fuzz_nested_dquote_lbracket_3",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"host": {
+            "nested435": {}
+          },
+          "[server": {
+            "deep479": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"host = nested435\n[server = deep479"
+      ],
+      "name": "s99_fuzz_nested_dquote_lbracket_3_build_model",
+      "source_test": "s99_fuzz_nested_dquote_lbracket_3",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1519,6 +1756,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\\item": {
+            "nested708": {}
+          },
+          "\\name": {
+            "deep133": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\\item = nested708\n\\name = deep133"
+      ],
+      "name": "s99_fuzz_nested_backslash_backslash_4_build_model",
+      "source_test": "s99_fuzz_nested_backslash_backslash_4",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "\\item"
       ],
@@ -1592,6 +1857,34 @@
       "name": "s99_fuzz_nested_question_dquote_5_build_hierarchy",
       "source_test": "s99_fuzz_nested_question_dquote_5",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"item": {
+            "deep576": {}
+          },
+          "?delta": {
+            "nested18": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "?delta = nested18\n\"item = deep576"
+      ],
+      "name": "s99_fuzz_nested_question_dquote_5_build_model",
+      "source_test": "s99_fuzz_nested_question_dquote_5",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1671,6 +1964,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "\"user": {
+            "nested759": {}
+          },
+          "\\data": {
+            "deep718": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "\"user = nested759\n\\data = deep718"
+      ],
+      "name": "s99_fuzz_nested_dquote_backslash_6_build_model",
+      "source_test": "s99_fuzz_nested_dquote_backslash_6",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "\"user"
       ],
@@ -1744,6 +2065,34 @@
       "name": "s99_fuzz_nested_rparen_backslash_7_build_hierarchy",
       "source_test": "s99_fuzz_nested_rparen_backslash_7",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          ")port": {
+            "nested292": {}
+          },
+          "\\server": {
+            "deep527": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ")port = nested292\n\\server = deep527"
+      ],
+      "name": "s99_fuzz_nested_rparen_backslash_7_build_model",
+      "source_test": "s99_fuzz_nested_rparen_backslash_7",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1823,6 +2172,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "$gamma": {
+            "deep225": {}
+          },
+          "}delta": {
+            "nested591": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "}delta = nested591\n$gamma = deep225"
+      ],
+      "name": "s99_fuzz_nested_rbrace_dollar_8_build_model",
+      "source_test": "s99_fuzz_nested_rbrace_dollar_8",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "}delta"
       ],
@@ -1896,6 +2273,34 @@
       "name": "s99_fuzz_nested_percent_ampersand_9_build_hierarchy",
       "source_test": "s99_fuzz_nested_percent_ampersand_9",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "%epsilon": {
+            "nested761": {}
+          },
+          "\u0026port": {
+            "deep211": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "%epsilon = nested761\n\u0026port = deep211"
+      ],
+      "name": "s99_fuzz_nested_percent_ampersand_9_build_model",
+      "source_test": "s99_fuzz_nested_percent_ampersand_9",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_list_access.json
+++ b/generated_tests/api_list_access.json
@@ -58,6 +58,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\nservers = web2\nservers = web3"
+      ],
+      "name": "basic_list_from_duplicates_build_model",
+      "source_test": "basic_list_from_duplicates",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "servers"
       ],
@@ -231,6 +256,48 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "item01": {},
+            "item02": {},
+            "item03": {},
+            "item04": {},
+            "item05": {},
+            "item06": {},
+            "item07": {},
+            "item08": {},
+            "item09": {},
+            "item10": {},
+            "item11": {},
+            "item12": {},
+            "item13": {},
+            "item14": {},
+            "item15": {},
+            "item16": {},
+            "item17": {},
+            "item18": {},
+            "item19": {},
+            "item20": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items = item01\nitems = item02\nitems = item03\nitems = item04\nitems = item05\nitems = item06\nitems = item07\nitems = item08\nitems = item09\nitems = item10\nitems = item11\nitems = item12\nitems = item13\nitems = item14\nitems = item15\nitems = item16\nitems = item17\nitems = item18\nitems = item19\nitems = item20"
+      ],
+      "name": "large_list_build_model",
+      "source_test": "large_list",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "items"
       ],
@@ -359,6 +426,37 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "End of list": {},
+            "Production servers": {}
+          },
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
+      ],
+      "name": "list_with_comments_build_model",
+      "source_test": "list_with_comments",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "servers"
       ],
@@ -474,6 +572,37 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "End of list": {},
+            "Production servers": {}
+          },
+          "servers": {
+            "web1": {},
+            "web2": {},
+            "web3": {}
+          }
+        }
+      },
+      "features": [
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
+      ],
+      "name": "list_with_comments_lexicographic_build_model",
+      "source_test": "list_with_comments_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "servers"
       ],
@@ -554,6 +683,29 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "existing": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
+      "name": "list_error_missing_key_build_model",
+      "source_test": "list_error_missing_key",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "missing"
       ],
@@ -617,6 +769,31 @@
       "name": "list_error_nested_missing_key_build_hierarchy",
       "source_test": "list_error_nested_missing_key",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "server": {
+              "web1": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  server = web1"
+      ],
+      "name": "list_error_nested_missing_key_build_model",
+      "source_test": "list_error_nested_missing_key",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -685,6 +862,29 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "value": {
+            "simple": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "value = simple"
+      ],
+      "name": "list_error_non_object_path_build_model",
+      "source_test": "list_error_non_object_path",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "value",
         "nested"
@@ -739,6 +939,25 @@
       "name": "list_edge_case_zero_length_build_hierarchy",
       "source_test": "list_edge_case_zero_length",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {}
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        ""
+      ],
+      "name": "list_edge_case_zero_length_build_model",
+      "source_test": "list_edge_case_zero_length",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -813,6 +1032,35 @@
       "name": "bare_list_basic_build_hierarchy",
       "source_test": "bare_list_basic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "servers": {
+            "": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "servers =\n  = web1\n  = web2\n  = web3"
+      ],
+      "name": "bare_list_basic_build_model",
+      "source_test": "bare_list_basic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -903,6 +1151,37 @@
       "name": "bare_list_nested_build_hierarchy",
       "source_test": "bare_list_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "network": {
+            "ports": {
+              "": {
+                "443": {},
+                "80": {},
+                "8080": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested_build_model",
+      "source_test": "bare_list_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1002,6 +1281,37 @@
       "name": "bare_list_nested_lexicographic_build_hierarchy",
       "source_test": "bare_list_nested_lexicographic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "network": {
+            "ports": {
+              "": {
+                "443": {},
+                "80": {},
+                "8080": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested_lexicographic_build_model",
+      "source_test": "bare_list_nested_lexicographic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1105,6 +1415,39 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "allowed_hosts": {
+            "": {
+              "127.0.0.1": {},
+              "example.com": {},
+              "localhost": {}
+            },
+            "/": {
+              "Production hosts": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
+      ],
+      "name": "bare_list_with_comments_build_model",
+      "source_test": "bare_list_with_comments",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "allowed_hosts"
       ],
@@ -1201,6 +1544,39 @@
       "name": "bare_list_with_comments_lexicographic_build_hierarchy",
       "source_test": "bare_list_with_comments_lexicographic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "allowed_hosts": {
+            "": {
+              "127.0.0.1": {},
+              "example.com": {},
+              "localhost": {}
+            },
+            "/": {
+              "Production hosts": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "comments"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
+      ],
+      "name": "bare_list_with_comments_lexicographic_build_model",
+      "source_test": "bare_list_with_comments_lexicographic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1303,6 +1679,41 @@
       "name": "bare_list_deeply_nested_build_hierarchy",
       "source_test": "bare_list_deeply_nested",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "": {
+                    "api1": {},
+                    "web1": {},
+                    "web2": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
+      ],
+      "name": "bare_list_deeply_nested_build_model",
+      "source_test": "bare_list_deeply_nested",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1411,6 +1822,41 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "environments": {
+              "production": {
+                "servers": {
+                  "": {
+                    "api1": {},
+                    "web1": {},
+                    "web2": {}
+                  }
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
+      ],
+      "name": "bare_list_deeply_nested_lexicographic_build_model",
+      "source_test": "bare_list_deeply_nested_lexicographic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "environments",
@@ -1506,6 +1952,42 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "5432": {}
+            },
+            "replicas": {
+              "": {
+                "replica1": {},
+                "replica2": {}
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
+      ],
+      "name": "bare_list_mixed_with_other_keys_build_model",
+      "source_test": "bare_list_mixed_with_other_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "database",
         "replicas"
@@ -1578,6 +2060,31 @@
       "name": "bare_list_error_not_a_list_build_hierarchy",
       "source_test": "bare_list_error_not_a_list",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "setting": {
+              "value": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  setting = value"
+      ],
+      "name": "bare_list_error_not_a_list_build_model",
+      "source_test": "bare_list_error_not_a_list",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -131,6 +131,34 @@
       "variants": []
     },
     {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "descriptions": {
+            "Another item": {},
+            "First line\n  second line": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "descriptions = First line\n  second line\ndescriptions = Another item"
+      ],
+      "name": "indented_line_is_continuation_build_model",
+      "source_test": "indented_line_is_continuation",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "descriptions"
       ],
@@ -207,6 +235,29 @@
       "name": "single_item_as_list_build_hierarchy",
       "source_test": "single_item_as_list",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "single": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = single"
+      ],
+      "name": "single_item_as_list_build_model",
+      "source_test": "single_item_as_list",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -303,6 +354,33 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "ports": {
+            "443": {},
+            "80": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
+      "name": "mixed_duplicate_single_keys_build_model",
+      "source_test": "mixed_duplicate_single_keys",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "host"
       ],
@@ -382,6 +460,35 @@
       "name": "nested_list_access_build_hierarchy",
       "source_test": "nested_list_access",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "hosts": {
+              "primary": {},
+              "secondary": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
+      "name": "nested_list_access_build_model",
+      "source_test": "nested_list_access",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -465,6 +572,29 @@
       "name": "empty_list_build_hierarchy",
       "source_test": "empty_list",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_list": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
+      "name": "empty_list_build_model",
+      "source_test": "empty_list",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -568,6 +698,32 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "numbers": {
+            "-17": {},
+            "0": {},
+            "1": {},
+            "42": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
+      "name": "list_with_numbers_build_model",
+      "source_test": "list_with_numbers",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "numbers"
       ],
@@ -668,6 +824,32 @@
       "name": "list_with_booleans_build_hierarchy",
       "source_test": "list_with_booleans",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flags": {
+            "false": {},
+            "no": {},
+            "true": {},
+            "yes": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
+      "name": "list_with_booleans_build_model",
+      "source_test": "list_with_booleans",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -775,6 +957,33 @@
       "name": "list_with_whitespace_build_hierarchy",
       "source_test": "list_with_whitespace",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {},
+            "normal": {},
+            "spaced": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
+      "name": "list_with_whitespace_build_model",
+      "source_test": "list_with_whitespace",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -887,6 +1096,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "names": {
+            "François": {},
+            "José": {},
+            "العربية": {},
+            "张三": {}
+          }
+        }
+      },
+      "features": [
+        "unicode"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode_build_model",
+      "source_test": "list_with_unicode",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "names"
       ],
@@ -989,6 +1226,32 @@
       "name": "list_with_special_characters_build_hierarchy",
       "source_test": "list_with_special_characters",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "symbols": {
+            "!^\u0026*()": {},
+            "\u003c\u003e=+": {},
+            "@#$%": {},
+            "[]{}|": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^\u0026*()\nsymbols = []{}|\nsymbols = \u003c\u003e=+"
+      ],
+      "name": "list_with_special_characters_build_model",
+      "source_test": "list_with_special_characters",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1099,6 +1362,38 @@
       "name": "list_multiline_values_build_hierarchy",
       "source_test": "list_multiline_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "expected": {
+        "count": 1,
+        "object": {
+          "descriptions": {
+            "Another item": {},
+            "First line": {},
+            "Third item": {}
+          },
+          "second line": {
+            "": {}
+          }
+        }
+      },
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "descriptions = First line\nsecond line\ndescriptions = Another item\ndescriptions = Third item"
+      ],
+      "name": "list_multiline_values_build_model",
+      "source_test": "list_multiline_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1219,6 +1514,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "cache": {
+              "redis": {}
+            },
+            "database": {
+              "hosts": {
+                "backup": {},
+                "primary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            },
+            "servers": {
+              "web1": {},
+              "web2": {}
+            }
+          },
+          "features": {
+            "api": {},
+            "auth": {},
+            "ui": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
+      "name": "complex_mixed_list_scenarios_build_model",
+      "source_test": "complex_mixed_list_scenarios",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "features"
       ],
@@ -1298,6 +1636,29 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "safe": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
+      "name": "list_path_traversal_protection_build_model",
+      "source_test": "list_path_traversal_protection",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "safe"
       ],
@@ -1369,6 +1730,29 @@
       "name": "parse_empty_value_build_hierarchy",
       "source_test": "parse_empty_value",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_key": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
+      "name": "parse_empty_value_build_model",
+      "source_test": "parse_empty_value",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_reference_compliant.json
+++ b/generated_tests/api_reference_compliant.json
@@ -50,6 +50,31 @@
       ]
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "item": {
+            "single": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "item = single"
+      ],
+      "name": "single_item_as_list_reference_build_model",
+      "source_test": "single_item_as_list_reference",
+      "validation": "build_model",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
       "args": [
         "item"
       ],
@@ -142,6 +167,33 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "host": {
+            "localhost": {}
+          },
+          "ports": {
+            "443": {},
+            "80": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
+      "name": "mixed_duplicate_single_keys_reference_build_model",
+      "source_test": "mixed_duplicate_single_keys_reference",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "host"
       ],
@@ -225,6 +277,37 @@
       ]
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "hosts": {
+              "primary": {},
+              "secondary": {}
+            },
+            "port": {
+              "5432": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
+      "name": "nested_list_access_reference_build_model",
+      "source_test": "nested_list_access_reference",
+      "validation": "build_model",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
       "args": [
         "database",
         "port"
@@ -299,6 +382,31 @@
       "name": "empty_list_reference_build_hierarchy",
       "source_test": "empty_list_reference",
       "validation": "build_hierarchy",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_list": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
+      "name": "empty_list_reference_build_model",
+      "source_test": "empty_list_reference",
+      "validation": "build_model",
       "variants": [
         "reference_compliant"
       ]
@@ -391,6 +499,32 @@
       "name": "list_with_numbers_reference_build_hierarchy",
       "source_test": "list_with_numbers_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "numbers": {
+            "-17": {},
+            "0": {},
+            "1": {},
+            "42": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
+      "name": "list_with_numbers_reference_build_model",
+      "source_test": "list_with_numbers_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -488,6 +622,32 @@
       "name": "list_with_booleans_reference_build_hierarchy",
       "source_test": "list_with_booleans_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flags": {
+            "false": {},
+            "no": {},
+            "true": {},
+            "yes": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
+      "name": "list_with_booleans_reference_build_model",
+      "source_test": "list_with_booleans_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -591,6 +751,34 @@
       "name": "list_with_whitespace_reference_build_hierarchy",
       "source_test": "list_with_whitespace_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "items": {
+            "": {},
+            "normal": {},
+            "spaced": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
+      "name": "list_with_whitespace_reference_build_model",
+      "source_test": "list_with_whitespace_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -698,6 +886,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "names": {
+            "François": {},
+            "José": {},
+            "العربية": {},
+            "张三": {}
+          }
+        }
+      },
+      "features": [
+        "unicode"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode_reference_build_model",
+      "source_test": "list_with_unicode_reference",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "names"
       ],
@@ -792,6 +1008,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "symbols": {
+            "!^\u0026*()": {},
+            "@#$%": {},
+            "[]{}|": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^\u0026*()\nsymbols = []{}|"
+      ],
+      "name": "list_with_special_characters_reference_build_model",
+      "source_test": "list_with_special_characters_reference",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "symbols"
       ],
@@ -864,6 +1105,49 @@
       "name": "complex_mixed_list_scenarios_reference_build_hierarchy",
       "source_test": "complex_mixed_list_scenarios_reference",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "cache": {
+              "redis": {}
+            },
+            "database": {
+              "hosts": {
+                "backup": {},
+                "primary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            },
+            "servers": {
+              "web1": {},
+              "web2": {}
+            }
+          },
+          "features": {
+            "api": {},
+            "auth": {},
+            "ui": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
+      "name": "complex_mixed_list_scenarios_reference_build_model",
+      "source_test": "complex_mixed_list_scenarios_reference",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -945,6 +1229,31 @@
       ]
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "safe": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
+      "name": "list_path_traversal_protection_reference_build_model",
+      "source_test": "list_path_traversal_protection_reference",
+      "validation": "build_model",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
       "args": [
         "safe"
       ],
@@ -1017,6 +1326,31 @@
       "name": "empty_value_reference_behavior_build_hierarchy",
       "source_test": "empty_value_reference_behavior",
       "validation": "build_hierarchy",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "empty_key": {
+            "": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
+      "name": "empty_value_reference_behavior_build_model",
+      "source_test": "empty_value_reference_behavior",
+      "validation": "build_model",
       "variants": [
         "reference_compliant"
       ]

--- a/generated_tests/api_typed_access.json
+++ b/generated_tests/api_typed_access.json
@@ -50,6 +50,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "port = 8080"
+      ],
+      "name": "parse_basic_integer_build_model",
+      "source_test": "parse_basic_integer",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "port"
       ],
@@ -121,6 +146,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "temperature": {
+            "98.6": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "temperature = 98.6"
+      ],
+      "name": "parse_basic_float_build_model",
+      "source_test": "parse_basic_float",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "temperature"
       ],
@@ -189,6 +239,31 @@
       "name": "parse_boolean_true_build_hierarchy",
       "source_test": "parse_boolean_true",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "enabled": {
+            "true": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "enabled = true"
+      ],
+      "name": "parse_boolean_true_build_model",
+      "source_test": "parse_boolean_true",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -272,6 +347,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "active": {
+            "yes": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes_build_model",
+      "source_test": "parse_boolean_yes",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "active"
       ],
@@ -347,6 +447,31 @@
       "name": "parse_boolean_yes_strict_literal_build_hierarchy",
       "source_test": "parse_boolean_yes_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "active": {
+            "yes": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes_strict_literal_build_model",
+      "source_test": "parse_boolean_yes_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -427,6 +552,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "disabled": {
+            "false": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "disabled = false"
+      ],
+      "name": "parse_boolean_false_build_model",
+      "source_test": "parse_boolean_false",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "disabled"
       ],
@@ -503,6 +653,29 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "name": {
+            "Alice": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "name = Alice"
+      ],
+      "name": "parse_string_fallback_build_model",
+      "source_test": "parse_string_fallback",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "name"
       ],
@@ -569,6 +742,31 @@
       "name": "parse_negative_integer_build_hierarchy",
       "source_test": "parse_negative_integer",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "offset": {
+            "-42": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "offset = -42"
+      ],
+      "name": "parse_negative_integer_build_model",
+      "source_test": "parse_negative_integer",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -652,6 +850,38 @@
       "name": "parse_zero_values_build_hierarchy",
       "source_test": "parse_zero_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "count": {
+            "0": {}
+          },
+          "disabled": {
+            "no": {}
+          },
+          "distance": {
+            "0.0": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
+      "name": "parse_zero_values_build_model",
+      "source_test": "parse_zero_values",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -791,6 +1021,38 @@
       "name": "parse_zero_values_strict_literal_build_hierarchy",
       "source_test": "parse_zero_values_strict_literal",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "count": {
+            "0": {}
+          },
+          "disabled": {
+            "no": {}
+          },
+          "distance": {
+            "0.0": {}
+          }
+        }
+      },
+      "features": [
+        "empty_keys",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
+      "name": "parse_zero_values_strict_literal_build_model",
+      "source_test": "parse_zero_values_strict_literal",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -950,6 +1212,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag1": {
+            "yes": {}
+          },
+          "flag2": {
+            "on": {}
+          },
+          "flag3": {
+            "1": {}
+          },
+          "flag4": {
+            "false": {}
+          },
+          "flag5": {
+            "no": {}
+          },
+          "flag6": {
+            "off": {}
+          },
+          "flag7": {
+            "0": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
+      ],
+      "name": "parse_boolean_variants_build_model",
+      "source_test": "parse_boolean_variants",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "flag3"
       ],
@@ -1081,6 +1386,49 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag1": {
+            "yes": {}
+          },
+          "flag2": {
+            "on": {}
+          },
+          "flag3": {
+            "1": {}
+          },
+          "flag4": {
+            "false": {}
+          },
+          "flag5": {
+            "no": {}
+          },
+          "flag6": {
+            "off": {}
+          },
+          "flag7": {
+            "0": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
+      ],
+      "name": "parse_boolean_variants_strict_literal_build_model",
+      "source_test": "parse_boolean_variants_strict_literal",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "flag3"
       ],
@@ -1198,6 +1546,43 @@
       "name": "parse_mixed_types_build_hierarchy",
       "source_test": "parse_mixed_types",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "debug": {
+            "off": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          },
+          "ssl": {
+            "true": {}
+          },
+          "timeout": {
+            "30.5": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types_build_model",
+      "source_test": "parse_mixed_types",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1368,6 +1753,43 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "debug": {
+            "off": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          },
+          "ssl": {
+            "true": {}
+          },
+          "timeout": {
+            "30.5": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types_strict_literal_build_model",
+      "source_test": "parse_mixed_types_strict_literal",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "host"
       ],
@@ -1522,6 +1944,35 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "flag": {
+            "true": {}
+          },
+          "number": {
+            "42": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "number =   42   \nflag =  true  "
+      ],
+      "name": "parse_with_whitespace_build_model",
+      "source_test": "parse_with_whitespace",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "number"
       ],
@@ -1633,6 +2084,40 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "decimal": {
+            "3.14": {}
+          },
+          "flag": {
+            "true": {}
+          },
+          "number": {
+            "42": {}
+          },
+          "text": {
+            "hello": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "number = 42\ndecimal = 3.14\nflag = true\ntext = hello"
+      ],
+      "name": "parse_with_conservative_options_build_model",
+      "source_test": "parse_with_conservative_options",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "decimal"
       ],
@@ -1727,6 +2212,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "port": {
+            "not_a_number": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "port = not_a_number"
+      ],
+      "name": "parse_integer_error_build_model",
+      "source_test": "parse_integer_error",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "port"
       ],
@@ -1794,6 +2304,31 @@
       "name": "parse_float_error_build_hierarchy",
       "source_test": "parse_float_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "temperature": {
+            "invalid": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "temperature = invalid"
+      ],
+      "name": "parse_float_error_build_model",
+      "source_test": "parse_float_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1867,6 +2402,31 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "enabled": {
+            "maybe": {}
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "enabled = maybe"
+      ],
+      "name": "parse_boolean_error_build_model",
+      "source_test": "parse_boolean_error",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "enabled"
       ],
@@ -1937,6 +2497,29 @@
       "name": "parse_missing_path_error_build_hierarchy",
       "source_test": "parse_missing_path_error",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "existing": {
+            "value": {}
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
+      "name": "parse_missing_path_error_build_model",
+      "source_test": "parse_missing_path_error",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2302,6 +2885,39 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "config": {
+            "debug": {
+              "true": {}
+            },
+            "experimental": {
+              "yes": {}
+            },
+            "verbose": {
+              "false": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  debug = true\n  verbose = false\n  experimental = yes"
+      ],
+      "name": "boolean_nested_object_build_model",
+      "source_test": "boolean_nested_object",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "flag",
@@ -2476,6 +3092,36 @@
       "behaviors": [],
       "expected": {
         "count": 1,
+        "object": {
+          "config": {
+            "count": {
+              "abc": {}
+            },
+            "name": {
+              "test": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  name = test\n  count = abc"
+      ],
+      "name": "type_mismatch_nested_path_build_model",
+      "source_test": "type_mismatch_nested_path",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
         "entries": [
           {
             "key": "empty",
@@ -2578,6 +3224,36 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "max_connections": {
+              "1000": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  port = 8080\n  max_connections = 1000"
+      ],
+      "name": "nested_get_int_build_model",
+      "source_test": "nested_get_int",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "server",
         "max_connections"
@@ -2659,6 +3335,40 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "database": {
+              "pool": {
+                "max": {
+                  "50": {}
+                },
+                "min": {
+                  "5": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
+      "name": "deeply_nested_get_int_build_model",
+      "source_test": "deeply_nested_get_int",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "config",
         "database",
@@ -2735,6 +3445,36 @@
       "name": "nested_get_float_build_hierarchy",
       "source_test": "nested_get_float",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "metrics": {
+            "cpu_threshold": {
+              "0.85": {}
+            },
+            "memory_limit": {
+              "2.5": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
+      "name": "nested_get_float_build_model",
+      "source_test": "nested_get_float",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2819,6 +3559,40 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "app": {
+            "scoring": {
+              "weights": {
+                "freshness": {
+                  "0.4": {}
+                },
+                "relevance": {
+                  "0.6": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
+      "name": "deeply_nested_get_float_build_model",
+      "source_test": "deeply_nested_get_float",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "app",
         "scoring",
@@ -2895,6 +3669,36 @@
       "name": "nested_get_bool_build_hierarchy",
       "source_test": "nested_get_bool",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "feature_flags": {
+            "beta_access": {
+              "false": {}
+            },
+            "dark_mode": {
+              "true": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
+      "name": "nested_get_bool_build_model",
+      "source_test": "nested_get_bool",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -2987,6 +3791,40 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "services": {
+            "auth": {
+              "settings": {
+                "allow_anonymous": {
+                  "false": {}
+                },
+                "require_mfa": {
+                  "true": {}
+                }
+              }
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
+      "name": "deeply_nested_get_bool_build_model",
+      "source_test": "deeply_nested_get_bool",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "services",
         "auth",
@@ -3070,6 +3908,34 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "database": {
+            "host": {
+              "localhost": {}
+            },
+            "name": {
+              "mydb": {}
+            }
+          }
+        }
+      },
+      "features": [],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
+      "name": "nested_get_string_basic_build_model",
+      "source_test": "nested_get_string_basic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "database",
         "name"
@@ -3144,6 +4010,42 @@
       "name": "nested_mixed_typed_access_build_hierarchy",
       "source_test": "nested_mixed_typed_access",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "server": {
+            "debug": {
+              "true": {}
+            },
+            "host": {
+              "0.0.0.0": {}
+            },
+            "port": {
+              "3000": {}
+            },
+            "rate_limit": {
+              "1.5": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access_build_model",
+      "source_test": "nested_mixed_typed_access",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -52,6 +52,32 @@
       "variants": []
     },
     {
+      "behaviors": [],
+      "expected": {
+        "count": 1,
+        "object": {
+          "key": {
+            "value\twith\ttabs": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs"
+      ],
+      "name": "tabs_as_whitespace_in_value_build_model",
+      "source_test": "tabs_as_whitespace_in_value",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
       "args": [
         "key"
       ],
@@ -694,6 +720,41 @@
     },
     {
       "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key1": {
+            "value1": {}
+          },
+          "key2": {
+            "value2": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_normalize_to_lf_basic_build_model",
+      "source_test": "crlf_normalize_to_lf_basic",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
         "crlf_preserve_literal"
       ],
       "conflicts": {
@@ -757,6 +818,41 @@
       "name": "crlf_preserve_literal_basic_build_hierarchy",
       "source_test": "crlf_preserve_literal_basic",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "key1": {
+            "value1\r": {}
+          },
+          "key2": {
+            "value2\r": {}
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
+      "name": "crlf_preserve_literal_basic_build_model",
+      "source_test": "crlf_preserve_literal_basic",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -934,6 +1030,43 @@
     },
     {
       "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_nested_structure_build_model",
+      "source_test": "crlf_nested_structure",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
         "crlf_preserve_literal"
       ],
       "conflicts": {
@@ -995,6 +1128,43 @@
       "name": "crlf_preserve_nested_structure_build_hierarchy",
       "source_test": "crlf_preserve_nested_structure",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "config": {
+            "host": {
+              "localhost\r": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          }
+        }
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
+      "name": "crlf_preserve_nested_structure_build_model",
+      "source_test": "crlf_preserve_nested_structure",
+      "validation": "build_model",
       "variants": []
     },
     {
@@ -1252,6 +1422,46 @@
     },
     {
       "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_preserve_literal"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "Port setting": {},
+            "Server config": {}
+          },
+          "host": {
+            "localhost": {}
+          },
+          "port": {
+            "8080": {}
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_normalize_comments_and_values_build_model",
+      "source_test": "crlf_normalize_comments_and_values",
+      "validation": "build_model",
+      "variants": []
+    },
+    {
+      "behaviors": [
         "crlf_preserve_literal"
       ],
       "conflicts": {
@@ -1371,6 +1581,46 @@
       "name": "crlf_preserve_comments_and_values_build_hierarchy",
       "source_test": "crlf_preserve_comments_and_values",
       "validation": "build_hierarchy",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "crlf_preserve_literal"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "crlf_normalize_to_lf"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "object": {
+          "/": {
+            "Port setting\r": {},
+            "Server config\r": {}
+          },
+          "host": {
+            "localhost\r": {}
+          },
+          "port": {
+            "8080\r": {}
+          }
+        }
+      },
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "parse_indented",
+        "build_model"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
+      "name": "crlf_preserve_comments_and_values_build_model",
+      "source_test": "crlf_preserve_comments_and_values",
+      "validation": "build_model",
       "variants": []
     },
     {

--- a/generator/generator.go
+++ b/generator/generator.go
@@ -284,6 +284,7 @@ func (fg *FlatGenerator) TransformSourceToFlat(sourceTest types.TestCase) ([]typ
 var compositeFunctionMap = map[string][]string{
 	"round_trip":          {"parse", "print"},
 	"build_hierarchy":     {"parse_indented", "build_hierarchy"},
+	"build_model":         {"parse_indented", "build_model"},
 	"load":                {"parse_indented", "build_hierarchy"},
 	"canonical_format":    {"parse", "print", "canonical_format"},
 	"compose_associative": {"parse", "compose"},
@@ -506,8 +507,8 @@ func (fg *FlatGenerator) createExpectedStructure(validation string, data interfa
 			}
 			expected.Entries = entryList
 		}
-	case "build_hierarchy":
-		// Hierarchy expects an object
+	case "build_hierarchy", "build_model":
+		// Hierarchy and canonical model both expect a nested object
 		expected.Count = 1
 		expected.Object = data
 	case "get_string", "get_int", "get_bool", "get_float":
@@ -579,8 +580,8 @@ func (fg *FlatGenerator) convertPredicate(predicate *types.Predicate) *generated
 		return nil
 	}
 	return &generated.GeneratedFormatSimpleJsonTestsElemPredicate{
-		Field: predicate.Field,
-		Op:    predicate.Op,
+		Field: generated.GeneratedFormatSimpleJsonTestsElemPredicateField(predicate.Field),
+		Op:    generated.GeneratedFormatSimpleJsonTestsElemPredicateOp(predicate.Op),
 		Value: predicate.Value,
 	}
 }

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -43,6 +43,12 @@ func TestBasicObjectConstructionBuildHierarchy(t *testing.T) {
 }
 
 
+// basic_object_construction_build_model - function:parse_indented function:build_model
+func TestBasicObjectConstructionBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // basic_object_construction_print - function:print
 func TestBasicObjectConstructionPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -82,6 +88,12 @@ func TestDeepNestedObjectsBuildHierarchy(t *testing.T) {
 }
 
 
+// deep_nested_objects_build_model - function:parse_indented function:build_model
+func TestDeepNestedObjectsBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // deep_nested_objects_print - function:print
 func TestDeepNestedObjectsPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -114,6 +126,12 @@ item = third`
 
 // duplicate_keys_to_lists_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestDuplicateKeysToListsBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// duplicate_keys_to_lists_build_model - function:parse_indented function:build_model
+func TestDuplicateKeysToListsBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_core_ccl_hierarchy_test.go
+++ b/go_tests/parsing/api_core_ccl_hierarchy_test.go
@@ -173,6 +173,12 @@ func TestNestedDuplicateKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// nested_duplicate_keys_build_model - function:parse_indented function:build_model
+func TestNestedDuplicateKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // nested_duplicate_keys_print - function:print
 func TestNestedDuplicateKeysPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -207,6 +213,12 @@ version = 1.0`
 
 // mixed_flat_and_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestMixedFlatAndNestedBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// mixed_flat_and_nested_build_model - function:parse_indented function:build_model
+func TestMixedFlatAndNestedBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -252,6 +264,12 @@ func TestNestedObjectsWithListsBuildHierarchy(t *testing.T) {
 }
 
 
+// nested_objects_with_lists_build_model - function:parse_indented function:build_model
+func TestNestedObjectsWithListsBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // nested_objects_with_lists_print - function:print
 func TestNestedObjectsWithListsPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -287,6 +305,12 @@ func TestDeeplyNestedListParse(t *testing.T) {
 
 // deeply_nested_list_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestDeeplyNestedListBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// deeply_nested_list_build_model - function:parse_indented function:build_model
+func TestDeeplyNestedListBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_core_ccl_integration_test.go
+++ b/go_tests/parsing/api_core_ccl_integration_test.go
@@ -43,6 +43,12 @@ func TestCompleteBasicWorkflowBuildHierarchy(t *testing.T) {
 }
 
 
+// complete_basic_workflow_build_model - function:parse_indented function:build_model
+func TestCompleteBasicWorkflowBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // complete_basic_workflow_print - function:print
 func TestCompleteBasicWorkflowPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -76,6 +82,12 @@ func TestCompleteNestedWorkflowParse(t *testing.T) {
 
 // complete_nested_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestCompleteNestedWorkflowBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// complete_nested_workflow_build_model - function:parse_indented function:build_model
+func TestCompleteNestedWorkflowBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -120,6 +132,12 @@ func TestCompleteMixedWorkflowBuildHierarchy(t *testing.T) {
 }
 
 
+// complete_mixed_workflow_build_model - function:parse_indented function:build_model
+func TestCompleteMixedWorkflowBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // complete_mixed_workflow_print - function:print
 func TestCompleteMixedWorkflowPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -156,6 +174,12 @@ ports =
 
 // complete_lists_workflow_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestCompleteListsWorkflowBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// complete_lists_workflow_build_model - function:parse_indented function:build_model
+func TestCompleteListsWorkflowBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -200,6 +224,12 @@ func TestCompleteListsWorkflowLexicographicBuildHierarchy(t *testing.T) {
 }
 
 
+// complete_lists_workflow_lexicographic_build_model - function:parse_indented function:build_model
+func TestCompleteListsWorkflowLexicographicBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // complete_lists_workflow_lexicographic_print - function:print
 func TestCompleteListsWorkflowLexicographicPrint(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -236,6 +266,12 @@ config =
 
 // complete_multiline_workflow_build_hierarchy - function:parse_indented function:build_hierarchy feature:multiline_continuation behavior:multiline_values
 func TestCompleteMultilineWorkflowBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// complete_multiline_workflow_build_model - function:parse_indented function:build_model feature:multiline_continuation behavior:multiline_values
+func TestCompleteMultilineWorkflowBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -290,6 +326,12 @@ features =
 
 // real_world_complete_workflow_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRealWorldCompleteWorkflowBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// real_world_complete_workflow_build_model - function:parse_indented function:build_model
+func TestRealWorldCompleteWorkflowBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_core_ccl_model_test.go
+++ b/go_tests/parsing/api_core_ccl_model_test.go
@@ -1,0 +1,160 @@
+package parsing_test
+
+import (
+	"testing"
+	
+	"github.com/catconflang/ccl-test-data/internal/mock"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Generated from generated_tests/api_core_ccl_model.json
+// Suite: Flat Format
+// Version: 1.0
+
+
+
+// model_single_pair_parse - function:parse
+func TestModelSinglePairParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "key", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// model_single_pair_build_model - function:parse_indented function:build_model
+func TestModelSinglePairBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// model_duplicate_keys_merge_to_multi_leaf_parse - function:parse
+func TestModelDuplicateKeysMergeToMultiLeafParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `item = first
+item = second`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "item", Value: "first"}, mock.Entry{Key: "item", Value: "second"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// model_duplicate_keys_merge_to_multi_leaf_build_model - function:parse_indented function:build_model
+func TestModelDuplicateKeysMergeToMultiLeafBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// model_repeated_value_is_idempotent_parse - function:parse
+func TestModelRepeatedValueIsIdempotentParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `item = a
+item = b
+item = a`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "item", Value: "a"}, mock.Entry{Key: "item", Value: "b"}, mock.Entry{Key: "item", Value: "a"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// model_repeated_value_is_idempotent_build_model - function:parse_indented function:build_model
+func TestModelRepeatedValueIsIdempotentBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// model_multiple_distinct_keys_parse - function:parse
+func TestModelMultipleDistinctKeysParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `host = localhost
+port = 8080`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "host", Value: "localhost"}, mock.Entry{Key: "port", Value: "8080"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// model_multiple_distinct_keys_build_model - function:parse_indented function:build_model
+func TestModelMultipleDistinctKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// model_empty_input_parse - function:parse
+func TestModelEmptyInputParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := ""
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
+// model_empty_input_build_model - function:parse_indented function:build_model
+func TestModelEmptyInputBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+

--- a/go_tests/parsing/api_edge_cases_test.go
+++ b/go_tests/parsing/api_edge_cases_test.go
@@ -796,6 +796,12 @@ func TestOcamlStressTestOriginalBuildHierarchy(t *testing.T) {
 }
 
 
+// ocaml_stress_test_original_build_model - function:parse_indented function:build_model feature:comments feature:empty_keys
+func TestOcamlStressTestOriginalBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // ocaml_stress_test_original_get_string - function:get_string feature:comments feature:empty_keys
 func TestOcamlStressTestOriginalGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -828,6 +834,12 @@ func TestForwardSlashesInMapKeysParse(t *testing.T) {
 
 // forward_slashes_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestForwardSlashesInMapKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// forward_slashes_in_map_keys_build_model - function:parse_indented function:build_model
+func TestForwardSlashesInMapKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -868,6 +880,12 @@ func TestBackslashesInMapKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// backslashes_in_map_keys_build_model - function:parse_indented function:build_model
+func TestBackslashesInMapKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // colons_in_map_keys_parse - function:parse
 func TestColonsInMapKeysParse(t *testing.T) {
 	
@@ -894,6 +912,12 @@ func TestColonsInMapKeysParse(t *testing.T) {
 
 // colons_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestColonsInMapKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// colons_in_map_keys_build_model - function:parse_indented function:build_model
+func TestColonsInMapKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -928,6 +952,12 @@ func TestHyphensInMapKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// hyphens_in_map_keys_build_model - function:parse_indented function:build_model
+func TestHyphensInMapKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // at_signs_in_map_keys_parse - function:parse
 func TestAtSignsInMapKeysParse(t *testing.T) {
 	
@@ -954,6 +984,12 @@ func TestAtSignsInMapKeysParse(t *testing.T) {
 
 // at_signs_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestAtSignsInMapKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// at_signs_in_map_keys_build_model - function:parse_indented function:build_model
+func TestAtSignsInMapKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -988,6 +1024,12 @@ func TestHashInMapKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// hash_in_map_keys_build_model - function:parse_indented function:build_model
+func TestHashInMapKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // brackets_in_map_keys_parse - function:parse
 func TestBracketsInMapKeysParse(t *testing.T) {
 	
@@ -1018,6 +1060,12 @@ func TestBracketsInMapKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// brackets_in_map_keys_build_model - function:parse_indented function:build_model
+func TestBracketsInMapKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parentheses_in_map_keys_parse - function:parse
 func TestParenthesesInMapKeysParse(t *testing.T) {
 	
@@ -1044,6 +1092,12 @@ func TestParenthesesInMapKeysParse(t *testing.T) {
 
 // parentheses_in_map_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParenthesesInMapKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parentheses_in_map_keys_build_model - function:parse_indented function:build_model
+func TestParenthesesInMapKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1079,6 +1133,12 @@ func TestMixedSpecialCharsInKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// mixed_special_chars_in_keys_build_model - function:parse_indented function:build_model
+func TestMixedSpecialCharsInKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // url_like_keys_parse - function:parse
 func TestUrlLikeKeysParse(t *testing.T) {
 	
@@ -1105,6 +1165,12 @@ func TestUrlLikeKeysParse(t *testing.T) {
 
 // url_like_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlLikeKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// url_like_keys_build_model - function:parse_indented function:build_model
+func TestUrlLikeKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1137,6 +1203,12 @@ func TestRelativePathParentParentBuildHierarchy(t *testing.T) {
 }
 
 
+// relative_path_parent_parent_build_model - function:parse_indented function:build_model
+func TestRelativePathParentParentBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // relative_path_parent_parse - function:parse
 func TestRelativePathParentParse(t *testing.T) {
 	
@@ -1161,6 +1233,12 @@ func TestRelativePathParentParse(t *testing.T) {
 
 // relative_path_parent_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathParentBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// relative_path_parent_build_model - function:parse_indented function:build_model
+func TestRelativePathParentBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1193,6 +1271,12 @@ func TestRelativePathSingleDotBuildHierarchy(t *testing.T) {
 }
 
 
+// relative_path_single_dot_build_model - function:parse_indented function:build_model
+func TestRelativePathSingleDotBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // double_slash_parse - function:parse
 func TestDoubleSlashParse(t *testing.T) {
 	
@@ -1221,6 +1305,12 @@ func TestDoubleSlashBuildHierarchy(t *testing.T) {
 }
 
 
+// double_slash_build_model - function:parse_indented function:build_model
+func TestDoubleSlashBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // relative_path_in_value_parse - function:parse
 func TestRelativePathInValueParse(t *testing.T) {
 	
@@ -1245,6 +1335,12 @@ func TestRelativePathInValueParse(t *testing.T) {
 
 // relative_path_in_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathInValueBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// relative_path_in_value_build_model - function:parse_indented function:build_model
+func TestRelativePathInValueBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1285,6 +1381,12 @@ func TestRelativePathInNestedValueBuildHierarchy(t *testing.T) {
 }
 
 
+// relative_path_in_nested_value_build_model - function:parse_indented function:build_model
+func TestRelativePathInNestedValueBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // relative_path_in_nested_value_get_string - function:get_string behavior:path_traversal
 func TestRelativePathInNestedValueGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1321,6 +1423,12 @@ func TestDoubleSlashInNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// double_slash_in_nested_build_model - function:parse_indented function:build_model
+func TestDoubleSlashInNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // relative_paths_deeply_nested_parse - function:parse
 func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 	
@@ -1348,6 +1456,12 @@ func TestRelativePathsDeeplyNestedParse(t *testing.T) {
 
 // relative_paths_deeply_nested_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathsDeeplyNestedBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// relative_paths_deeply_nested_build_model - function:parse_indented function:build_model
+func TestRelativePathsDeeplyNestedBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1385,6 +1499,12 @@ func TestRelativePathsAsNestedKeysParse(t *testing.T) {
 
 // relative_paths_as_nested_keys_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestRelativePathsAsNestedKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// relative_paths_as_nested_keys_build_model - function:parse_indented function:build_model
+func TestRelativePathsAsNestedKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1428,6 +1548,12 @@ func TestMixedRelativeAndAbsoluteNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// mixed_relative_and_absolute_nested_build_model - function:parse_indented function:build_model
+func TestMixedRelativeAndAbsoluteNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // mixed_relative_and_absolute_nested_get_string - function:get_string behavior:path_traversal
 func TestMixedRelativeAndAbsoluteNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1467,6 +1593,12 @@ func TestDoubleSlashDeeplyNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// double_slash_deeply_nested_build_model - function:parse_indented function:build_model
+func TestDoubleSlashDeeplyNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // double_slash_deeply_nested_get_string - function:get_string behavior:path_traversal
 func TestDoubleSlashDeeplyNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1497,6 +1629,12 @@ func TestUrlAsKeyParse(t *testing.T) {
 
 // url_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlAsKeyBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// url_as_key_build_model - function:parse_indented function:build_model
+func TestUrlAsKeyBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1535,6 +1673,12 @@ func TestUrlWithPortAsKeyBuildHierarchy(t *testing.T) {
 }
 
 
+// url_with_port_as_key_build_model - function:parse_indented function:build_model
+func TestUrlWithPortAsKeyBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // url_with_path_as_key_parse - function:parse
 func TestUrlWithPathAsKeyParse(t *testing.T) {
 	
@@ -1563,6 +1707,12 @@ func TestUrlWithPathAsKeyBuildHierarchy(t *testing.T) {
 }
 
 
+// url_with_path_as_key_build_model - function:parse_indented function:build_model
+func TestUrlWithPathAsKeyBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // url_in_value_parse - function:parse
 func TestUrlInValueParse(t *testing.T) {
 	
@@ -1587,6 +1737,12 @@ func TestUrlInValueParse(t *testing.T) {
 
 // url_in_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlInValueBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// url_in_value_build_model - function:parse_indented function:build_model
+func TestUrlInValueBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1623,6 +1779,12 @@ func TestUrlsAsNestedKeysAndValuesParse(t *testing.T) {
 
 // urls_as_nested_keys_and_values_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlsAsNestedKeysAndValuesBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// urls_as_nested_keys_and_values_build_model - function:parse_indented function:build_model
+func TestUrlsAsNestedKeysAndValuesBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1667,6 +1829,12 @@ func TestUrlsDeeplyNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// urls_deeply_nested_build_model - function:parse_indented function:build_model
+func TestUrlsDeeplyNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // urls_deeply_nested_get_string - function:get_string behavior:path_traversal
 func TestUrlsDeeplyNestedGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1681,6 +1849,12 @@ func TestUrlWithQueryParamsAsKeyParse(t *testing.T) {
 
 // url_with_query_params_as_key_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestUrlWithQueryParamsAsKeyBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// url_with_query_params_as_key_build_model - function:parse_indented function:build_model behavior:delimiter_prefer_spaced
+func TestUrlWithQueryParamsAsKeyBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1713,6 +1887,12 @@ func TestDelimiterFirstUrlWithQueryParamsBuildHierarchy(t *testing.T) {
 }
 
 
+// delimiter_first_url_with_query_params_build_model - function:parse_indented function:build_model behavior:delimiter_first_equals
+func TestDelimiterFirstUrlWithQueryParamsBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // delimiter_first_multiple_equals_parse - function:parse behavior:delimiter_first_equals
 func TestDelimiterFirstMultipleEqualsParse(t *testing.T) {
 	
@@ -1737,6 +1917,12 @@ func TestDelimiterFirstMultipleEqualsParse(t *testing.T) {
 
 // delimiter_first_multiple_equals_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_first_equals
 func TestDelimiterFirstMultipleEqualsBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// delimiter_first_multiple_equals_build_model - function:parse_indented function:build_model behavior:delimiter_first_equals
+func TestDelimiterFirstMultipleEqualsBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1769,6 +1955,12 @@ func TestDelimiterFirstEmptyValueBuildHierarchy(t *testing.T) {
 }
 
 
+// delimiter_first_empty_value_build_model - function:parse_indented function:build_model behavior:delimiter_first_equals
+func TestDelimiterFirstEmptyValueBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // delimiter_spaced_multiple_equals_parse - function:parse behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedMultipleEqualsParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
@@ -1777,6 +1969,12 @@ func TestDelimiterSpacedMultipleEqualsParse(t *testing.T) {
 
 // delimiter_spaced_multiple_equals_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedMultipleEqualsBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// delimiter_spaced_multiple_equals_build_model - function:parse_indented function:build_model behavior:delimiter_prefer_spaced
+func TestDelimiterSpacedMultipleEqualsBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1793,6 +1991,12 @@ func TestDelimiterSpacedFallbackNoSpaceBuildHierarchy(t *testing.T) {
 }
 
 
+// delimiter_spaced_fallback_no_space_build_model - function:parse_indented function:build_model behavior:delimiter_prefer_spaced
+func TestDelimiterSpacedFallbackNoSpaceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // delimiter_spaced_empty_value_parse - function:parse behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedEmptyValueParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:delimiter_prefer_spaced")
@@ -1801,6 +2005,12 @@ func TestDelimiterSpacedEmptyValueParse(t *testing.T) {
 
 // delimiter_spaced_empty_value_build_hierarchy - function:parse_indented function:build_hierarchy behavior:delimiter_prefer_spaced
 func TestDelimiterSpacedEmptyValueBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// delimiter_spaced_empty_value_build_model - function:parse_indented function:build_model behavior:delimiter_prefer_spaced
+func TestDelimiterSpacedEmptyValueBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1829,6 +2039,12 @@ func TestUrlWithFragmentAsKeyParse(t *testing.T) {
 
 // url_with_fragment_as_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestUrlWithFragmentAsKeyBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// url_with_fragment_as_key_build_model - function:parse_indented function:build_model
+func TestUrlWithFragmentAsKeyBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed1_test.go
@@ -812,6 +812,12 @@ func TestS1FuzzValName0BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_val_name_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzValName0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_val_name_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -842,6 +848,12 @@ func TestS1FuzzValData1Parse(t *testing.T) {
 
 // s1_fuzz_val_data_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValData1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_val_data_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzValData1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -880,6 +892,12 @@ func TestS1FuzzValMode2BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_val_mode_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzValMode2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_val_mode_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValMode2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -914,6 +932,12 @@ func TestS1FuzzValName3BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_val_name_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzValName3BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_val_name_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzValName3GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -944,6 +968,12 @@ func TestS1FuzzValUser4Parse(t *testing.T) {
 
 // s1_fuzz_val_user_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzValUser4BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_val_user_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzValUser4BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -983,6 +1013,12 @@ func TestS1FuzzNestedAmpersandRbrace0BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_nested_ampersand_rbrace_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedAmpersandRbrace0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_nested_ampersand_rbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandRbrace0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1014,6 +1050,12 @@ func TestS1FuzzNestedQuestionRbracket1Parse(t *testing.T) {
 
 // s1_fuzz_nested_question_rbracket_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedQuestionRbracket1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_nested_question_rbracket_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedQuestionRbracket1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1053,6 +1095,12 @@ func TestS1FuzzNestedPlusSlash2BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_nested_plus_slash_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedPlusSlash2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_nested_plus_slash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedPlusSlash2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1084,6 +1132,12 @@ $port = deep486`
 
 // s1_fuzz_nested_ampersand_dollar_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedAmpersandDollar3BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_nested_ampersand_dollar_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedAmpersandDollar3BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1123,6 +1177,12 @@ func TestS1FuzzNestedTildeSquote4BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_nested_tilde_squote_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedTildeSquote4BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_nested_tilde_squote_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedTildeSquote4GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1154,6 +1214,12 @@ func TestS1FuzzNestedHyphenAmpersand5Parse(t *testing.T) {
 
 // s1_fuzz_nested_hyphen_ampersand_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedHyphenAmpersand5BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_nested_hyphen_ampersand_5_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedHyphenAmpersand5BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1193,6 +1259,12 @@ func TestS1FuzzNestedDollarAsterisk6BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_nested_dollar_asterisk_6_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedDollarAsterisk6BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_nested_dollar_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedDollarAsterisk6GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1224,6 +1296,12 @@ func TestS1FuzzNestedUnderscoreSemicolon7Parse(t *testing.T) {
 
 // s1_fuzz_nested_underscore_semicolon_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedUnderscoreSemicolon7BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_nested_underscore_semicolon_7_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedUnderscoreSemicolon7BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1263,6 +1341,12 @@ func TestS1FuzzNestedAtRparen8BuildHierarchy(t *testing.T) {
 }
 
 
+// s1_fuzz_nested_at_rparen_8_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedAtRparen8BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s1_fuzz_nested_at_rparen_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS1FuzzNestedAtRparen8GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1294,6 +1378,12 @@ func TestS1FuzzNestedRbraceTilde9Parse(t *testing.T) {
 
 // s1_fuzz_nested_rbrace_tilde_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS1FuzzNestedRbraceTilde9BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s1_fuzz_nested_rbrace_tilde_9_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS1FuzzNestedRbraceTilde9BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed42_test.go
@@ -812,6 +812,12 @@ func TestS42FuzzValData0BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_val_data_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzValData0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_val_data_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValData0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -842,6 +848,12 @@ func TestS42FuzzValBeta1Parse(t *testing.T) {
 
 // s42_fuzz_val_beta_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValBeta1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_val_beta_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzValBeta1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -880,6 +892,12 @@ func TestS42FuzzValName2BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_val_name_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzValName2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValName2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -914,6 +932,12 @@ func TestS42FuzzValPath3BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_val_path_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzValPath3BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzValPath3GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -944,6 +968,12 @@ func TestS42FuzzValName4Parse(t *testing.T) {
 
 // s42_fuzz_val_name_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzValName4BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_val_name_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzValName4BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -983,6 +1013,12 @@ func TestS42FuzzNestedLbraceRbracket0BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_nested_lbrace_rbracket_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedLbraceRbracket0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_nested_lbrace_rbracket_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbracket0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1014,6 +1050,12 @@ func TestS42FuzzNestedLbraceRbrace1Parse(t *testing.T) {
 
 // s42_fuzz_nested_lbrace_rbrace_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_nested_lbrace_rbrace_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedLbraceRbrace1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1053,6 +1095,12 @@ func TestS42FuzzNestedAmpersandPercent2BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_nested_ampersand_percent_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedAmpersandPercent2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_nested_ampersand_percent_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedAmpersandPercent2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1084,6 +1132,12 @@ func TestS42FuzzNestedDquoteGt3Parse(t *testing.T) {
 
 // s42_fuzz_nested_dquote_gt_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteGt3BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_nested_dquote_gt_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedDquoteGt3BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1123,6 +1177,12 @@ func TestS42FuzzNestedPercentDollar4BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_nested_percent_dollar_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedPercentDollar4BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_nested_percent_dollar_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedPercentDollar4GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1154,6 +1214,12 @@ func TestS42FuzzNestedDquoteRbracket5Parse(t *testing.T) {
 
 // s42_fuzz_nested_dquote_rbracket_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedDquoteRbracket5BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_nested_dquote_rbracket_5_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedDquoteRbracket5BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1193,6 +1259,12 @@ func TestS42FuzzNestedLbraceAmpersand6BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_nested_lbrace_ampersand_6_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedLbraceAmpersand6BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_nested_lbrace_ampersand_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceAmpersand6GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1224,6 +1296,12 @@ func TestS42FuzzNestedSemicolonHyphen7Parse(t *testing.T) {
 
 // s42_fuzz_nested_semicolon_hyphen_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedSemicolonHyphen7BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_nested_semicolon_hyphen_7_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedSemicolonHyphen7BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1263,6 +1341,12 @@ func TestS42FuzzNestedLbraceRbrace8BuildHierarchy(t *testing.T) {
 }
 
 
+// s42_fuzz_nested_lbrace_rbrace_8_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedLbraceRbrace8BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s42_fuzz_nested_lbrace_rbrace_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS42FuzzNestedLbraceRbrace8GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1294,6 +1378,12 @@ func TestS42FuzzNestedTildeAmpersand9Parse(t *testing.T) {
 
 // s42_fuzz_nested_tilde_ampersand_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS42FuzzNestedTildeAmpersand9BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s42_fuzz_nested_tilde_ampersand_9_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS42FuzzNestedTildeAmpersand9BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed49_test.go
@@ -812,6 +812,12 @@ func TestS49FuzzValEpsilon0BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_val_epsilon_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzValEpsilon0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_val_epsilon_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValEpsilon0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -842,6 +848,12 @@ func TestS49FuzzValConfig1Parse(t *testing.T) {
 
 // s49_fuzz_val_config_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValConfig1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_val_config_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzValConfig1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -880,6 +892,12 @@ func TestS49FuzzValName2BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_val_name_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzValName2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_val_name_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValName2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -914,6 +932,12 @@ func TestS49FuzzValMode3BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_val_mode_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzValMode3BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_val_mode_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzValMode3GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -944,6 +968,12 @@ func TestS49FuzzValServer4Parse(t *testing.T) {
 
 // s49_fuzz_val_server_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzValServer4BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_val_server_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzValServer4BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -983,6 +1013,12 @@ func TestS49FuzzNestedSquoteLbrace0BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_nested_squote_lbrace_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedSquoteLbrace0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_nested_squote_lbrace_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedSquoteLbrace0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1014,6 +1050,12 @@ _user = deep650`
 
 // s49_fuzz_nested_at_underscore_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedAtUnderscore1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_nested_at_underscore_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedAtUnderscore1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1053,6 +1095,12 @@ func TestS49FuzzNestedRparenBackslash2BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_nested_rparen_backslash_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedRparenBackslash2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_nested_rparen_backslash_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedRparenBackslash2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1084,6 +1132,12 @@ func TestS49FuzzNestedDollarGt3Parse(t *testing.T) {
 
 // s49_fuzz_nested_dollar_gt_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedDollarGt3BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_nested_dollar_gt_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedDollarGt3BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1123,6 +1177,12 @@ func TestS49FuzzNestedDquoteLbrace4BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_nested_dquote_lbrace_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedDquoteLbrace4BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_nested_dquote_lbrace_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedDquoteLbrace4GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1154,6 +1214,12 @@ func TestS49FuzzNestedSemicolonAsterisk5Parse(t *testing.T) {
 
 // s49_fuzz_nested_semicolon_asterisk_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedSemicolonAsterisk5BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_nested_semicolon_asterisk_5_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedSemicolonAsterisk5BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1193,6 +1259,12 @@ func TestS49FuzzNestedQuestionAsterisk6BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_nested_question_asterisk_6_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedQuestionAsterisk6BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_nested_question_asterisk_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedQuestionAsterisk6GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1224,6 +1296,12 @@ func TestS49FuzzNestedPlusAmpersand7Parse(t *testing.T) {
 
 // s49_fuzz_nested_plus_ampersand_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedPlusAmpersand7BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_nested_plus_ampersand_7_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedPlusAmpersand7BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1263,6 +1341,12 @@ func TestS49FuzzNestedAsteriskDquote8BuildHierarchy(t *testing.T) {
 }
 
 
+// s49_fuzz_nested_asterisk_dquote_8_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedAsteriskDquote8BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s49_fuzz_nested_asterisk_dquote_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS49FuzzNestedAsteriskDquote8GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1294,6 +1378,12 @@ func TestS49FuzzNestedRbraceSlash9Parse(t *testing.T) {
 
 // s49_fuzz_nested_rbrace_slash_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS49FuzzNestedRbraceSlash9BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s49_fuzz_nested_rbrace_slash_9_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS49FuzzNestedRbraceSlash9BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
+++ b/go_tests/parsing/api_fuzz_special_chars_seed99_test.go
@@ -812,6 +812,12 @@ func TestS99FuzzValPath0BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_val_path_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzValPath0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_val_path_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -842,6 +848,12 @@ func TestS99FuzzValItem1Parse(t *testing.T) {
 
 // s99_fuzz_val_item_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValItem1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_val_item_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzValItem1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -880,6 +892,12 @@ func TestS99FuzzValServer2BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_val_server_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzValServer2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_val_server_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValServer2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -914,6 +932,12 @@ func TestS99FuzzValPath3BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_val_path_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzValPath3BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_val_path_3_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzValPath3GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -944,6 +968,12 @@ func TestS99FuzzValAlpha4Parse(t *testing.T) {
 
 // s99_fuzz_val_alpha_4_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzValAlpha4BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_val_alpha_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzValAlpha4BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -983,6 +1013,12 @@ func TestS99FuzzNestedSlashRparen0BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_nested_slash_rparen_0_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedSlashRparen0BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_nested_slash_rparen_0_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashRparen0GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1014,6 +1050,12 @@ func TestS99FuzzNestedLtPercent1Parse(t *testing.T) {
 
 // s99_fuzz_nested_lt_percent_1_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedLtPercent1BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_nested_lt_percent_1_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedLtPercent1BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1053,6 +1095,12 @@ func TestS99FuzzNestedSlashLbrace2BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_nested_slash_lbrace_2_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedSlashLbrace2BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_nested_slash_lbrace_2_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedSlashLbrace2GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1084,6 +1132,12 @@ func TestS99FuzzNestedDquoteLbracket3Parse(t *testing.T) {
 
 // s99_fuzz_nested_dquote_lbracket_3_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteLbracket3BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_nested_dquote_lbracket_3_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedDquoteLbracket3BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1123,6 +1177,12 @@ func TestS99FuzzNestedBackslashBackslash4BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_nested_backslash_backslash_4_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedBackslashBackslash4BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_nested_backslash_backslash_4_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedBackslashBackslash4GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1154,6 +1214,12 @@ func TestS99FuzzNestedQuestionDquote5Parse(t *testing.T) {
 
 // s99_fuzz_nested_question_dquote_5_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedQuestionDquote5BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_nested_question_dquote_5_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedQuestionDquote5BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1193,6 +1259,12 @@ func TestS99FuzzNestedDquoteBackslash6BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_nested_dquote_backslash_6_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedDquoteBackslash6BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_nested_dquote_backslash_6_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedDquoteBackslash6GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1224,6 +1296,12 @@ func TestS99FuzzNestedRparenBackslash7Parse(t *testing.T) {
 
 // s99_fuzz_nested_rparen_backslash_7_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedRparenBackslash7BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_nested_rparen_backslash_7_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedRparenBackslash7BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1263,6 +1341,12 @@ func TestS99FuzzNestedRbraceDollar8BuildHierarchy(t *testing.T) {
 }
 
 
+// s99_fuzz_nested_rbrace_dollar_8_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedRbraceDollar8BuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // s99_fuzz_nested_rbrace_dollar_8_get_string - function:get_string feature:optional_typed_accessors
 func TestS99FuzzNestedRbraceDollar8GetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1294,6 +1378,12 @@ func TestS99FuzzNestedPercentAmpersand9Parse(t *testing.T) {
 
 // s99_fuzz_nested_percent_ampersand_9_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestS99FuzzNestedPercentAmpersand9BuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// s99_fuzz_nested_percent_ampersand_9_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestS99FuzzNestedPercentAmpersand9BuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_list_access_test.go
+++ b/go_tests/parsing/api_list_access_test.go
@@ -44,6 +44,12 @@ func TestBasicListFromDuplicatesBuildHierarchy(t *testing.T) {
 }
 
 
+// basic_list_from_duplicates_build_model - function:parse_indented function:build_model
+func TestBasicListFromDuplicatesBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // basic_list_from_duplicates_get_list - function:get_list behavior:list_coercion_enabled
 func TestBasicListFromDuplicatesGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -97,6 +103,12 @@ func TestLargeListBuildHierarchy(t *testing.T) {
 }
 
 
+// large_list_build_model - function:parse_indented function:build_model
+func TestLargeListBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // large_list_get_list - function:get_list behavior:list_coercion_enabled
 func TestLargeListGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -131,6 +143,12 @@ servers = web3
 
 // list_with_comments_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments behavior:array_order_insertion
 func TestListWithCommentsBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_with_comments_build_model - function:parse_indented function:build_model feature:comments
+func TestListWithCommentsBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -173,6 +191,12 @@ func TestListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_comments_lexicographic_build_model - function:parse_indented function:build_model feature:comments
+func TestListWithCommentsLexicographicBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_comments_lexicographic_get_list - function:get_list feature:comments behavior:list_coercion_enabled behavior:array_order_lexicographic
 func TestListWithCommentsLexicographicGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -203,6 +227,12 @@ func TestListErrorMissingKeyParse(t *testing.T) {
 
 // list_error_missing_key_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListErrorMissingKeyBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_error_missing_key_build_model - function:parse_indented function:build_model
+func TestListErrorMissingKeyBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -242,6 +272,12 @@ func TestListErrorNestedMissingKeyBuildHierarchy(t *testing.T) {
 }
 
 
+// list_error_nested_missing_key_build_model - function:parse_indented function:build_model
+func TestListErrorNestedMissingKeyBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_error_nested_missing_key_get_list - function:get_list
 func TestListErrorNestedMissingKeyGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -272,6 +308,12 @@ func TestListErrorNonObjectPathParse(t *testing.T) {
 
 // list_error_non_object_path_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestListErrorNonObjectPathBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_error_non_object_path_build_model - function:parse_indented function:build_model
+func TestListErrorNonObjectPathBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -310,6 +352,12 @@ func TestListEdgeCaseZeroLengthBuildHierarchy(t *testing.T) {
 }
 
 
+// list_edge_case_zero_length_build_model - function:parse_indented function:build_model
+func TestListEdgeCaseZeroLengthBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_edge_case_zero_length_get_list - function:get_list
 func TestListEdgeCaseZeroLengthGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -343,6 +391,12 @@ func TestBareListBasicParse(t *testing.T) {
 
 // bare_list_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys
 func TestBareListBasicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// bare_list_basic_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListBasicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -385,6 +439,12 @@ func TestBareListNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// bare_list_nested_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // bare_list_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion behavior:path_traversal
 func TestBareListNestedGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -419,6 +479,12 @@ func TestBareListNestedLexicographicParse(t *testing.T) {
 
 // bare_list_nested_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListNestedLexicographicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// bare_list_nested_lexicographic_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListNestedLexicographicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -461,6 +527,12 @@ func TestBareListWithCommentsBuildHierarchy(t *testing.T) {
 }
 
 
+// bare_list_with_comments_build_model - function:parse_indented function:build_model feature:empty_keys feature:comments
+func TestBareListWithCommentsBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // bare_list_with_comments_get_list - function:get_list feature:empty_keys feature:comments behavior:array_order_insertion
 func TestBareListWithCommentsGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -495,6 +567,12 @@ func TestBareListWithCommentsLexicographicParse(t *testing.T) {
 
 // bare_list_with_comments_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:comments behavior:array_order_lexicographic
 func TestBareListWithCommentsLexicographicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// bare_list_with_comments_lexicographic_build_model - function:parse_indented function:build_model feature:empty_keys feature:comments
+func TestBareListWithCommentsLexicographicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -539,6 +617,12 @@ func TestBareListDeeplyNestedBuildHierarchy(t *testing.T) {
 }
 
 
+// bare_list_deeply_nested_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListDeeplyNestedBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // bare_list_deeply_nested_get_list - function:get_list feature:empty_keys behavior:array_order_insertion behavior:path_traversal
 func TestBareListDeeplyNestedGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -575,6 +659,12 @@ func TestBareListDeeplyNestedLexicographicParse(t *testing.T) {
 
 // bare_list_deeply_nested_lexicographic_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys behavior:array_order_lexicographic
 func TestBareListDeeplyNestedLexicographicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// bare_list_deeply_nested_lexicographic_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListDeeplyNestedLexicographicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -618,6 +708,12 @@ func TestBareListMixedWithOtherKeysBuildHierarchy(t *testing.T) {
 }
 
 
+// bare_list_mixed_with_other_keys_build_model - function:parse_indented function:build_model feature:empty_keys
+func TestBareListMixedWithOtherKeysBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // bare_list_mixed_with_other_keys_get_list - function:get_list feature:empty_keys behavior:path_traversal
 func TestBareListMixedWithOtherKeysGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -649,6 +745,12 @@ func TestBareListErrorNotAListParse(t *testing.T) {
 
 // bare_list_error_not_a_list_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestBareListErrorNotAListBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// bare_list_error_not_a_list_build_model - function:parse_indented function:build_model
+func TestBareListErrorNotAListBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -38,6 +38,12 @@ func TestIndentedLineIsContinuationBuildHierarchy(t *testing.T) {
 }
 
 
+// indented_line_is_continuation_build_model - function:parse_indented function:build_model feature:multiline_continuation behavior:multiline_values
+func TestIndentedLineIsContinuationBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // indented_line_is_continuation_get_list - function:get_list feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
 func TestIndentedLineIsContinuationGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -68,6 +74,12 @@ func TestSingleItemAsListParse(t *testing.T) {
 
 // single_item_as_list_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestSingleItemAsListBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// single_item_as_list_build_model - function:parse_indented function:build_model
+func TestSingleItemAsListBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -104,6 +116,12 @@ host = localhost`
 
 // mixed_duplicate_single_keys_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestMixedDuplicateSingleKeysBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// mixed_duplicate_single_keys_build_model - function:parse_indented function:build_model
+func TestMixedDuplicateSingleKeysBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -145,6 +163,12 @@ func TestNestedListAccessBuildHierarchy(t *testing.T) {
 }
 
 
+// nested_list_access_build_model - function:parse_indented function:build_model
+func TestNestedListAccessBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // nested_list_access_get_list - function:get_list behavior:list_coercion_enabled behavior:path_traversal
 func TestNestedListAccessGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -175,6 +199,12 @@ func TestEmptyListParse(t *testing.T) {
 
 // empty_list_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestEmptyListBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// empty_list_build_model - function:parse_indented function:build_model
+func TestEmptyListBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -216,6 +246,12 @@ func TestListWithNumbersBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_numbers_build_model - function:parse_indented function:build_model
+func TestListWithNumbersBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_numbers_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithNumbersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -249,6 +285,12 @@ flags = no`
 
 // list_with_booleans_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestListWithBooleansBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_with_booleans_build_model - function:parse_indented function:build_model
+func TestListWithBooleansBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -290,6 +332,12 @@ func TestListWithWhitespaceBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_whitespace_build_model - function:parse_indented function:build_model feature:whitespace
+func TestListWithWhitespaceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_whitespace_get_list - function:get_list feature:whitespace behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithWhitespaceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -323,6 +371,12 @@ names = العربية`
 
 // list_with_unicode_build_hierarchy - function:parse_indented function:build_hierarchy feature:unicode behavior:array_order_insertion
 func TestListWithUnicodeBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_with_unicode_build_model - function:parse_indented function:build_model feature:unicode
+func TestListWithUnicodeBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -364,6 +418,12 @@ func TestListWithSpecialCharactersBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_special_characters_build_model - function:parse_indented function:build_model
+func TestListWithSpecialCharactersBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_special_characters_get_list - function:get_list behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListWithSpecialCharactersGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -382,6 +442,12 @@ func TestListMultilineValuesBuildHierarchy(t *testing.T) {
 }
 
 
+// list_multiline_values_build_model - function:parse_indented function:build_model feature:multiline_continuation behavior:multiline_values
+func TestListMultilineValuesBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_multiline_values_get_list - function:get_list feature:multiline_continuation behavior:list_coercion_enabled behavior:array_order_insertion
 func TestListMultilineValuesGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -396,6 +462,12 @@ func TestComplexMixedListScenariosParseIndented(t *testing.T) {
 
 // complex_mixed_list_scenarios_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_insertion
 func TestComplexMixedListScenariosBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// complex_mixed_list_scenarios_build_model - function:parse_indented function:build_model
+func TestComplexMixedListScenariosBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -434,6 +506,12 @@ func TestListPathTraversalProtectionBuildHierarchy(t *testing.T) {
 }
 
 
+// list_path_traversal_protection_build_model - function:parse_indented function:build_model
+func TestListPathTraversalProtectionBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_path_traversal_protection_get_list - function:get_list behavior:list_coercion_enabled
 func TestListPathTraversalProtectionGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -464,6 +542,12 @@ func TestParseEmptyValueParse(t *testing.T) {
 
 // parse_empty_value_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParseEmptyValueBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_empty_value_build_model - function:parse_indented function:build_model
+func TestParseEmptyValueBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_reference_compliant_test.go
+++ b/go_tests/parsing/api_reference_compliant_test.go
@@ -42,6 +42,12 @@ func TestSingleItemAsListReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// single_item_as_list_reference_build_model - function:parse_indented function:build_model variant:reference_compliant
+func TestSingleItemAsListReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // single_item_as_list_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestSingleItemAsListReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -74,6 +80,12 @@ host = localhost`
 
 // mixed_duplicate_single_keys_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestMixedDuplicateSingleKeysReferenceBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// mixed_duplicate_single_keys_reference_build_model - function:parse_indented function:build_model
+func TestMixedDuplicateSingleKeysReferenceBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -115,6 +127,12 @@ func TestNestedListAccessReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// nested_list_access_reference_build_model - function:parse_indented function:build_model variant:reference_compliant
+func TestNestedListAccessReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // nested_list_access_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:path_traversal variant:reference_compliant
 func TestNestedListAccessReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -145,6 +163,12 @@ func TestEmptyListReferenceParse(t *testing.T) {
 
 // empty_list_reference_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestEmptyListReferenceBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// empty_list_reference_build_model - function:parse_indented function:build_model variant:reference_compliant
+func TestEmptyListReferenceBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -186,6 +210,12 @@ func TestListWithNumbersReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_numbers_reference_build_model - function:parse_indented function:build_model
+func TestListWithNumbersReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_numbers_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithNumbersReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -219,6 +249,12 @@ flags = no`
 
 // list_with_booleans_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestListWithBooleansReferenceBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_with_booleans_reference_build_model - function:parse_indented function:build_model
+func TestListWithBooleansReferenceBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -260,6 +296,12 @@ func TestListWithWhitespaceReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_whitespace_reference_build_model - function:parse_indented function:build_model feature:empty_keys feature:whitespace
+func TestListWithWhitespaceReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_whitespace_reference_get_list - function:get_list feature:empty_keys feature:whitespace behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithWhitespaceReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -293,6 +335,12 @@ names = العربية`
 
 // list_with_unicode_reference_build_hierarchy - function:parse_indented function:build_hierarchy feature:unicode behavior:array_order_lexicographic
 func TestListWithUnicodeReferenceBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// list_with_unicode_reference_build_model - function:parse_indented function:build_model feature:unicode
+func TestListWithUnicodeReferenceBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -333,6 +381,12 @@ func TestListWithSpecialCharactersReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// list_with_special_characters_reference_build_model - function:parse_indented function:build_model
+func TestListWithSpecialCharactersReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_with_special_characters_reference_get_list - function:get_list behavior:list_coercion_disabled behavior:array_order_lexicographic
 func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -341,6 +395,12 @@ func TestListWithSpecialCharactersReferenceGetList(t *testing.T) {
 
 // complex_mixed_list_scenarios_reference_build_hierarchy - function:parse_indented function:build_hierarchy behavior:array_order_lexicographic
 func TestComplexMixedListScenariosReferenceBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// complex_mixed_list_scenarios_reference_build_model - function:parse_indented function:build_model
+func TestComplexMixedListScenariosReferenceBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -379,6 +439,12 @@ func TestListPathTraversalProtectionReferenceBuildHierarchy(t *testing.T) {
 }
 
 
+// list_path_traversal_protection_reference_build_model - function:parse_indented function:build_model variant:reference_compliant
+func TestListPathTraversalProtectionReferenceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // list_path_traversal_protection_reference_get_list - function:get_list behavior:list_coercion_disabled variant:reference_compliant
 func TestListPathTraversalProtectionReferenceGetList(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -409,6 +475,12 @@ func TestEmptyValueReferenceBehaviorParse(t *testing.T) {
 
 // empty_value_reference_behavior_build_hierarchy - function:parse_indented function:build_hierarchy variant:reference_compliant
 func TestEmptyValueReferenceBehaviorBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// empty_value_reference_behavior_build_model - function:parse_indented function:build_model variant:reference_compliant
+func TestEmptyValueReferenceBehaviorBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_typed_access_test.go
+++ b/go_tests/parsing/api_typed_access_test.go
@@ -42,6 +42,12 @@ func TestParseBasicIntegerBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_basic_integer_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBasicIntegerBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_basic_integer_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBasicIntegerGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -72,6 +78,12 @@ func TestParseBasicFloatParse(t *testing.T) {
 
 // parse_basic_float_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBasicFloatBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_basic_float_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBasicFloatBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -110,6 +122,12 @@ func TestParseBooleanTrueBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_boolean_true_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanTrueBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_boolean_true_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient
 func TestParseBooleanTrueGetBool(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -140,6 +158,12 @@ func TestParseBooleanYesParse(t *testing.T) {
 
 // parse_boolean_yes_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanYesBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_boolean_yes_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanYesBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -178,6 +202,12 @@ func TestParseBooleanYesStrictLiteralBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_boolean_yes_strict_literal_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanYesStrictLiteralBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_boolean_yes_strict_literal_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanYesStrictLiteralGetBool(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -208,6 +238,12 @@ func TestParseBooleanFalseParse(t *testing.T) {
 
 // parse_boolean_false_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseBooleanFalseBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_boolean_false_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanFalseBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -246,6 +282,12 @@ func TestParseStringFallbackBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_string_fallback_build_model - function:parse_indented function:build_model
+func TestParseStringFallbackBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_string_fallback_get_string - function:get_string
 func TestParseStringFallbackGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -276,6 +318,12 @@ func TestParseNegativeIntegerParse(t *testing.T) {
 
 // parse_negative_integer_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseNegativeIntegerBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_negative_integer_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseNegativeIntegerBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -312,6 +360,12 @@ disabled = no`
 
 // parse_zero_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_zero_values_build_model - function:parse_indented function:build_model feature:empty_keys feature:optional_typed_accessors
+func TestParseZeroValuesBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -360,6 +414,12 @@ disabled = no`
 
 // parse_zero_values_strict_literal_build_hierarchy - function:parse_indented function:build_hierarchy feature:empty_keys feature:optional_typed_accessors
 func TestParseZeroValuesStrictLiteralBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_zero_values_strict_literal_build_model - function:parse_indented function:build_model feature:empty_keys feature:optional_typed_accessors
+func TestParseZeroValuesStrictLiteralBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -416,6 +476,12 @@ func TestParseBooleanVariantsBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_boolean_variants_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanVariantsBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_boolean_variants_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBooleanVariantsGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -462,6 +528,12 @@ func TestParseBooleanVariantsStrictLiteralBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_boolean_variants_strict_literal_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanVariantsStrictLiteralBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_boolean_variants_strict_literal_get_int - function:get_int feature:optional_typed_accessors
 func TestParseBooleanVariantsStrictLiteralGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -502,6 +574,12 @@ debug = off`
 
 // parse_mixed_types_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseMixedTypesBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_mixed_types_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseMixedTypesBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -562,6 +640,12 @@ func TestParseMixedTypesStrictLiteralBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_mixed_types_strict_literal_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseMixedTypesStrictLiteralBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_mixed_types_strict_literal_get_string - function:get_string feature:optional_typed_accessors
 func TestParseMixedTypesStrictLiteralGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -615,6 +699,12 @@ func TestParseWithWhitespaceBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_with_whitespace_build_model - function:parse_indented function:build_model feature:whitespace feature:optional_typed_accessors
+func TestParseWithWhitespaceBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_with_whitespace_get_int - function:get_int feature:whitespace feature:optional_typed_accessors
 func TestParseWithWhitespaceGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -654,6 +744,12 @@ text = hello`
 
 // parse_with_conservative_options_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseWithConservativeOptionsBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_with_conservative_options_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseWithConservativeOptionsBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -698,6 +794,12 @@ func TestParseIntegerErrorBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_integer_error_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseIntegerErrorBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_integer_error_get_int - function:get_int feature:optional_typed_accessors
 func TestParseIntegerErrorGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -728,6 +830,12 @@ func TestParseFloatErrorParse(t *testing.T) {
 
 // parse_float_error_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestParseFloatErrorBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_float_error_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseFloatErrorBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -766,6 +874,12 @@ func TestParseBooleanErrorBuildHierarchy(t *testing.T) {
 }
 
 
+// parse_boolean_error_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestParseBooleanErrorBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // parse_boolean_error_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict
 func TestParseBooleanErrorGetBool(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -796,6 +910,12 @@ func TestParseMissingPathErrorParse(t *testing.T) {
 
 // parse_missing_path_error_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestParseMissingPathErrorBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// parse_missing_path_error_build_model - function:parse_indented function:build_model
+func TestParseMissingPathErrorBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -962,6 +1082,12 @@ func TestBooleanNestedObjectBuildHierarchy(t *testing.T) {
 }
 
 
+// boolean_nested_object_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestBooleanNestedObjectBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // type_mismatch_get_int_on_bool_parse - function:parse feature:optional_typed_accessors
 func TestTypeMismatchGetIntOnBoolParse(t *testing.T) {
 	
@@ -1052,6 +1178,12 @@ func TestTypeMismatchNestedPathBuildHierarchy(t *testing.T) {
 }
 
 
+// type_mismatch_nested_path_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestTypeMismatchNestedPathBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // boolean_empty_value_error_parse - function:parse feature:optional_typed_accessors
 func TestBooleanEmptyValueErrorParse(t *testing.T) {
 	
@@ -1110,6 +1242,12 @@ func TestNestedGetIntBuildHierarchy(t *testing.T) {
 }
 
 
+// nested_get_int_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestNestedGetIntBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // nested_get_int_get_int - function:get_int feature:optional_typed_accessors behavior:path_traversal
 func TestNestedGetIntGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1148,6 +1286,12 @@ func TestDeeplyNestedGetIntBuildHierarchy(t *testing.T) {
 }
 
 
+// deeply_nested_get_int_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestDeeplyNestedGetIntBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // deeply_nested_get_int_get_int - function:get_int feature:optional_typed_accessors behavior:path_traversal
 func TestDeeplyNestedGetIntGetInt(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1180,6 +1324,12 @@ func TestNestedGetFloatParse(t *testing.T) {
 
 // nested_get_float_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedGetFloatBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_float_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestNestedGetFloatBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1222,6 +1372,12 @@ func TestDeeplyNestedGetFloatBuildHierarchy(t *testing.T) {
 }
 
 
+// deeply_nested_get_float_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestDeeplyNestedGetFloatBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // deeply_nested_get_float_get_float - function:get_float feature:optional_typed_accessors behavior:path_traversal
 func TestDeeplyNestedGetFloatGetFloat(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1254,6 +1410,12 @@ func TestNestedGetBoolParse(t *testing.T) {
 
 // nested_get_bool_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedGetBoolBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_bool_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestNestedGetBoolBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1296,6 +1458,12 @@ func TestDeeplyNestedGetBoolBuildHierarchy(t *testing.T) {
 }
 
 
+// deeply_nested_get_bool_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestDeeplyNestedGetBoolBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // deeply_nested_get_bool_get_bool - function:get_bool feature:optional_typed_accessors behavior:boolean_strict behavior:boolean_lenient behavior:path_traversal
 func TestDeeplyNestedGetBoolGetBool(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -1328,6 +1496,12 @@ func TestNestedGetStringBasicParse(t *testing.T) {
 
 // nested_get_string_basic_build_hierarchy - function:parse_indented function:build_hierarchy
 func TestNestedGetStringBasicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_get_string_basic_build_model - function:parse_indented function:build_model
+func TestNestedGetStringBasicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -1366,6 +1540,12 @@ func TestNestedMixedTypedAccessParse(t *testing.T) {
 
 // nested_mixed_typed_access_build_hierarchy - function:parse_indented function:build_hierarchy feature:optional_typed_accessors
 func TestNestedMixedTypedAccessBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// nested_mixed_typed_access_build_model - function:parse_indented function:build_model feature:optional_typed_accessors
+func TestNestedMixedTypedAccessBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -42,6 +42,12 @@ func TestTabsAsWhitespaceInValueBuildHierarchy(t *testing.T) {
 }
 
 
+// tabs_as_whitespace_in_value_build_model - function:parse_indented function:build_model feature:whitespace feature:tab_in_value_preserved
+func TestTabsAsWhitespaceInValueBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // tabs_as_whitespace_in_value_get_string - function:get_string feature:whitespace feature:tab_in_value_preserved
 func TestTabsAsWhitespaceInValueGetString(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
@@ -352,6 +358,12 @@ func TestCrlfNormalizeToLfBasicBuildHierarchy(t *testing.T) {
 }
 
 
+// crlf_normalize_to_lf_basic_build_model - function:parse_indented function:build_model feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeToLfBasicBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // crlf_preserve_literal_basic_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
@@ -360,6 +372,12 @@ func TestCrlfPreserveLiteralBasicParse(t *testing.T) {
 
 // crlf_preserve_literal_basic_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveLiteralBasicBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// crlf_preserve_literal_basic_build_model - function:parse_indented function:build_model feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveLiteralBasicBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -442,6 +460,12 @@ func TestCrlfNestedStructureBuildHierarchy(t *testing.T) {
 }
 
 
+// crlf_nested_structure_build_model - function:parse_indented function:build_model feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNestedStructureBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // crlf_preserve_nested_structure_parse - function:parse feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
@@ -450,6 +474,12 @@ func TestCrlfPreserveNestedStructureParse(t *testing.T) {
 
 // crlf_preserve_nested_structure_build_hierarchy - function:parse_indented function:build_hierarchy feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveNestedStructureBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// crlf_preserve_nested_structure_build_model - function:parse_indented function:build_model feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveNestedStructureBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 
@@ -528,6 +558,12 @@ func TestCrlfNormalizeCommentsAndValuesBuildHierarchy(t *testing.T) {
 }
 
 
+// crlf_normalize_comments_and_values_build_model - function:parse_indented function:build_model feature:comments feature:whitespace behavior:crlf_normalize_to_lf
+func TestCrlfNormalizeCommentsAndValuesBuildModel(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
 // crlf_preserve_comments_and_values_parse - function:parse feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesParse(t *testing.T) {
 	t.Skip("Test skipped due to tag filter: behavior:crlf_preserve_literal")
@@ -542,6 +578,12 @@ func TestCrlfPreserveCommentsAndValuesFilter(t *testing.T) {
 
 // crlf_preserve_comments_and_values_build_hierarchy - function:parse_indented function:build_hierarchy feature:comments feature:whitespace behavior:crlf_preserve_literal
 func TestCrlfPreserveCommentsAndValuesBuildHierarchy(t *testing.T) {
+	t.Skip("Test does not match run-only filter: [function:parse]")
+}
+
+
+// crlf_preserve_comments_and_values_build_model - function:parse_indented function:build_model feature:comments feature:whitespace behavior:crlf_preserve_literal
+func TestCrlfPreserveCommentsAndValuesBuildModel(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")
 }
 

--- a/internal/generator/templates.go
+++ b/internal/generator/templates.go
@@ -599,6 +599,8 @@ func (g *Generator) generateFlatFormatValidation(test types.TestCase) (string, e
 		return g.generateFlatFilterValidation(test)
 	case "build_hierarchy":
 		return g.generateFlatBuildHierarchyValidation(test)
+	case "build_model":
+		return g.generateFlatBuildModelValidation(test)
 	case "get_string", "get_int", "get_bool", "get_float", "get_list":
 		return g.generateFlatTypedAccessValidation(test, test.Validation)
 	default:
@@ -812,6 +814,22 @@ func (g *Generator) generateFlatBuildHierarchyValidation(test types.TestCase) (s
 	objectResult := ccl.BuildHierarchy(parseResult)
 	expected := %s
 	assert.Equal(t, expected, objectResult)`, formatGoValue(expectedMap)), nil
+}
+
+// generateFlatBuildModelValidation generates build_model validation for flat format.
+// build_model produces the OCaml-canonical recursive map-of-maps; expect is always a nested object.
+func (g *Generator) generateFlatBuildModelValidation(test types.TestCase) (string, error) {
+	expectedMap, ok := test.Expected.(map[string]interface{})
+	if !ok {
+		return "", fmt.Errorf("expected map for build_model validation, got %T", test.Expected)
+	}
+
+	return fmt.Sprintf(`// BuildModel validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	modelResult := ccl.BuildModel(parseResult)
+	expected := %s
+	assert.Equal(t, expected, modelResult)`, formatGoValue(expectedMap)), nil
 }
 
 // generateFlatTypedAccessValidation generates typed access validation for flat format

--- a/internal/mock/ccl.go
+++ b/internal/mock/ccl.go
@@ -244,6 +244,52 @@ func (c *CCL) BuildHierarchy(entries []Entry) map[string]interface{} {
 	return result
 }
 
+// BuildModel produces the OCaml-canonical recursive model: every value becomes
+// a key in an inner map pointing to an empty map. Duplicate keys merge their
+// inner maps. Mirrors the flat-pattern of BuildHierarchy — no recursive parsing
+// of block values, matching the parity boundary set there.
+func (c *CCL) BuildModel(entries []Entry) map[string]interface{} {
+	result := make(map[string]interface{})
+
+	for _, entry := range entries {
+		key := entry.Key
+		value := entry.Value
+
+		if strings.Contains(key, ".") {
+			parts := strings.Split(key, ".")
+			current := result
+			for i, part := range parts {
+				if i == len(parts)-1 {
+					mergeModelLeaf(current, part, value)
+				} else {
+					if _, exists := current[part]; !exists {
+						current[part] = make(map[string]interface{})
+					}
+					if nested, ok := current[part].(map[string]interface{}); ok {
+						current = nested
+					}
+				}
+			}
+		} else {
+			mergeModelLeaf(result, key, value)
+		}
+	}
+
+	return result
+}
+
+// mergeModelLeaf inserts {value: {}} under key in m, merging if key already exists.
+func mergeModelLeaf(m map[string]interface{}, key, value string) {
+	inner, ok := m[key].(map[string]interface{})
+	if !ok {
+		inner = make(map[string]interface{})
+		m[key] = inner
+	}
+	if _, exists := inner[value]; !exists {
+		inner[value] = map[string]interface{}{}
+	}
+}
+
 // GetString implements string access
 func (c *CCL) GetString(obj map[string]interface{}, path []string) (string, error) {
 	value, err := c.getValue(obj, path)

--- a/loader/loader.go
+++ b/loader/loader.go
@@ -501,6 +501,8 @@ func (tl *TestLoader) loadCompactFormat(data []byte) ([]types.TestCase, error) {
 				validations.ExpandDotted = validationValue
 			case "build_hierarchy":
 				validations.BuildHierarchy = validationValue
+			case "build_model":
+				validations.BuildModel = validationValue
 			case "get_string":
 				validations.GetString = validationValue
 			case "get_int":
@@ -594,8 +596,8 @@ func (tl *TestLoader) extractExpectedValue(validation string, expected interface
 		if entries, ok := expectedMap["entries"]; ok {
 			return entries
 		}
-	case "build_hierarchy":
-		// Expects an object
+	case "build_hierarchy", "build_model":
+		// Both expect a nested object
 		if object, ok := expectedMap["object"]; ok {
 			return object
 		}

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -47,7 +47,8 @@
         "description": "Single CCL function to validate",
         "enum": [
           "parse", "parse_indented", "filter", "compose",
-          "build_hierarchy", "get_string", "get_int", "get_bool", "get_float", "get_list",
+          "build_hierarchy", "build_model",
+          "get_string", "get_int", "get_bool", "get_float", "get_list",
           "print", "canonical_format", "load", "round_trip",
           "compose_associative", "identity_left", "identity_right"
         ]
@@ -137,7 +138,8 @@
           "type": "string",
           "enum": [
             "parse", "parse_indented", "filter", "compose",
-            "build_hierarchy", "get_string", "get_int", "get_bool", "get_float", "get_list",
+            "build_hierarchy", "build_model",
+            "get_string", "get_int", "get_bool", "get_float", "get_list",
             "print", "canonical_format", "load", "round_trip",
             "compose_associative", "identity_left", "identity_right"
           ]

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -144,7 +144,8 @@
       "description": "A CCL function that implementations provide. Mirrors ccl-test-data/config.CCLFunction.",
       "enum": [
         "parse", "parse_indented", "filter", "compose",
-        "build_hierarchy", "get_string", "get_int", "get_bool", "get_float", "get_list",
+        "build_hierarchy", "build_model",
+        "get_string", "get_int", "get_bool", "get_float", "get_list",
         "print", "canonical_format", "load", "round_trip"
       ]
     },

--- a/source_tests/core/api_core_ccl_hierarchy.json
+++ b/source_tests/core/api_core_ccl_hierarchy.json
@@ -29,6 +29,13 @@
           }
         },
         {
+          "function": "build_model",
+          "expect": {
+            "name": {"Alice": {}},
+            "age": {"42": {}}
+          }
+        },
+        {
           "function": "load",
           "expect": {
             "age": "42",
@@ -41,6 +48,7 @@
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "load",
         "parse",
         "print"
@@ -77,6 +85,20 @@
           }
         },
         {
+          "function": "build_model",
+          "expect": {
+            "server": {
+              "cache": {
+                "enabled": {"true": {}}
+              },
+              "database": {
+                "host": {"localhost": {}},
+                "port": {"5432": {}}
+              }
+            }
+          }
+        },
+        {
           "function": "load",
           "expect": {
             "server": {
@@ -96,6 +118,7 @@
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "load",
         "parse",
         "print"
@@ -136,6 +159,16 @@
           }
         },
         {
+          "function": "build_model",
+          "expect": {
+            "item": {
+              "first": {},
+              "second": {},
+              "third": {}
+            }
+          }
+        },
+        {
           "function": "load",
           "expect": {
             "item": [
@@ -151,6 +184,7 @@
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "load",
         "parse",
         "print"

--- a/source_tests/core/api_core_ccl_hierarchy.json
+++ b/source_tests/core/api_core_ccl_hierarchy.json
@@ -2,10 +2,19 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "load",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
       "name": "basic_object_construction",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
@@ -15,63 +24,67 @@
               "key": "age",
               "value": "42"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "name = Alice\nage = 42"
+          "expect": "name = Alice\nage = 42",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "age": "42",
             "name": "Alice"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "build_model",
           "expect": {
-            "name": {"Alice": {}},
-            "age": {"42": {}}
-          }
+            "age": {
+              "42": {}
+            },
+            "name": {
+              "Alice": {}
+            }
+          },
+          "function": "build_model"
         },
         {
-          "function": "load",
           "expect": {
             "age": "42",
             "name": "Alice"
-          }
+          },
+          "function": "load"
         }
-      ],
-      "inputs": [
-        "name = Alice\nage = 42"
-      ],
+      ]
+    },
+    {
       "functions": [
         "build_hierarchy",
         "build_model",
         "load",
         "parse",
         "print"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+      ],
       "name": "deep_nested_objects",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "server",
               "value": "\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
+          "expect": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "server": {
               "cache": {
@@ -82,24 +95,30 @@
                 "port": "5432"
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "build_model",
           "expect": {
             "server": {
               "cache": {
-                "enabled": {"true": {}}
+                "enabled": {
+                  "true": {}
+                }
               },
               "database": {
-                "host": {"localhost": {}},
-                "port": {"5432": {}}
+                "host": {
+                  "localhost": {}
+                },
+                "port": {
+                  "5432": {}
+                }
               }
             }
-          }
+          },
+          "function": "build_model"
         },
         {
-          "function": "load",
           "expect": {
             "server": {
               "cache": {
@@ -110,25 +129,25 @@
                 "port": "5432"
               }
             }
-          }
+          },
+          "function": "load"
         }
-      ],
-      "inputs": [
-        "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
-      ],
+      ]
+    },
+    {
       "functions": [
         "build_hierarchy",
         "build_model",
         "load",
         "parse",
         "print"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "item = first\nitem = second\nitem = third"
+      ],
       "name": "duplicate_keys_to_lists",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item",
@@ -142,72 +161,71 @@
               "key": "item",
               "value": "third"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "item = first\nitem = second\nitem = third"
+          "expect": "item = first\nitem = second\nitem = third",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "item": [
               "first",
               "second",
               "third"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "build_model",
           "expect": {
             "item": {
               "first": {},
               "second": {},
               "third": {}
             }
-          }
+          },
+          "function": "build_model"
         },
         {
-          "function": "load",
           "expect": {
             "item": [
               "first",
               "second",
               "third"
             ]
-          }
+          },
+          "function": "load"
         }
-      ],
-      "inputs": [
-        "item = first\nitem = second\nitem = third"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "build_model",
-        "load",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "config =\n  server = web1\n  server = web2\n  port = 80"
+      ],
       "name": "nested_duplicate_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  server = web1\n  server = web2\n  port = 80"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "config =\n  server = web1\n  server = web2\n  port = 80"
+          "expect": "config =\n  server = web1\n  server = web2\n  port = 80",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "port": "80",
@@ -216,23 +234,38 @@
                 "web2"
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "port": {
+                "80": {}
+              },
+              "server": {
+                "web1": {},
+                "web2": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "config =\n  server = web1\n  server = web2\n  port = 80"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
+      ],
       "name": "mixed_flat_and_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
@@ -246,14 +279,14 @@
               "key": "version",
               "value": "1.0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
+          "expect": "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "debug": "true",
@@ -261,36 +294,56 @@
             },
             "name": "Alice",
             "version": "1.0"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "debug": {
+                "true": {}
+              },
+              "timeout": {
+                "30": {}
+              }
+            },
+            "name": {
+              "Alice": {}
+            },
+            "version": {
+              "1.0": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "name = Alice\nconfig =\n  debug = true\n  timeout = 30\nversion = 1.0"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
+      ],
       "name": "nested_objects_with_lists",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "environments",
               "value": "\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
+          "expect": "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "environments": {
               "dev": {
@@ -305,32 +358,62 @@
                 ]
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "environments": {
+              "dev": {
+                "port": {
+                  "3000": {}
+                },
+                "server": {
+                  "localhost": {}
+                }
+              },
+              "prod": {
+                "port": {
+                  "80": {}
+                },
+                "server": {
+                  "web1": {},
+                  "web2": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "environments =\n  prod =\n    server = web1\n    server = web2\n    port = 80\n  dev =\n    server = localhost\n    port = 3000"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers = web1\n      servers = web2\n      servers = api1"
+      ],
       "name": "deeply_nested_list",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  environments =\n    production =\n      servers = web1\n      servers = web2\n      servers = api1"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "environments": {
@@ -343,31 +426,35 @@
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "config": {
+              "environments": {
+                "production": {
+                  "servers": {
+                    "api1": {},
+                    "web1": {},
+                    "web2": {}
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "environments",
             "production",
             "servers"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "array_order_lexicographic",
-        "path_traversal"
-      ],
-      "inputs": [
-        "config =\n  environments =\n    production =\n      servers = web1\n      servers = web2\n      servers = api1"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_core_ccl_integration.json
+++ b/source_tests/core/api_core_ccl_integration.json
@@ -2,10 +2,18 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "name = Alice\nage = 42"
+      ],
       "name": "complete_basic_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
@@ -15,70 +23,99 @@
               "key": "age",
               "value": "42"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "name = Alice\nage = 42"
+          "expect": "name = Alice\nage = 42",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "age": "42",
             "name": "Alice"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "age": {
+              "42": {}
+            },
+            "name": {
+              "Alice": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "name = Alice\nage = 42"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  enabled = true"
+      ],
       "name": "complete_nested_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "database",
               "value": "\n  host = localhost\n  port = 5432\n  enabled = true"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "database =\n  host = localhost\n  port = 5432\n  enabled = true"
+          "expect": "database =\n  host = localhost\n  port = 5432\n  enabled = true",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "enabled": "true",
               "host": "localhost",
               "port": "5432"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "database": {
+              "enabled": {
+                "true": {}
+              },
+              "host": {
+                "localhost": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "database =\n  host = localhost\n  port = 5432\n  enabled = true"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
+      ],
       "name": "complete_mixed_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "app",
@@ -92,14 +129,14 @@
               "key": "config",
               "value": "\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
+          "expect": "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "app": "MyApp",
             "config": {
@@ -110,23 +147,51 @@
               }
             },
             "version": "1.0.0"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "app": {
+              "MyApp": {}
+            },
+            "config": {
+              "debug": {
+                "true": {}
+              },
+              "features": {
+                "feature1": {
+                  "enabled": {}
+                },
+                "feature2": {
+                  "disabled": {}
+                }
+              }
+            },
+            "version": {
+              "1.0.0": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "app = MyApp\nversion = 1.0.0\nconfig =\n  debug = true\n  features =\n    feature1 = enabled\n    feature2 = disabled"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+      ],
       "name": "complete_lists_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
@@ -136,14 +201,14 @@
               "key": "ports",
               "value": "\n  port = 80\n  port = 443"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+          "expect": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "ports": {
               "port": [
@@ -158,26 +223,45 @@
                 "web3"
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "ports": {
+              "port": {
+                "443": {},
+                "80": {}
+              }
+            },
+            "servers": {
+              "server": {
+                "web1": {},
+                "web2": {},
+                "web3": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "array_order_insertion"
+        "array_order_lexicographic"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
       ],
       "inputs": [
         "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
       ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
-      ]
-    },
-    {
       "name": "complete_lists_workflow_lexicographic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
@@ -187,14 +271,14 @@
               "key": "ports",
               "value": "\n  port = 80\n  port = 443"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
+          "expect": "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "ports": {
               "port": [
@@ -209,26 +293,48 @@
                 "web3"
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "ports": {
+              "port": {
+                "443": {},
+                "80": {}
+              }
+            },
+            "servers": {
+              "server": {
+                "web1": {},
+                "web2": {},
+                "web3": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "array_order_lexicographic"
-      ],
-      "inputs": [
-        "servers =\n  server = web1\n  server = web2\n  server = web3\nports =\n  port = 80\n  port = 443"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
+      ],
       "name": "complete_multiline_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "description",
@@ -238,14 +344,14 @@
               "key": "config",
               "value": "\n  settings =\n    value1 = one\n    value2 = two"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
+          "expect": "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "settings": {
@@ -254,29 +360,42 @@
               }
             },
             "description": "Welcome to our app\n  This is a multi-line description\n  With several lines"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "settings": {
+                "value1": {
+                  "one": {}
+                },
+                "value2": {
+                  "two": {}
+                }
+              }
+            },
+            "description": {
+              "Welcome to our app\n  This is a multi-line description\n  With several lines": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "multiline_values"
-      ],
-      "features": [
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "description = Welcome to our app\n  This is a multi-line description\n  With several lines\nconfig =\n  settings =\n    value1 = one\n    value2 = two"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
+      ],
       "name": "real_world_complete_workflow",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "service",
@@ -298,14 +417,14 @@
               "key": "features",
               "value": "\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "print",
-          "expect": "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
+          "expect": "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental",
+          "function": "print"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "credentials": {
@@ -336,16 +455,67 @@
             },
             "service": "MyMicroservice",
             "version": "2.1.0"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "database": {
+              "credentials": {
+                "password": {
+                  "secret123": {}
+                },
+                "user": {
+                  "service_user": {}
+                }
+              },
+              "host": {
+                "db.example.com": {}
+              },
+              "pools": {
+                "read": {
+                  "5": {}
+                },
+                "write": {
+                  "2": {}
+                }
+              },
+              "port": {
+                "5432": {}
+              }
+            },
+            "features": {
+              "feature_a": {
+                "enabled": {}
+              },
+              "feature_b": {
+                "disabled": {}
+              },
+              "feature_c": {
+                "experimental": {}
+              }
+            },
+            "logging": {
+              "level": {
+                "info": {}
+              },
+              "outputs": {
+                "output": {
+                  "console": {},
+                  "file": {},
+                  "syslog": {}
+                }
+              }
+            },
+            "service": {
+              "MyMicroservice": {}
+            },
+            "version": {
+              "2.1.0": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "service = MyMicroservice\nversion = 2.1.0\ndatabase =\n  host = db.example.com\n  port = 5432\n  credentials =\n    user = service_user\n    password = secret123\n  pools =\n    read = 5\n    write = 2\nlogging =\n  level = info\n  outputs =\n    output = console\n    output = file\n    output = syslog\nfeatures =\n  feature_a = enabled\n  feature_b = disabled\n  feature_c = experimental"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse",
-        "print"
       ]
     }
   ]

--- a/source_tests/core/api_core_ccl_model.json
+++ b/source_tests/core/api_core_ccl_model.json
@@ -1,0 +1,135 @@
+{
+  "$schema": "../../schemas/source-format.json",
+  "tests": [
+    {
+      "name": "model_single_pair",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {
+              "key": "key",
+              "value": "value"
+            }
+          ]
+        },
+        {
+          "function": "build_model",
+          "expect": {
+            "key": {"value": {}}
+          }
+        }
+      ],
+      "inputs": [
+        "key = value"
+      ],
+      "functions": [
+        "build_model",
+        "parse"
+      ]
+    },
+    {
+      "name": "model_duplicate_keys_merge_to_multi_leaf",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {"key": "item", "value": "first"},
+            {"key": "item", "value": "second"}
+          ]
+        },
+        {
+          "function": "build_model",
+          "expect": {
+            "item": {
+              "first": {},
+              "second": {}
+            }
+          }
+        }
+      ],
+      "inputs": [
+        "item = first\nitem = second"
+      ],
+      "functions": [
+        "build_model",
+        "parse"
+      ]
+    },
+    {
+      "name": "model_repeated_value_is_idempotent",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {"key": "item", "value": "a"},
+            {"key": "item", "value": "b"},
+            {"key": "item", "value": "a"}
+          ]
+        },
+        {
+          "function": "build_model",
+          "expect": {
+            "item": {
+              "a": {},
+              "b": {}
+            }
+          }
+        }
+      ],
+      "inputs": [
+        "item = a\nitem = b\nitem = a"
+      ],
+      "functions": [
+        "build_model",
+        "parse"
+      ]
+    },
+    {
+      "name": "model_multiple_distinct_keys",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": [
+            {"key": "host", "value": "localhost"},
+            {"key": "port", "value": "8080"}
+          ]
+        },
+        {
+          "function": "build_model",
+          "expect": {
+            "host": {"localhost": {}},
+            "port": {"8080": {}}
+          }
+        }
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080"
+      ],
+      "functions": [
+        "build_model",
+        "parse"
+      ]
+    },
+    {
+      "name": "model_empty_input",
+      "tests": [
+        {
+          "function": "parse",
+          "expect": []
+        },
+        {
+          "function": "build_model",
+          "expect": {}
+        }
+      ],
+      "inputs": [
+        ""
+      ],
+      "functions": [
+        "build_model",
+        "parse"
+      ]
+    }
+  ]
+}

--- a/source_tests/core/api_edge_cases.json
+++ b/source_tests/core/api_edge_cases.json
@@ -2,325 +2,330 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
-      "name": "basic_single_no_spaces",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "val"
-            }
-          ]
-        }
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key=val"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "basic_with_spaces",
+      "name": "basic_single_no_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "whitespace"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key = val"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "indented_key",
+      "name": "basic_with_spaces",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "whitespace"
+      ],
+      "functions": [
+        "parse_indented"
       ],
       "inputs": [
         "  key = val"
       ],
-      "functions": [
-        "parse_indented"
-      ]
-    },
-    {
-      "name": "value_trailing_spaces",
+      "name": "indented_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "whitespace"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key = val  "
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "key_value_surrounded_spaces",
+      "name": "value_trailing_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "whitespace"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "  key  =  val  "
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "surrounded_by_newlines",
+      "name": "key_value_surrounded_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
+      ]
+    },
+    {
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "\nkey = val\n"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "key_empty_value",
+      "name": "surrounded_by_newlines",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
-              "value": ""
+              "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key ="
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "empty_value_with_newline",
+      "name": "key_empty_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key =\n"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "empty_value_with_spaces",
+      "name": "empty_value_with_newline",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys",
         "whitespace"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "key =  "
       ],
-      "functions": [
-        "parse"
+      "name": "empty_value_with_spaces",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "key",
+              "value": ""
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
-      "name": "empty_key_indented",
-      "tests": [
-        {
-          "function": "parse_indented",
-          "expect": [
-            {
-              "key": "",
-              "value": "val"
-            }
-          ]
-        }
-      ],
       "features": [
         "empty_keys"
+      ],
+      "functions": [
+        "parse_indented"
       ],
       "inputs": [
         "  = val"
       ],
-      "functions": [
-        "parse_indented"
-      ]
-    },
-    {
-      "name": "empty_key_with_newline",
+      "name": "empty_key_indented",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "\n  = val"
       ],
-      "functions": [
-        "parse"
+      "name": "empty_key_with_newline",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "",
+              "value": "val"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "  =  "
+      ],
       "name": "empty_key_value_with_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "whitespace"
-      ],
-      "inputs": [
-        "  =  "
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "a=b=c"
+      ],
       "name": "equals_in_value_no_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a",
               "value": "b=c"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "a=b=c"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "a = b = c"
+      ],
       "name": "equals_in_value_with_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a",
               "value": "b = c"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "a = b = c"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key1 = val1\nkey2 = val2"
+      ],
       "name": "multiple_key_value_pairs",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key1",
@@ -330,214 +335,217 @@
               "key": "key2",
               "value": "val2"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "key1 = val1\nkey2 = val2"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\tkey\t=\tvalue"
+      ],
       "name": "key_with_tabs_ocaml_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "whitespace"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "\tkey\t=\tvalue"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "onlyspaces =     "
+      ],
       "name": "whitespace_only_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "onlyspaces",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys",
         "whitespace"
       ],
-      "inputs": [
-        "onlyspaces =     "
-      ],
       "functions": [
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        " =  = "
+      ],
       "name": "multiple_empty_equality",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "",
               "value": "="
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "whitespace"
-      ],
-      "inputs": [
-        " =  = "
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
-      "name": "key_with_newline_before_equals",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "val"
-            }
-          ]
-        }
-      ],
       "features": [
         "multiline_keys",
         "whitespace"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key \n= val\n"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "complex_multi_newline_whitespace",
+      "name": "key_with_newline_before_equals",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "multiline_keys",
         "whitespace"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "  \n key  \n=  val  \n"
       ],
-      "functions": [
-        "parse"
+      "name": "complex_multi_newline_whitespace",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "key",
+              "value": "val"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
+      "features": [
+        "multiline_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "my\n key\n= val"
+      ],
       "name": "multiline_key_with_spaces",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "my key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "multiline_keys",
-        "whitespace"
-      ],
-      "inputs": [
-        "my\n key\n= val"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "a\n b\n c\n= val"
+      ],
       "name": "multiline_key_three_lines",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a b c",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "multiline_keys"
-      ],
-      "inputs": [
-        "a\n b\n c\n= val"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "multiline_keys",
+        "empty_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key\n="
+      ],
       "name": "multiline_key_empty_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "multiline_keys",
-        "empty_keys"
-      ],
-      "inputs": [
-        "key\n="
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "first = val1\nkey\n= val2"
+      ],
       "name": "multiline_key_with_regular_entry",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "first",
@@ -547,252 +555,249 @@
               "key": "key",
               "value": "val2"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "multiline_keys"
-      ],
-      "inputs": [
-        "first = val1\nkey\n= val2"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
-      "name": "multiline_key_blank_lines_between",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "val"
-            }
-          ]
-        }
-      ],
       "features": [
         "multiline_keys",
         "whitespace"
+      ],
+      "functions": [
+        "parse"
       ],
       "inputs": [
         "key\n\n= val"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "multiline_key_tabs_in_continuation",
+      "name": "multiline_key_blank_lines_between",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "multiline_keys",
         "whitespace"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "key\n\t= val"
       ],
-      "functions": [
-        "parse"
+      "name": "multiline_key_tabs_in_continuation",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "key",
+              "value": "val"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
+      "features": [
+        "empty_keys",
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key =  \n"
+      ],
       "name": "empty_value_with_trailing_spaces_newline",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys",
         "whitespace"
       ],
-      "inputs": [
-        "key =  \n"
-      ],
       "functions": [
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\n  =  \n"
+      ],
       "name": "empty_key_value_with_surrounding_newlines",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "whitespace"
-      ],
-      "inputs": [
-        "\n  =  \n"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = localhost"
+      ],
       "name": "quotes_treated_as_literal_unquoted",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "host",
               "value": "localhost"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "host = localhost"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host = \"localhost\""
+      ],
       "name": "quotes_treated_as_literal_quoted",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "host",
               "value": "\"localhost\""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "host = \"localhost\""
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key =\n  val"
+      ],
       "name": "nested_single_line",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "\n  val"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "key =\n  val"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key =\n  line1\n  line2"
+      ],
       "name": "nested_multi_line",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "\n  line1\n  line2"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "multiline_values"
       ],
       "features": [
         "multiline_continuation"
       ],
-      "inputs": [
-        "key =\n  line1\n  line2"
-      ],
       "functions": [
-        "parse"
-      ]
-    },
-    {
+        "parse_indented"
+      ],
+      "inputs": [
+        "key =\n  line1\n\n  line2"
+      ],
       "name": "nested_with_blank_line",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "key",
               "value": "\n  line1\n\n  line2"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
-      "behaviors": [
-        "multiline_values"
-      ],
-      "features": [
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "key =\n  line1\n\n  line2"
-      ],
-      "functions": [
-        "parse_indented"
       ]
     },
     {
+      "functions": [
+        "parse_indented"
+      ],
+      "inputs": [
+        "key =\n  field1 = value1\n  field2 =\n    subfield = x\n    another = y"
+      ],
       "name": "deep_nested_structure",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "key",
               "value": "\n  field1 = value1\n  field2 =\n    subfield = x\n    another = y"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
-      "inputs": [
-        "key =\n  field1 = value1\n  field2 =\n    subfield = x\n    another = y"
-      ],
-      "functions": [
-        "parse_indented"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "name = Dmitrii Kovanikov\nlogin = chshersh\nlanguage = OCaml\ndate = 2024-05-25"
+      ],
       "name": "realistic_stress_test",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
@@ -810,21 +815,28 @@
               "key": "date",
               "value": "2024-05-25"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "name = Dmitrii Kovanikov\nlogin = chshersh\nlanguage = OCaml\ndate = 2024-05-25"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "comments",
+        "empty_keys"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "/= This is a CCL document\ntitle = CCL Example\n\ndatabase =\n  enabled = true\n  ports =\n    = 8000\n    = 8001\n    = 8002\n  limits =\n    cpu = 1500mi\n    memory = 10Gb\n\nuser =\n  guestId = 42\n\nuser =\n  login = chshersh\n  createdAt = 2024-12-31"
+      ],
       "name": "ocaml_stress_test_original",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "/": "This is a CCL document",
             "database": {
@@ -847,17 +859,59 @@
               "guestId": "42",
               "login": "chshersh"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "CCL Example",
+          "expect": {
+            "/": {
+              "This is a CCL document": {}
+            },
+            "database": {
+              "enabled": {
+                "true": {}
+              },
+              "limits": {
+                "cpu": {
+                  "1500mi": {}
+                },
+                "memory": {
+                  "10Gb": {}
+                }
+              },
+              "ports": {
+                "": {
+                  "8000": {},
+                  "8001": {},
+                  "8002": {}
+                }
+              }
+            },
+            "title": {
+              "CCL Example": {}
+            },
+            "user": {
+              "createdAt": {
+                "2024-12-31": {}
+              },
+              "guestId": {
+                "42": {}
+              },
+              "login": {
+                "chshersh": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "title"
-          ]
+          ],
+          "expect": "CCL Example",
+          "function": "get_string"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
@@ -879,618 +933,850 @@
               "key": "user",
               "value": "\n  login = chshersh\n  createdAt = 2024-12-31"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "comments",
-        "empty_keys"
-      ],
-      "inputs": [
-        "/= This is a CCL document\ntitle = CCL Example\n\ndatabase =\n  enabled = true\n  ports =\n    = 8000\n    = 8001\n    = 8002\n  limits =\n    cpu = 1500mi\n    memory = 10Gb\n\nuser =\n  guestId = 42\n\nuser =\n  login = chshersh\n  createdAt = 2024-12-31"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "mappings =\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
+      ],
       "name": "forward_slashes_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "mappings",
               "value": "\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "mappings": {
               "config/settings.json": ".vscode/settings.json",
               "src/template.env": ".env"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "mappings": {
+              "config/settings.json": {
+                ".vscode/settings.json": {}
+              },
+              "src/template.env": {
+                ".env": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "mappings",
             "config/settings.json"
           ],
-          "expect": ".vscode/settings.json"
+          "expect": ".vscode/settings.json",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "mappings =\n  config/settings.json = .vscode/settings.json\n  src/template.env = .env"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "paths =\n  C:\\Users\\config = user_settings\n  D:\\data\\file.txt = backup"
+      ],
       "name": "backslashes_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "paths",
               "value": "\n  C:\\Users\\config = user_settings\n  D:\\data\\file.txt = backup"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "paths": {
               "C:\\Users\\config": "user_settings",
               "D:\\data\\file.txt": "backup"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "paths": {
+              "C:\\Users\\config": {
+                "user_settings": {}
+              },
+              "D:\\data\\file.txt": {
+                "backup": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "paths =\n  C:\\Users\\config = user_settings\n  D:\\data\\file.txt = backup"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "timestamps =\n  12:30:45 = morning\n  23:59:59 = midnight"
+      ],
       "name": "colons_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "timestamps",
               "value": "\n  12:30:45 = morning\n  23:59:59 = midnight"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "timestamps": {
               "12:30:45": "morning",
               "23:59:59": "midnight"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "timestamps": {
+              "12:30:45": {
+                "morning": {}
+              },
+              "23:59:59": {
+                "midnight": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "timestamps =\n  12:30:45 = morning\n  23:59:59 = midnight"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "packages =\n  my-package-name = 1.0.0\n  another-lib = 2.3.4"
+      ],
       "name": "hyphens_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "packages",
               "value": "\n  my-package-name = 1.0.0\n  another-lib = 2.3.4"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "packages": {
-              "my-package-name": "1.0.0",
-              "another-lib": "2.3.4"
+              "another-lib": "2.3.4",
+              "my-package-name": "1.0.0"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "packages": {
+              "another-lib": {
+                "2.3.4": {}
+              },
+              "my-package-name": {
+                "1.0.0": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "packages =\n  my-package-name = 1.0.0\n  another-lib = 2.3.4"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "emails =\n  user@example.com = primary\n  admin@test.org = secondary"
+      ],
       "name": "at_signs_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "emails",
               "value": "\n  user@example.com = primary\n  admin@test.org = secondary"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "emails": {
-              "user@example.com": "primary",
-              "admin@test.org": "secondary"
+              "admin@test.org": "secondary",
+              "user@example.com": "primary"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "emails": {
+              "admin@test.org": {
+                "secondary": {}
+              },
+              "user@example.com": {
+                "primary": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "emails =\n  user@example.com = primary\n  admin@test.org = secondary"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "issues =\n  issue#123 = open\n  bug#456 = closed"
+      ],
       "name": "hash_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "issues",
               "value": "\n  issue#123 = open\n  bug#456 = closed"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "issues": {
-              "issue#123": "open",
-              "bug#456": "closed"
+              "bug#456": "closed",
+              "issue#123": "open"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "issues": {
+              "bug#456": {
+                "closed": {}
+              },
+              "issue#123": {
+                "open": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "issues =\n  issue#123 = open\n  bug#456 = closed"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "arrays =\n  items[0] = first\n  items[1] = second"
+      ],
       "name": "brackets_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "arrays",
               "value": "\n  items[0] = first\n  items[1] = second"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "arrays": {
               "items[0]": "first",
               "items[1]": "second"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "arrays": {
+              "items[0]": {
+                "first": {}
+              },
+              "items[1]": {
+                "second": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "arrays =\n  items[0] = first\n  items[1] = second"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "functions =\n  init() = setup\n  run(args) = execute"
+      ],
       "name": "parentheses_in_map_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "functions",
               "value": "\n  init() = setup\n  run(args) = execute"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "functions": {
               "init()": "setup",
               "run(args)": "execute"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "functions": {
+              "init()": {
+                "setup": {}
+              },
+              "run(args)": {
+                "execute": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "functions =\n  init() = setup\n  run(args) = execute"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "complex =\n  user@host:8080/api = endpoint\n  file#v1.2.3 = release\n  path\\to\\[item] = location"
+      ],
       "name": "mixed_special_chars_in_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "complex",
               "value": "\n  user@host:8080/api = endpoint\n  file#v1.2.3 = release\n  path\\to\\[item] = location"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "complex": {
-              "user@host:8080/api": "endpoint",
               "file#v1.2.3": "release",
-              "path\\to\\[item]": "location"
+              "path\\to\\[item]": "location",
+              "user@host:8080/api": "endpoint"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "complex": {
+              "file#v1.2.3": {
+                "release": {}
+              },
+              "path\\to\\[item]": {
+                "location": {}
+              },
+              "user@host:8080/api": {
+                "endpoint": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "complex =\n  user@host:8080/api = endpoint\n  file#v1.2.3 = release\n  path\\to\\[item] = location"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "endpoints =\n  https://api.example.com/v1 = production\n  http://localhost:3000/test = development"
+      ],
       "name": "url_like_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "endpoints",
               "value": "\n  https://api.example.com/v1 = production\n  http://localhost:3000/test = development"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "endpoints": {
-              "https://api.example.com/v1": "production",
-              "http://localhost:3000/test": "development"
+              "http://localhost:3000/test": "development",
+              "https://api.example.com/v1": "production"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "endpoints": {
+              "http://localhost:3000/test": {
+                "development": {}
+              },
+              "https://api.example.com/v1": {
+                "production": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "endpoints =\n  https://api.example.com/v1 = production\n  http://localhost:3000/test = development"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "../.. = up_two_levels"
+      ],
       "name": "relative_path_parent_parent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "../..",
               "value": "up_two_levels"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "../..": "up_two_levels"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "../..": {
+              "up_two_levels": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "../.. = up_two_levels"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "../ = parent_dir"
+      ],
       "name": "relative_path_parent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "../",
               "value": "parent_dir"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "../": "parent_dir"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "../": {
+              "parent_dir": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "../ = parent_dir"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        ". = current_dir"
+      ],
       "name": "relative_path_single_dot",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ".",
               "value": "current_dir"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ".": "current_dir"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            ".": {
+              "current_dir": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        ". = current_dir"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "// = double_slash_value"
+      ],
       "name": "double_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "//",
               "value": "double_slash_value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "//": "double_slash_value"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "//": {
+              "double_slash_value": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "// = double_slash_value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "path = ../../src"
+      ],
       "name": "relative_path_in_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "path",
               "value": "../../src"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "path": "../../src"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "path": {
+              "../../src": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "path"
           ],
-          "expect": "../../src"
+          "expect": "../../src",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "path = ../../src"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "mappings =\n  ../foo = ../bar\n  ../../config = ../../data"
+      ],
       "name": "relative_path_in_nested_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "mappings",
               "value": "\n  ../foo = ../bar\n  ../../config = ../../data"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "mappings": {
-              "../foo": "../bar",
-              "../../config": "../../data"
+              "../../config": "../../data",
+              "../foo": "../bar"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "mappings": {
+              "../../config": {
+                "../../data": {}
+              },
+              "../foo": {
+                "../bar": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "mappings",
             "../foo"
           ],
-          "expect": "../bar"
+          "expect": "../bar",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "mappings =\n  ../foo = ../bar\n  ../../config = ../../data"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "urls =\n  //api = //backup\n  //server = /root"
+      ],
       "name": "double_slash_in_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "urls",
               "value": "\n  //api = //backup\n  //server = /root"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "urls": {
               "//api": "//backup",
               "//server": "/root"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "urls": {
+              "//api": {
+                "//backup": {}
+              },
+              "//server": {
+                "/root": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "urls =\n  //api = //backup\n  //server = /root"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
-      "name": "relative_paths_deeply_nested",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "config",
-              "value": "\n  build = \n    output = ../../dist\n    cache = ../.cache"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "config": {
-              "build": {
-                "output": "../../dist",
-                "cache": "../.cache"
-              }
-            }
-          }
-        },
-        {
-          "function": "get_string",
-          "args": [
-            "config",
-            "build",
-            "output"
-          ],
-          "expect": "../../dist"
-        },
-        {
-          "function": "get_string",
-          "args": [
-            "config",
-            "build",
-            "cache"
-          ],
-          "expect": "../.cache"
-        }
-      ],
-      "inputs": [
-        "config =\n  build = \n    output = ../../dist\n    cache = ../.cache"
-      ],
       "behaviors": [
         "path_traversal"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
+      ],
+      "inputs": [
+        "config =\n  build = \n    output = ../../dist\n    cache = ../.cache"
+      ],
+      "name": "relative_paths_deeply_nested",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "config",
+              "value": "\n  build = \n    output = ../../dist\n    cache = ../.cache"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "config": {
+              "build": {
+                "cache": "../.cache",
+                "output": "../../dist"
+              }
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "build": {
+                "cache": {
+                  "../.cache": {}
+                },
+                "output": {
+                  "../../dist": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "config",
+            "build",
+            "output"
+          ],
+          "expect": "../../dist",
+          "function": "get_string"
+        },
+        {
+          "args": [
+            "config",
+            "build",
+            "cache"
+          ],
+          "expect": "../.cache",
+          "function": "get_string"
+        }
       ]
     },
     {
+      "behaviors": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "imports =\n  .. = \n    main = ../src/main\n    test = ../tests"
+      ],
       "name": "relative_paths_as_nested_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "imports",
               "value": "\n  .. = \n    main = ../src/main\n    test = ../tests"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "imports": {
               "..": {
@@ -1498,92 +1784,129 @@
                 "test": "../tests"
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "imports": {
+              "..": {
+                "main": {
+                  "../src/main": {}
+                },
+                "test": {
+                  "../tests": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "imports",
             "..",
             "main"
           ],
-          "expect": "../src/main"
+          "expect": "../src/main",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "imports =\n  .. = \n    main = ../src/main\n    test = ../tests"
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "path_traversal"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "paths =\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
+      ],
       "name": "mixed_relative_and_absolute_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "paths",
               "value": "\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "paths": {
-              "relative": {
-                "up": "../../",
-                "current": "."
-              },
               "absolute": {
                 "root": "/"
+              },
+              "relative": {
+                "current": ".",
+                "up": "../../"
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "paths": {
+              "absolute": {
+                "root": {
+                  "/": {}
+                }
+              },
+              "relative": {
+                "current": {
+                  ".": {}
+                },
+                "up": {
+                  "../../": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "paths",
             "relative",
             "up"
           ],
-          "expect": "../../"
+          "expect": "../../",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "paths =\n  relative = \n    up = ../../\n    current = .\n  absolute = \n    root = /"
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "path_traversal"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "servers =\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
+      ],
       "name": "double_slash_deeply_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
               "value": "\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "servers": {
               "primary": {
@@ -1594,482 +1917,637 @@
                 "//internal": "//backup.example.com"
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "servers": {
+              "primary": {
+                "api": {
+                  "//api.example.com": {}
+                },
+                "cdn": {
+                  "//cdn.example.com": {}
+                }
+              },
+              "secondary": {
+                "//internal": {
+                  "//backup.example.com": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "servers",
             "primary",
             "api"
           ],
-          "expect": "//api.example.com"
+          "expect": "//api.example.com",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "servers =\n  primary = \n    api = //api.example.com\n    cdn = //cdn.example.com\n  secondary = \n    //internal = //backup.example.com"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "https://api.example.com = production"
+      ],
       "name": "url_as_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "https://api.example.com",
               "value": "production"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "https://api.example.com": "production"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "https://api.example.com": {
+              "production": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "https://api.example.com"
           ],
-          "expect": "production"
+          "expect": "production",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "https://api.example.com = production"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "http://localhost:8080 = dev"
+      ],
       "name": "url_with_port_as_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "http://localhost:8080",
               "value": "dev"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "http://localhost:8080": "dev"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "http://localhost:8080": {
+              "dev": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "http://localhost:8080 = dev"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "https://api.example.com/v1/users = users_endpoint"
+      ],
       "name": "url_with_path_as_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "https://api.example.com/v1/users",
               "value": "users_endpoint"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "https://api.example.com/v1/users": "users_endpoint"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "https://api.example.com/v1/users": {
+              "users_endpoint": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "https://api.example.com/v1/users = users_endpoint"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "endpoint = https://api.example.com/v1/data"
+      ],
       "name": "url_in_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "endpoint",
               "value": "https://api.example.com/v1/data"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "endpoint": "https://api.example.com/v1/data"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "endpoint": {
+              "https://api.example.com/v1/data": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "endpoint"
           ],
-          "expect": "https://api.example.com/v1/data"
+          "expect": "https://api.example.com/v1/data",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "endpoint = https://api.example.com/v1/data"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
-      "name": "urls_as_nested_keys_and_values",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "mappings",
-              "value": "\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "mappings": {
-              "https://api.example.com": "https://prod.example.com",
-              "https://staging.example.com": "https://stage.example.com"
-            }
-          }
-        },
-        {
-          "function": "get_string",
-          "args": [
-            "mappings",
-            "https://api.example.com"
-          ],
-          "expect": "https://prod.example.com"
-        }
-      ],
-      "inputs": [
-        "mappings =\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
-      ],
       "behaviors": [
         "path_traversal"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
+      ],
+      "inputs": [
+        "mappings =\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
+      ],
+      "name": "urls_as_nested_keys_and_values",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "mappings",
+              "value": "\n  https://api.example.com = https://prod.example.com\n  https://staging.example.com = https://stage.example.com"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "mappings": {
+              "https://api.example.com": "https://prod.example.com",
+              "https://staging.example.com": "https://stage.example.com"
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "mappings": {
+              "https://api.example.com": {
+                "https://prod.example.com": {}
+              },
+              "https://staging.example.com": {
+                "https://stage.example.com": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "mappings",
+            "https://api.example.com"
+          ],
+          "expect": "https://prod.example.com",
+          "function": "get_string"
+        }
       ]
     },
     {
+      "behaviors": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
+      ],
       "name": "urls_deeply_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "services": {
                 "api": {
-                  "url": "https://api.example.com",
-                  "backup": "https://backup.example.com"
+                  "backup": "https://backup.example.com",
+                  "url": "https://api.example.com"
                 },
                 "cdn": {
                   "url": "https://cdn.example.com"
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "config": {
+              "services": {
+                "api": {
+                  "backup": {
+                    "https://backup.example.com": {}
+                  },
+                  "url": {
+                    "https://api.example.com": {}
+                  }
+                },
+                "cdn": {
+                  "url": {
+                    "https://cdn.example.com": {}
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "services",
             "api",
             "url"
           ],
-          "expect": "https://api.example.com"
+          "expect": "https://api.example.com",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "config =\n  services = \n    api = \n      url = https://api.example.com\n      backup = https://backup.example.com\n    cdn = \n      url = https://cdn.example.com"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
-      "name": "url_with_query_params_as_key",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "https://api.example.com/search?q=test&page=1",
-              "value": "search_results"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "https://api.example.com/search?q=test&page=1": "search_results"
-          }
-        }
-      ],
       "behaviors": [
         "delimiter_prefer_spaced"
       ],
-      "inputs": [
-        "https://api.example.com/search?q=test&page=1 = search_results"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "parse"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test\u0026page=1 = search_results"
+      ],
+      "name": "url_with_query_params_as_key",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "https://api.example.com/search?q=test\u0026page=1",
+              "value": "search_results"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "https://api.example.com/search?q=test\u0026page=1": "search_results"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "https://api.example.com/search?q=test\u0026page=1": {
+              "search_results": {}
+            }
+          },
+          "function": "build_model"
+        }
       ]
     },
     {
-      "name": "delimiter_first_url_with_query_params",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "https://api.example.com/search?q",
-              "value": "test&page=1 = search_results"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "https://api.example.com/search?q": "test&page=1 = search_results"
-          }
-        }
-      ],
       "behaviors": [
         "delimiter_first_equals"
       ],
-      "inputs": [
-        "https://api.example.com/search?q=test&page=1 = search_results"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "parse"
+      ],
+      "inputs": [
+        "https://api.example.com/search?q=test\u0026page=1 = search_results"
+      ],
+      "name": "delimiter_first_url_with_query_params",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "https://api.example.com/search?q",
+              "value": "test\u0026page=1 = search_results"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "https://api.example.com/search?q": "test\u0026page=1 = search_results"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "https://api.example.com/search?q": {
+              "test\u0026page=1 = search_results": {}
+            }
+          },
+          "function": "build_model"
+        }
       ]
     },
     {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
       "name": "delimiter_first_multiple_equals",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a",
               "value": "b = c=d"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "a": "b = c=d"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "a": {
+              "b = c=d": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "delimiter_first_equals"
-      ],
-      "inputs": [
-        "a=b = c=d"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "delimiter_first_equals"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
       "name": "delimiter_first_empty_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a",
               "value": "b ="
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "a": "b ="
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "a": {
+              "b =": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "delimiter_first_equals"
-      ],
-      "inputs": [
-        "a=b ="
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "a=b = c=d"
+      ],
       "name": "delimiter_spaced_multiple_equals",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a=b",
               "value": "c=d"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "a=b": "c=d"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "a=b": {
+              "c=d": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "delimiter_prefer_spaced"
-      ],
-      "inputs": [
-        "a=b = c=d"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "key=value"
+      ],
       "name": "delimiter_spaced_fallback_no_space",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "key": "value"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "key": {
+              "value": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "delimiter_prefer_spaced"
-      ],
-      "inputs": [
-        "key=value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "delimiter_prefer_spaced"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "a=b ="
+      ],
       "name": "delimiter_spaced_empty_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "a=b",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "a=b": ""
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "a=b": {
+              "": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "delimiter_prefer_spaced"
-      ],
-      "inputs": [
-        "a=b ="
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "https://docs.example.com/guide#section-1 = docs_section_1"
+      ],
       "name": "url_with_fragment_as_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "https://docs.example.com/guide#section-1",
               "value": "docs_section_1"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "https://docs.example.com/guide#section-1": "docs_section_1"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "https://docs.example.com/guide#section-1": {
+              "docs_section_1": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "inputs": [
-        "https://docs.example.com/guide#section-1 = docs_section_1"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_fuzz_special_chars_seed1.json
+++ b/source_tests/core/api_fuzz_special_chars_seed1.json
@@ -2,943 +2,1011 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "' = val406"
+      ],
       "name": "s1_fuzz_single_squote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'",
               "value": "val406"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "' = val406"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "* = val236"
+      ],
       "name": "s1_fuzz_single_asterisk",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "*",
               "value": "val236"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "* = val236"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\\ = val775"
+      ],
       "name": "s1_fuzz_single_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\\",
               "value": "val775"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\\ = val775"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "} = val221"
+      ],
       "name": "s1_fuzz_single_rbrace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}",
               "value": "val221"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "} = val221"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "~ = val416"
+      ],
       "name": "s1_fuzz_single_tilde",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "~",
               "value": "val416"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "~ = val416"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "; = val155"
+      ],
       "name": "s1_fuzz_single_semicolon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ";",
               "value": "val155"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "; = val155"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "+ = val794"
+      ],
       "name": "s1_fuzz_single_plus",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "+",
               "value": "val794"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "+ = val794"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$ = val665"
+      ],
       "name": "s1_fuzz_single_dollar",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$",
               "value": "val665"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$ = val665"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "% = val973"
+      ],
       "name": "s1_fuzz_single_percent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%",
               "value": "val973"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "% = val973"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "@ = val410"
+      ],
       "name": "s1_fuzz_single_at",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "@",
               "value": "val410"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "@ = val410"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\" = val797"
+      ],
       "name": "s1_fuzz_single_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"",
               "value": "val797"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\" = val797"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "( = val364"
+      ],
       "name": "s1_fuzz_single_lparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(",
               "value": "val364"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "( = val364"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003c = val789"
+      ],
       "name": "s1_fuzz_single_lt",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "<",
+              "key": "\u003c",
               "value": "val789"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "< = val789"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "[ = val216"
+      ],
       "name": "s1_fuzz_single_lbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "[",
               "value": "val216"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "[ = val216"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ") = val374"
+      ],
       "name": "s1_fuzz_single_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")",
               "value": "val374"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ") = val374"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "@\u003c/ = combo594"
+      ],
       "name": "s1_fuzz_combo_at_lt_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "@</",
+              "key": "@\u003c/",
               "value": "combo594"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "@</ = combo594"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/(;\\ = combo220"
+      ],
       "name": "s1_fuzz_combo_slash_lparen_semicolon_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/(;\\",
               "value": "combo220"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/(;\\ = combo220"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003c# = combo31"
+      ],
       "name": "s1_fuzz_combo_lt_hash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "<#",
+              "key": "\u003c#",
               "value": "combo31"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "<# = combo31"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "(\"! = combo359"
+      ],
       "name": "s1_fuzz_combo_lparen_dquote_bang",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(\"!",
               "value": "combo359"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "(\"! = combo359"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/#\\\" = combo87"
+      ],
       "name": "s1_fuzz_combo_slash_hash_backslash_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/#\\\"",
               "value": "combo87"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/#\\\" = combo87"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/%| = combo957"
+      ],
       "name": "s1_fuzz_combo_slash_percent_pipe",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/%|",
               "value": "combo957"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/%| = combo957"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "{|\\ = combo828"
+      ],
       "name": "s1_fuzz_combo_lbrace_pipe_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{|\\",
               "value": "combo828"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "{|\\ = combo828"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "!%/ = combo382"
+      ],
       "name": "s1_fuzz_combo_bang_percent_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!%/",
               "value": "combo382"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "!%/ = combo382"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "{|) = combo608"
+      ],
       "name": "s1_fuzz_combo_lbrace_pipe_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{|)",
               "value": "combo608"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "{|) = combo608"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ":;'\u003c = combo488"
+      ],
       "name": "s1_fuzz_combo_colon_semicolon_squote_lt",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": ":;'<",
+              "key": ":;'\u003c",
               "value": "combo488"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ":;'< = combo488"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "[host = pos428"
+      ],
       "name": "s1_fuzz_pos_start_lbracket_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "[host",
               "value": "pos428"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "[host = pos428"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "ga$mma = pos138"
+      ],
       "name": "s1_fuzz_pos_middle_dollar_gamma",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "ga$mma",
               "value": "pos138"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "ga$mma = pos138"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "name| = pos691"
+      ],
       "name": "s1_fuzz_pos_end_pipe_name",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name|",
               "value": "pos691"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "name| = pos691"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "*server = pos50"
+      ],
       "name": "s1_fuzz_pos_start_asterisk_server",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "*server",
               "value": "pos50"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "*server = pos50"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "al\u003epha = pos153"
+      ],
       "name": "s1_fuzz_pos_middle_gt_alpha",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "al>pha",
+              "key": "al\u003epha",
               "value": "pos153"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "al>pha = pos153"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item' = pos133"
+      ],
       "name": "s1_fuzz_pos_end_squote_item",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item'",
               "value": "pos133"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "item' = pos133"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\"mode = pos155"
+      ],
       "name": "s1_fuzz_pos_start_dquote_mode",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"mode",
               "value": "pos155"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\"mode = pos155"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "po\u0026rt = pos601"
+      ],
       "name": "s1_fuzz_pos_middle_ampersand_port",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "po&rt",
+              "key": "po\u0026rt",
               "value": "pos601"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "po&rt = pos601"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "host# = pos976"
+      ],
       "name": "s1_fuzz_pos_end_hash_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "host#",
               "value": "pos976"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "host# = pos976"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$path = pos556"
+      ],
       "name": "s1_fuzz_pos_start_dollar_path",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$path",
               "value": "pos556"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$path = pos556"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "name = data?x77]x88"
+      ],
       "name": "s1_fuzz_val_name_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
               "value": "data?x77]x88"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "name": "data?x77]x88"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data?x77]x88",
+          "expect": {
+            "name": {
+              "data?x77]x88": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "data?x77]x88",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = data?x77]x88"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "data = data'x23!x22"
+      ],
       "name": "s1_fuzz_val_data_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "data",
               "value": "data'x23!x22"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "data": "data'x23!x22"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data'x23!x22",
+          "expect": {
+            "data": {
+              "data'x23!x22": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "data"
-          ]
+          ],
+          "expect": "data'x23!x22",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "data = data'x23!x22"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "mode = data?x30\"x15~x73"
+      ],
       "name": "s1_fuzz_val_mode_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "mode",
               "value": "data?x30\"x15~x73"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "mode": "data?x30\"x15~x73"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data?x30\"x15~x73",
+          "expect": {
+            "mode": {
+              "data?x30\"x15~x73": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "mode"
-          ]
+          ],
+          "expect": "data?x30\"x15~x73",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "mode = data?x30\"x15~x73"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "name = data$x23~x81@x41"
+      ],
       "name": "s1_fuzz_val_name_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
               "value": "data$x23~x81@x41"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "name": "data$x23~x81@x41"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data$x23~x81@x41",
+          "expect": {
+            "name": {
+              "data$x23~x81@x41": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "data$x23~x81@x41",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = data$x23~x81@x41"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "user = data}x85$x2$x43"
+      ],
       "name": "s1_fuzz_val_user_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "user",
               "value": "data}x85$x2$x43"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "user": "data}x85$x2$x43"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data}x85$x2$x43",
+          "expect": {
+            "user": {
+              "data}x85$x2$x43": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "user"
-          ]
+          ],
+          "expect": "data}x85$x2$x43",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "user = data}x85$x2$x43"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\u0026alpha = nested297\n}gamma = deep715"
+      ],
       "name": "s1_fuzz_nested_ampersand_rbrace_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&alpha",
+              "key": "\u0026alpha",
               "value": "nested297"
             },
             {
               "key": "}gamma",
               "value": "deep715"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "&alpha": "nested297",
+            "\u0026alpha": "nested297",
             "}gamma": "deep715"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested297",
+          "expect": {
+            "\u0026alpha": {
+              "nested297": {}
+            },
+            "}gamma": {
+              "deep715": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
-            "&alpha"
-          ]
+            "\u0026alpha"
+          ],
+          "expect": "nested297",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "&alpha = nested297\n}gamma = deep715"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "?port = nested105\n]name = deep997"
+      ],
       "name": "s1_fuzz_nested_question_rbracket_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?port",
@@ -948,40 +1016,52 @@
               "key": "]name",
               "value": "deep997"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "?port": "nested105",
             "]name": "deep997"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested105",
+          "expect": {
+            "?port": {
+              "nested105": {}
+            },
+            "]name": {
+              "deep997": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "?port"
-          ]
+          ],
+          "expect": "nested105",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "?port = nested105\n]name = deep997"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "+config = nested427\n/server = deep329"
+      ],
       "name": "s1_fuzz_nested_plus_slash_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "+config",
@@ -991,83 +1071,107 @@
               "key": "/server",
               "value": "deep329"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "+config": "nested427",
             "/server": "deep329"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested427",
+          "expect": {
+            "+config": {
+              "nested427": {}
+            },
+            "/server": {
+              "deep329": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "+config"
-          ]
+          ],
+          "expect": "nested427",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "+config = nested427\n/server = deep329"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\u0026name = nested41\n$port = deep486"
+      ],
       "name": "s1_fuzz_nested_ampersand_dollar_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&name",
+              "key": "\u0026name",
               "value": "nested41"
             },
             {
               "key": "$port",
               "value": "deep486"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "$port": "deep486",
-            "&name": "nested41"
-          }
+            "\u0026name": "nested41"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested41",
+          "expect": {
+            "$port": {
+              "deep486": {}
+            },
+            "\u0026name": {
+              "nested41": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
-            "&name"
-          ]
+            "\u0026name"
+          ],
+          "expect": "nested41",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "&name = nested41\n$port = deep486"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "~beta = nested332\n'beta = deep158"
+      ],
       "name": "s1_fuzz_nested_tilde_squote_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "~beta",
@@ -1077,83 +1181,107 @@
               "key": "'beta",
               "value": "deep158"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "'beta": "deep158",
             "~beta": "nested332"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested332",
+          "expect": {
+            "'beta": {
+              "deep158": {}
+            },
+            "~beta": {
+              "nested332": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "~beta"
-          ]
+          ],
+          "expect": "nested332",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "~beta = nested332\n'beta = deep158"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "-config = nested723\n\u0026epsilon = deep891"
+      ],
       "name": "s1_fuzz_nested_hyphen_ampersand_5",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "-config",
               "value": "nested723"
             },
             {
-              "key": "&epsilon",
+              "key": "\u0026epsilon",
               "value": "deep891"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "&epsilon": "deep891",
+            "\u0026epsilon": "deep891",
             "-config": "nested723"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested723",
+          "expect": {
+            "\u0026epsilon": {
+              "deep891": {}
+            },
+            "-config": {
+              "nested723": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "-config"
-          ]
+          ],
+          "expect": "nested723",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "-config = nested723\n&epsilon = deep891"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "$path = nested884\n*mode = deep88"
+      ],
       "name": "s1_fuzz_nested_dollar_asterisk_6",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$path",
@@ -1163,40 +1291,52 @@
               "key": "*mode",
               "value": "deep88"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "$path": "nested884",
             "*mode": "deep88"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested884",
+          "expect": {
+            "$path": {
+              "nested884": {}
+            },
+            "*mode": {
+              "deep88": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "$path"
-          ]
+          ],
+          "expect": "nested884",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "$path = nested884\n*mode = deep88"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "_path = nested515\n;alpha = deep519"
+      ],
       "name": "s1_fuzz_nested_underscore_semicolon_7",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "_path",
@@ -1206,40 +1346,52 @@
               "key": ";alpha",
               "value": "deep519"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ";alpha": "deep519",
             "_path": "nested515"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested515",
+          "expect": {
+            ";alpha": {
+              "deep519": {}
+            },
+            "_path": {
+              "nested515": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "_path"
-          ]
+          ],
+          "expect": "nested515",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "_path = nested515\n;alpha = deep519"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "@server = nested286\n)gamma = deep475"
+      ],
       "name": "s1_fuzz_nested_at_rparen_8",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "@server",
@@ -1249,40 +1401,52 @@
               "key": ")gamma",
               "value": "deep475"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ")gamma": "deep475",
             "@server": "nested286"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested286",
+          "expect": {
+            ")gamma": {
+              "deep475": {}
+            },
+            "@server": {
+              "nested286": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "@server"
-          ]
+          ],
+          "expect": "nested286",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "@server = nested286\n)gamma = deep475"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "}beta = nested295\n~alpha = deep415"
+      ],
       "name": "s1_fuzz_nested_rbrace_tilde_9",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}beta",
@@ -1292,33 +1456,34 @@
               "key": "~alpha",
               "value": "deep415"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "}beta": "nested295",
             "~alpha": "deep415"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested295",
+          "expect": {
+            "}beta": {
+              "nested295": {}
+            },
+            "~alpha": {
+              "deep415": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "}beta"
-          ]
+          ],
+          "expect": "nested295",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "}beta = nested295\n~alpha = deep415"
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_fuzz_special_chars_seed42.json
+++ b/source_tests/core/api_fuzz_special_chars_seed42.json
@@ -2,900 +2,956 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "( = val620"
+      ],
       "name": "s42_fuzz_single_lparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(",
               "value": "val620"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "( = val620"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "- = val619"
+      ],
       "name": "s42_fuzz_single_hyphen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "-",
               "value": "val619"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "- = val619"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "] = val334"
+      ],
       "name": "s42_fuzz_single_rbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "]",
               "value": "val334"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "] = val334"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\\ = val595"
+      ],
       "name": "s42_fuzz_single_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\\",
               "value": "val595"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\\ = val595"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/ = val509"
+      ],
       "name": "s42_fuzz_single_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
               "value": "val509"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/ = val509"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$ = val877"
+      ],
       "name": "s42_fuzz_single_dollar",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$",
               "value": "val877"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$ = val877"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "} = val644"
+      ],
       "name": "s42_fuzz_single_rbrace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}",
               "value": "val644"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "} = val644"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "+ = val412"
+      ],
       "name": "s42_fuzz_single_plus",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "+",
               "value": "val412"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "+ = val412"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\" = val691"
+      ],
       "name": "s42_fuzz_single_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"",
               "value": "val691"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\" = val691"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "! = val528"
+      ],
       "name": "s42_fuzz_single_bang",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!",
               "value": "val528"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "! = val528"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "# = val238"
+      ],
       "name": "s42_fuzz_single_hash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "#",
               "value": "val238"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "# = val238"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003e = val318"
+      ],
       "name": "s42_fuzz_single_gt",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": ">",
+              "key": "\u003e",
               "value": "val318"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "> = val318"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "[ = val72"
+      ],
       "name": "s42_fuzz_single_lbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "[",
               "value": "val72"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "[ = val72"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ") = val688"
+      ],
       "name": "s42_fuzz_single_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")",
               "value": "val688"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ") = val688"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "? = val825"
+      ],
       "name": "s42_fuzz_single_question",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?",
               "value": "val825"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "? = val825"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "|\u003c; = combo808"
+      ],
       "name": "s42_fuzz_combo_pipe_lt_semicolon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "|<;",
+              "key": "|\u003c;",
               "value": "combo808"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "|<; = combo808"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "]\"* = combo591"
+      ],
       "name": "s42_fuzz_combo_rbracket_dquote_asterisk",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "]\"*",
               "value": "combo591"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "]\"* = combo591"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "}'+ = combo440"
+      ],
       "name": "s42_fuzz_combo_rbrace_squote_plus",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}'+",
               "value": "combo440"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "}'+ = combo440"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u0026\") = combo488"
+      ],
       "name": "s42_fuzz_combo_ampersand_dquote_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&\")",
+              "key": "\u0026\")",
               "value": "combo488"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "&\") = combo488"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "-~ = combo135"
+      ],
       "name": "s42_fuzz_combo_hyphen_tilde",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "-~",
               "value": "combo135"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "-~ = combo135"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "@\u003c;[ = combo491"
+      ],
       "name": "s42_fuzz_combo_at_lt_semicolon_lbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "@<;[",
+              "key": "@\u003c;[",
               "value": "combo491"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "@<;[ = combo491"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "'_ = combo768"
+      ],
       "name": "s42_fuzz_combo_squote_underscore",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'_",
               "value": "combo768"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "'_ = combo768"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003c: = combo590"
+      ],
       "name": "s42_fuzz_combo_lt_colon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "<:",
+              "key": "\u003c:",
               "value": "combo590"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "<: = combo590"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "@/* = combo681"
+      ],
       "name": "s42_fuzz_combo_at_slash_asterisk",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "@/*",
               "value": "combo681"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "@/* = combo681"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\"|/ = combo76"
+      ],
       "name": "s42_fuzz_combo_dquote_pipe_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"|/",
               "value": "combo76"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\"|/ = combo76"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "!port = pos235"
+      ],
       "name": "s42_fuzz_pos_start_bang_port",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!port",
               "value": "pos235"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "!port = pos235"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "da'ta = pos941"
+      ],
       "name": "s42_fuzz_pos_middle_squote_data",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "da'ta",
               "value": "pos941"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "da'ta = pos941"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "data\u003e = pos187"
+      ],
       "name": "s42_fuzz_pos_end_gt_data",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "data>",
+              "key": "data\u003e",
               "value": "pos187"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "data> = pos187"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/host = pos306"
+      ],
       "name": "s42_fuzz_pos_start_slash_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/host",
               "value": "pos306"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/host = pos306"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "na#me = pos189"
+      ],
       "name": "s42_fuzz_pos_middle_hash_name",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "na#me",
               "value": "pos189"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "na#me = pos189"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "delta+ = pos397"
+      ],
       "name": "s42_fuzz_pos_end_plus_delta",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "delta+",
               "value": "pos397"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "delta+ = pos397"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "'path = pos238"
+      ],
       "name": "s42_fuzz_pos_start_squote_path",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'path",
               "value": "pos238"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "'path = pos238"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "po(rt = pos139"
+      ],
       "name": "s42_fuzz_pos_middle_lparen_port",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "po(rt",
               "value": "pos139"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "po(rt = pos139"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "gamma; = pos404"
+      ],
       "name": "s42_fuzz_pos_end_semicolon_gamma",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "gamma;",
               "value": "pos404"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "gamma; = pos404"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003ealpha = pos196"
+      ],
       "name": "s42_fuzz_pos_start_gt_alpha",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": ">alpha",
+              "key": "\u003ealpha",
               "value": "pos196"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ">alpha = pos196"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "data = data|x58"
+      ],
       "name": "s42_fuzz_val_data_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "data",
               "value": "data|x58"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "data": "data|x58"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data|x58",
+          "expect": {
+            "data": {
+              "data|x58": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "data"
-          ]
+          ],
+          "expect": "data|x58",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "data = data|x58"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "beta = data\\x12"
+      ],
       "name": "s42_fuzz_val_beta_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "beta",
               "value": "data\\x12"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "beta": "data\\x12"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data\\x12",
+          "expect": {
+            "beta": {
+              "data\\x12": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "beta"
-          ]
+          ],
+          "expect": "data\\x12",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "beta = data\\x12"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "name = data\\x77\"x95_x85"
+      ],
       "name": "s42_fuzz_val_name_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
               "value": "data\\x77\"x95_x85"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "name": "data\\x77\"x95_x85"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data\\x77\"x95_x85",
+          "expect": {
+            "name": {
+              "data\\x77\"x95_x85": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "data\\x77\"x95_x85",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = data\\x77\"x95_x85"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "path = data-x45"
+      ],
       "name": "s42_fuzz_val_path_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "path",
               "value": "data-x45"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "path": "data-x45"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data-x45",
+          "expect": {
+            "path": {
+              "data-x45": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "path"
-          ]
+          ],
+          "expect": "data-x45",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "path = data-x45"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "name = data{x49\"x55"
+      ],
       "name": "s42_fuzz_val_name_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
               "value": "data{x49\"x55"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "name": "data{x49\"x55"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data{x49\"x55",
+          "expect": {
+            "name": {
+              "data{x49\"x55": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "data{x49\"x55",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = data{x49\"x55"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "{host = nested259\n]name = deep985"
+      ],
       "name": "s42_fuzz_nested_lbrace_rbracket_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{host",
@@ -905,40 +961,52 @@
               "key": "]name",
               "value": "deep985"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "]name": "deep985",
             "{host": "nested259"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested259",
+          "expect": {
+            "]name": {
+              "deep985": {}
+            },
+            "{host": {
+              "nested259": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "{host"
-          ]
+          ],
+          "expect": "nested259",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "{host = nested259\n]name = deep985"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "{port = nested169\n}mode = deep270"
+      ],
       "name": "s42_fuzz_nested_lbrace_rbrace_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{port",
@@ -948,126 +1016,162 @@
               "key": "}mode",
               "value": "deep270"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "{port": "nested169",
             "}mode": "deep270"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested169",
+          "expect": {
+            "{port": {
+              "nested169": {}
+            },
+            "}mode": {
+              "deep270": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "{port"
-          ]
+          ],
+          "expect": "nested169",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "{port = nested169\n}mode = deep270"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\u0026delta = nested56\n%data = deep952"
+      ],
       "name": "s42_fuzz_nested_ampersand_percent_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&delta",
+              "key": "\u0026delta",
               "value": "nested56"
             },
             {
               "key": "%data",
               "value": "deep952"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "%data": "deep952",
-            "&delta": "nested56"
-          }
+            "\u0026delta": "nested56"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested56",
+          "expect": {
+            "%data": {
+              "deep952": {}
+            },
+            "\u0026delta": {
+              "nested56": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
-            "&delta"
-          ]
+            "\u0026delta"
+          ],
+          "expect": "nested56",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "&delta = nested56\n%data = deep952"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\"epsilon = nested885\n\u003euser = deep168"
+      ],
       "name": "s42_fuzz_nested_dquote_gt_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"epsilon",
               "value": "nested885"
             },
             {
-              "key": ">user",
+              "key": "\u003euser",
               "value": "deep168"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"epsilon": "nested885",
-            ">user": "deep168"
-          }
+            "\u003euser": "deep168"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested885",
+          "expect": {
+            "\"epsilon": {
+              "nested885": {}
+            },
+            "\u003euser": {
+              "deep168": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\"epsilon"
-          ]
+          ],
+          "expect": "nested885",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\"epsilon = nested885\n>user = deep168"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "%alpha = nested438\n$path = deep65"
+      ],
       "name": "s42_fuzz_nested_percent_dollar_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%alpha",
@@ -1077,40 +1181,52 @@
               "key": "$path",
               "value": "deep65"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "$path": "deep65",
             "%alpha": "nested438"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested438",
+          "expect": {
+            "$path": {
+              "deep65": {}
+            },
+            "%alpha": {
+              "nested438": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "%alpha"
-          ]
+          ],
+          "expect": "nested438",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "%alpha = nested438\n$path = deep65"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\"gamma = nested524\n]mode = deep57"
+      ],
       "name": "s42_fuzz_nested_dquote_rbracket_5",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"gamma",
@@ -1120,83 +1236,107 @@
               "key": "]mode",
               "value": "deep57"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"gamma": "nested524",
             "]mode": "deep57"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested524",
+          "expect": {
+            "\"gamma": {
+              "nested524": {}
+            },
+            "]mode": {
+              "deep57": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\"gamma"
-          ]
+          ],
+          "expect": "nested524",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\"gamma = nested524\n]mode = deep57"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "{data = nested474\n\u0026port = deep22"
+      ],
       "name": "s42_fuzz_nested_lbrace_ampersand_6",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{data",
               "value": "nested474"
             },
             {
-              "key": "&port",
+              "key": "\u0026port",
               "value": "deep22"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "&port": "deep22",
+            "\u0026port": "deep22",
             "{data": "nested474"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested474",
+          "expect": {
+            "\u0026port": {
+              "deep22": {}
+            },
+            "{data": {
+              "nested474": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "{data"
-          ]
+          ],
+          "expect": "nested474",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "{data = nested474\n&port = deep22"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        ";data = nested239\n-server = deep284"
+      ],
       "name": "s42_fuzz_nested_semicolon_hyphen_7",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ";data",
@@ -1206,40 +1346,52 @@
               "key": "-server",
               "value": "deep284"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "-server": "deep284",
             ";data": "nested239"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested239",
+          "expect": {
+            "-server": {
+              "deep284": {}
+            },
+            ";data": {
+              "nested239": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             ";data"
-          ]
+          ],
+          "expect": "nested239",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        ";data = nested239\n-server = deep284"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "{host = nested125\n}user = deep615"
+      ],
       "name": "s42_fuzz_nested_lbrace_rbrace_8",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "{host",
@@ -1249,76 +1401,89 @@
               "key": "}user",
               "value": "deep615"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "{host": "nested125",
             "}user": "deep615"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested125",
+          "expect": {
+            "{host": {
+              "nested125": {}
+            },
+            "}user": {
+              "deep615": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "{host"
-          ]
+          ],
+          "expect": "nested125",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "{host = nested125\n}user = deep615"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "~beta = nested835\n\u0026gamma = deep966"
+      ],
       "name": "s42_fuzz_nested_tilde_ampersand_9",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "~beta",
               "value": "nested835"
             },
             {
-              "key": "&gamma",
+              "key": "\u0026gamma",
               "value": "deep966"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "&gamma": "deep966",
+            "\u0026gamma": "deep966",
             "~beta": "nested835"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested835",
+          "expect": {
+            "\u0026gamma": {
+              "deep966": {}
+            },
+            "~beta": {
+              "nested835": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "~beta"
-          ]
+          ],
+          "expect": "nested835",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "~beta = nested835\n&gamma = deep966"
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_fuzz_special_chars_seed49.json
+++ b/source_tests/core/api_fuzz_special_chars_seed49.json
@@ -2,900 +2,956 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "( = val911"
+      ],
       "name": "s49_fuzz_single_lparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(",
               "value": "val911"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "( = val911"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "| = val79"
+      ],
       "name": "s49_fuzz_single_pipe",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "|",
               "value": "val79"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "| = val79"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "% = val935"
+      ],
       "name": "s49_fuzz_single_percent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%",
               "value": "val935"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "% = val935"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "* = val545"
+      ],
       "name": "s49_fuzz_single_asterisk",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "*",
               "value": "val545"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "* = val545"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\\ = val748"
+      ],
       "name": "s49_fuzz_single_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\\",
               "value": "val748"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\\ = val748"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/ = val718"
+      ],
       "name": "s49_fuzz_single_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
               "value": "val718"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/ = val718"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "] = val858"
+      ],
       "name": "s49_fuzz_single_rbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "]",
               "value": "val858"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "] = val858"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u0026 = val116"
+      ],
       "name": "s49_fuzz_single_ampersand",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&",
+              "key": "\u0026",
               "value": "val116"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "& = val116"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "@ = val518"
+      ],
       "name": "s49_fuzz_single_at",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "@",
               "value": "val518"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "@ = val518"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\" = val757"
+      ],
       "name": "s49_fuzz_single_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"",
               "value": "val757"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\" = val757"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$ = val874"
+      ],
       "name": "s49_fuzz_single_dollar",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$",
               "value": "val874"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$ = val874"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "! = val221"
+      ],
       "name": "s49_fuzz_single_bang",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!",
               "value": "val221"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "! = val221"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ") = val331"
+      ],
       "name": "s49_fuzz_single_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")",
               "value": "val331"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ") = val331"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "} = val9"
+      ],
       "name": "s49_fuzz_single_rbrace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}",
               "value": "val9"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "} = val9"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "~ = val714"
+      ],
       "name": "s49_fuzz_single_tilde",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "~",
               "value": "val714"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "~ = val714"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "(#* = combo926"
+      ],
       "name": "s49_fuzz_combo_lparen_hash_asterisk",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(#*",
               "value": "combo926"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "(#* = combo926"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "}/_} = combo173"
+      ],
       "name": "s49_fuzz_combo_rbrace_slash_underscore_rbrace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}/_}",
               "value": "combo173"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "}/_} = combo173"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "]\\%@ = combo764"
+      ],
       "name": "s49_fuzz_combo_rbracket_backslash_percent_at",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "]\\%@",
               "value": "combo764"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "]\\%@ = combo764"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "]{'[ = combo827"
+      ],
       "name": "s49_fuzz_combo_rbracket_lbrace_squote_lbracket",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "]{'[",
               "value": "combo827"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "]{'[ = combo827"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ":) = combo140"
+      ],
       "name": "s49_fuzz_combo_colon_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ":)",
               "value": "combo140"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ":) = combo140"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003e~) = combo274"
+      ],
       "name": "s49_fuzz_combo_gt_tilde_rparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": ">~)",
+              "key": "\u003e~)",
               "value": "combo274"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ">~) = combo274"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ";\u003e: = combo111"
+      ],
       "name": "s49_fuzz_combo_semicolon_gt_colon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": ";>:",
+              "key": ";\u003e:",
               "value": "combo111"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ";>: = combo111"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "?+\\ = combo711"
+      ],
       "name": "s49_fuzz_combo_question_plus_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?+\\",
               "value": "combo711"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "?+\\ = combo711"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u0026\u0026 = combo102"
+      ],
       "name": "s49_fuzz_combo_ampersand_ampersand",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&&",
+              "key": "\u0026\u0026",
               "value": "combo102"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "&& = combo102"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "~\u0026~ = combo549"
+      ],
       "name": "s49_fuzz_combo_tilde_ampersand_tilde",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "~&~",
+              "key": "~\u0026~",
               "value": "combo549"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "~&~ = combo549"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "#host = pos568"
+      ],
       "name": "s49_fuzz_pos_start_hash_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "#host",
               "value": "pos568"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "#host = pos568"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "be/ta = pos975"
+      ],
       "name": "s49_fuzz_pos_middle_slash_beta",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "be/ta",
               "value": "pos975"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "be/ta = pos975"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "config( = pos258"
+      ],
       "name": "s49_fuzz_pos_end_lparen_config",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config(",
               "value": "pos258"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "config( = pos258"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "'data = pos985"
+      ],
       "name": "s49_fuzz_pos_start_squote_data",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'data",
               "value": "pos985"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "'data = pos985"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "al]pha = pos844"
+      ],
       "name": "s49_fuzz_pos_middle_rbracket_alpha",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "al]pha",
               "value": "pos844"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "al]pha = pos844"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "name% = pos392"
+      ],
       "name": "s49_fuzz_pos_end_percent_name",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name%",
               "value": "pos392"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "name% = pos392"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ")user = pos217"
+      ],
       "name": "s49_fuzz_pos_start_rparen_user",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")user",
               "value": "pos217"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ")user = pos217"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "ho[st = pos439"
+      ],
       "name": "s49_fuzz_pos_middle_lbracket_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "ho[st",
               "value": "pos439"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "ho[st = pos439"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "beta~ = pos557"
+      ],
       "name": "s49_fuzz_pos_end_tilde_beta",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "beta~",
               "value": "pos557"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "beta~ = pos557"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$config = pos46"
+      ],
       "name": "s49_fuzz_pos_start_dollar_config",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$config",
               "value": "pos46"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$config = pos46"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
-      "name": "s49_fuzz_val_epsilon_0",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "epsilon",
-              "value": "data;x5&x96?x73"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "epsilon": "data;x5&x96?x73"
-          }
-        },
-        {
-          "function": "get_string",
-          "expect": "data;x5&x96?x73",
-          "args": [
-            "epsilon"
-          ]
-        }
-      ],
-      "inputs": [
-        "epsilon = data;x5&x96?x73"
-      ],
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
+      ],
+      "inputs": [
+        "epsilon = data;x5\u0026x96?x73"
+      ],
+      "name": "s49_fuzz_val_epsilon_0",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "epsilon",
+              "value": "data;x5\u0026x96?x73"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "epsilon": "data;x5\u0026x96?x73"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "epsilon": {
+              "data;x5\u0026x96?x73": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "epsilon"
+          ],
+          "expect": "data;x5\u0026x96?x73",
+          "function": "get_string"
+        }
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "config = data'x33"
+      ],
       "name": "s49_fuzz_val_config_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "data'x33"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": "data'x33"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data'x33",
+          "expect": {
+            "config": {
+              "data'x33": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config"
-          ]
+          ],
+          "expect": "data'x33",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "config = data'x33"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "name = data\u003cx71"
+      ],
       "name": "s49_fuzz_val_name_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
-              "value": "data<x71"
+              "value": "data\u003cx71"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "name": "data<x71"
-          }
+            "name": "data\u003cx71"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data<x71",
+          "expect": {
+            "name": {
+              "data\u003cx71": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "data\u003cx71",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = data<x71"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "mode = data+x19"
+      ],
       "name": "s49_fuzz_val_mode_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "mode",
               "value": "data+x19"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "mode": "data+x19"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data+x19",
+          "expect": {
+            "mode": {
+              "data+x19": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "mode"
-          ]
+          ],
+          "expect": "data+x19",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "mode = data+x19"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "server = data#x70-x10"
+      ],
       "name": "s49_fuzz_val_server_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "server",
               "value": "data#x70-x10"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "server": "data#x70-x10"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data#x70-x10",
+          "expect": {
+            "server": {
+              "data#x70-x10": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "server"
-          ]
+          ],
+          "expect": "data#x70-x10",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "server = data#x70-x10"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "'name = nested330\n{user = deep34"
+      ],
       "name": "s49_fuzz_nested_squote_lbrace_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'name",
@@ -905,40 +961,52 @@
               "key": "{user",
               "value": "deep34"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "'name": "nested330",
             "{user": "deep34"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested330",
+          "expect": {
+            "'name": {
+              "nested330": {}
+            },
+            "{user": {
+              "deep34": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "'name"
-          ]
+          ],
+          "expect": "nested330",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "'name = nested330\n{user = deep34"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "@name = nested517\n_user = deep650"
+      ],
       "name": "s49_fuzz_nested_at_underscore_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "@name",
@@ -948,40 +1016,52 @@
               "key": "_user",
               "value": "deep650"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "@name": "nested517",
             "_user": "deep650"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested517",
+          "expect": {
+            "@name": {
+              "nested517": {}
+            },
+            "_user": {
+              "deep650": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "@name"
-          ]
+          ],
+          "expect": "nested517",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "@name = nested517\n_user = deep650"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        ")epsilon = nested451\n\\delta = deep648"
+      ],
       "name": "s49_fuzz_nested_rparen_backslash_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")epsilon",
@@ -991,83 +1071,107 @@
               "key": "\\delta",
               "value": "deep648"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ")epsilon": "nested451",
             "\\delta": "deep648"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested451",
+          "expect": {
+            ")epsilon": {
+              "nested451": {}
+            },
+            "\\delta": {
+              "deep648": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             ")epsilon"
-          ]
+          ],
+          "expect": "nested451",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        ")epsilon = nested451\n\\delta = deep648"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "$port = nested76\n\u003ehost = deep444"
+      ],
       "name": "s49_fuzz_nested_dollar_gt_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$port",
               "value": "nested76"
             },
             {
-              "key": ">host",
+              "key": "\u003ehost",
               "value": "deep444"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "$port": "nested76",
-            ">host": "deep444"
-          }
+            "\u003ehost": "deep444"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested76",
+          "expect": {
+            "$port": {
+              "nested76": {}
+            },
+            "\u003ehost": {
+              "deep444": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "$port"
-          ]
+          ],
+          "expect": "nested76",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "$port = nested76\n>host = deep444"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\"host = nested587\n{gamma = deep774"
+      ],
       "name": "s49_fuzz_nested_dquote_lbrace_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"host",
@@ -1077,40 +1181,52 @@
               "key": "{gamma",
               "value": "deep774"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"host": "nested587",
             "{gamma": "deep774"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested587",
+          "expect": {
+            "\"host": {
+              "nested587": {}
+            },
+            "{gamma": {
+              "deep774": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\"host"
-          ]
+          ],
+          "expect": "nested587",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\"host = nested587\n{gamma = deep774"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        ";host = nested246\n*item = deep424"
+      ],
       "name": "s49_fuzz_nested_semicolon_asterisk_5",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ";host",
@@ -1120,40 +1236,52 @@
               "key": "*item",
               "value": "deep424"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "*item": "deep424",
             ";host": "nested246"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested246",
+          "expect": {
+            "*item": {
+              "deep424": {}
+            },
+            ";host": {
+              "nested246": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             ";host"
-          ]
+          ],
+          "expect": "nested246",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        ";host = nested246\n*item = deep424"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "?epsilon = nested334\n*delta = deep689"
+      ],
       "name": "s49_fuzz_nested_question_asterisk_6",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?epsilon",
@@ -1163,83 +1291,107 @@
               "key": "*delta",
               "value": "deep689"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "*delta": "deep689",
             "?epsilon": "nested334"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested334",
+          "expect": {
+            "*delta": {
+              "deep689": {}
+            },
+            "?epsilon": {
+              "nested334": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "?epsilon"
-          ]
+          ],
+          "expect": "nested334",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "?epsilon = nested334\n*delta = deep689"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "+server = nested496\n\u0026gamma = deep440"
+      ],
       "name": "s49_fuzz_nested_plus_ampersand_7",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "+server",
               "value": "nested496"
             },
             {
-              "key": "&gamma",
+              "key": "\u0026gamma",
               "value": "deep440"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "&gamma": "deep440",
+            "\u0026gamma": "deep440",
             "+server": "nested496"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested496",
+          "expect": {
+            "\u0026gamma": {
+              "deep440": {}
+            },
+            "+server": {
+              "nested496": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "+server"
-          ]
+          ],
+          "expect": "nested496",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "+server = nested496\n&gamma = deep440"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "*item = nested578\n\"delta = deep232"
+      ],
       "name": "s49_fuzz_nested_asterisk_dquote_8",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "*item",
@@ -1249,40 +1401,52 @@
               "key": "\"delta",
               "value": "deep232"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"delta": "deep232",
             "*item": "nested578"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested578",
+          "expect": {
+            "\"delta": {
+              "deep232": {}
+            },
+            "*item": {
+              "nested578": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "*item"
-          ]
+          ],
+          "expect": "nested578",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "*item = nested578\n\"delta = deep232"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "}host = nested668\n/delta = deep756"
+      ],
       "name": "s49_fuzz_nested_rbrace_slash_9",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}host",
@@ -1292,33 +1456,34 @@
               "key": "/delta",
               "value": "deep756"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/delta": "deep756",
             "}host": "nested668"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested668",
+          "expect": {
+            "/delta": {
+              "deep756": {}
+            },
+            "}host": {
+              "nested668": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "}host"
-          ]
+          ],
+          "expect": "nested668",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "}host = nested668\n/delta = deep756"
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_fuzz_special_chars_seed99.json
+++ b/source_tests/core/api_fuzz_special_chars_seed99.json
@@ -2,900 +2,956 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "_ = val35"
+      ],
       "name": "s99_fuzz_single_underscore",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "_",
               "value": "val35"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "_ = val35"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\\ = val524"
+      ],
       "name": "s99_fuzz_single_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\\",
               "value": "val524"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\\ = val524"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "% = val196"
+      ],
       "name": "s99_fuzz_single_percent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%",
               "value": "val196"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "% = val196"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\" = val52"
+      ],
       "name": "s99_fuzz_single_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"",
               "value": "val52"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "\" = val52"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "| = val653"
+      ],
       "name": "s99_fuzz_single_pipe",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "|",
               "value": "val653"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "| = val653"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "? = val143"
+      ],
       "name": "s99_fuzz_single_question",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?",
               "value": "val143"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "? = val143"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "} = val623"
+      ],
       "name": "s99_fuzz_single_rbrace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}",
               "value": "val623"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "} = val623"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "- = val645"
+      ],
       "name": "s99_fuzz_single_hyphen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "-",
               "value": "val645"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "- = val645"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "( = val220"
+      ],
       "name": "s99_fuzz_single_lparen",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "(",
               "value": "val220"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "( = val220"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "/ = val115"
+      ],
       "name": "s99_fuzz_single_slash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
               "value": "val115"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "/ = val115"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "! = val103"
+      ],
       "name": "s99_fuzz_single_bang",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!",
               "value": "val103"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "! = val103"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "# = val874"
+      ],
       "name": "s99_fuzz_single_hash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "#",
               "value": "val874"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "# = val874"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u0026 = val520"
+      ],
       "name": "s99_fuzz_single_ampersand",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&",
+              "key": "\u0026",
               "value": "val520"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "& = val520"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "$ = val921"
+      ],
       "name": "s99_fuzz_single_dollar",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "$",
               "value": "val921"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "$ = val921"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ": = val671"
+      ],
       "name": "s99_fuzz_single_colon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ":",
               "value": "val671"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ": = val671"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "[*\u003e = combo828"
+      ],
       "name": "s99_fuzz_combo_lbracket_asterisk_gt",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "[*>",
+              "key": "[*\u003e",
               "value": "combo828"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "[*> = combo828"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "%;' = combo983"
+      ],
       "name": "s99_fuzz_combo_percent_semicolon_squote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%;'",
               "value": "combo983"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "%;' = combo983"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "'_)' = combo857"
+      ],
       "name": "s99_fuzz_combo_squote_underscore_rparen_squote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "'_)'",
               "value": "combo857"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "'_)' = combo857"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "_[\u003c\\ = combo602"
+      ],
       "name": "s99_fuzz_combo_underscore_lbracket_lt_backslash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "_[<\\",
+              "key": "_[\u003c\\",
               "value": "combo602"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "_[<\\ = combo602"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u0026(\" = combo48"
+      ],
       "name": "s99_fuzz_combo_ampersand_lparen_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "&(\"",
+              "key": "\u0026(\"",
               "value": "combo48"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "&(\" = combo48"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ")|(# = combo531"
+      ],
       "name": "s99_fuzz_combo_rparen_pipe_lparen_hash",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")|(#",
               "value": "combo531"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ")|(# = combo531"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "~*@? = combo716"
+      ],
       "name": "s99_fuzz_combo_tilde_asterisk_at_question",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "~*@?",
               "value": "combo716"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "~*@? = combo716"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "_*? = combo909"
+      ],
       "name": "s99_fuzz_combo_underscore_asterisk_question",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "_*?",
               "value": "combo909"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "_*? = combo909"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "!' = combo182"
+      ],
       "name": "s99_fuzz_combo_bang_squote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "!'",
               "value": "combo182"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "!' = combo182"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "?_\" = combo211"
+      ],
       "name": "s99_fuzz_combo_question_underscore_dquote",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?_\"",
               "value": "combo211"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "?_\" = combo211"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "%item = pos832"
+      ],
       "name": "s99_fuzz_pos_start_percent_item",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%item",
               "value": "pos832"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "%item = pos832"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "da]ta = pos418"
+      ],
       "name": "s99_fuzz_pos_middle_rbracket_data",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "da]ta",
               "value": "pos418"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "da]ta = pos418"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "delta\u003e = pos239"
+      ],
       "name": "s99_fuzz_pos_end_gt_delta",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "delta>",
+              "key": "delta\u003e",
               "value": "pos239"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "delta> = pos239"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        ")port = pos895"
+      ],
       "name": "s99_fuzz_pos_start_rparen_port",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")port",
               "value": "pos895"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        ")port = pos895"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "al_pha = pos195"
+      ],
       "name": "s99_fuzz_pos_middle_underscore_alpha",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "al_pha",
               "value": "pos195"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "al_pha = pos195"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "epsilon{ = pos824"
+      ],
       "name": "s99_fuzz_pos_end_lbrace_epsilon",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "epsilon{",
               "value": "pos824"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "epsilon{ = pos824"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "\u003calpha = pos633"
+      ],
       "name": "s99_fuzz_pos_start_lt_alpha",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "<alpha",
+              "key": "\u003calpha",
               "value": "pos633"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "<alpha = pos633"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "ho%st = pos14"
+      ],
       "name": "s99_fuzz_pos_middle_percent_host",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "ho%st",
               "value": "pos14"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "ho%st = pos14"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "item| = pos19"
+      ],
       "name": "s99_fuzz_pos_end_pipe_item",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item|",
               "value": "pos19"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "item| = pos19"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "%server = pos981"
+      ],
       "name": "s99_fuzz_pos_start_percent_server",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%server",
               "value": "pos981"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "%server = pos981"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "path = data'x66"
+      ],
       "name": "s99_fuzz_val_path_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "path",
               "value": "data'x66"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "path": "data'x66"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data'x66",
+          "expect": {
+            "path": {
+              "data'x66": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "path"
-          ]
+          ],
+          "expect": "data'x66",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "path = data'x66"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "item = data]x41!x78"
+      ],
       "name": "s99_fuzz_val_item_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item",
               "value": "data]x41!x78"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "item": "data]x41!x78"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data]x41!x78",
+          "expect": {
+            "item": {
+              "data]x41!x78": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "item"
-          ]
+          ],
+          "expect": "data]x41!x78",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "item = data]x41!x78"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "server = data[x73;x54!x24"
+      ],
       "name": "s99_fuzz_val_server_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "server",
               "value": "data[x73;x54!x24"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "server": "data[x73;x54!x24"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data[x73;x54!x24",
+          "expect": {
+            "server": {
+              "data[x73;x54!x24": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "server"
-          ]
+          ],
+          "expect": "data[x73;x54!x24",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "server = data[x73;x54!x24"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "path = data~x4\u003ex82~x46"
+      ],
       "name": "s99_fuzz_val_path_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "path",
-              "value": "data~x4>x82~x46"
+              "value": "data~x4\u003ex82~x46"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "path": "data~x4>x82~x46"
-          }
+            "path": "data~x4\u003ex82~x46"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data~x4>x82~x46",
+          "expect": {
+            "path": {
+              "data~x4\u003ex82~x46": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "path"
-          ]
+          ],
+          "expect": "data~x4\u003ex82~x46",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "path = data~x4>x82~x46"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "alpha = data\u003cx11[x43"
+      ],
       "name": "s99_fuzz_val_alpha_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "alpha",
-              "value": "data<x11[x43"
+              "value": "data\u003cx11[x43"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
-            "alpha": "data<x11[x43"
-          }
+            "alpha": "data\u003cx11[x43"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "data<x11[x43",
+          "expect": {
+            "alpha": {
+              "data\u003cx11[x43": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "alpha"
-          ]
+          ],
+          "expect": "data\u003cx11[x43",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "alpha = data<x11[x43"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "/data = nested929\n)item = deep37"
+      ],
       "name": "s99_fuzz_nested_slash_rparen_0",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/data",
@@ -905,83 +961,107 @@
               "key": ")item",
               "value": "deep37"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ")item": "deep37",
             "/data": "nested929"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested929",
+          "expect": {
+            ")item": {
+              "deep37": {}
+            },
+            "/data": {
+              "nested929": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "/data"
-          ]
+          ],
+          "expect": "nested929",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "/data = nested929\n)item = deep37"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\u003cport = nested722\n%config = deep795"
+      ],
       "name": "s99_fuzz_nested_lt_percent_1",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
-              "key": "<port",
+              "key": "\u003cport",
               "value": "nested722"
             },
             {
               "key": "%config",
               "value": "deep795"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "%config": "deep795",
-            "<port": "nested722"
-          }
+            "\u003cport": "nested722"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested722",
+          "expect": {
+            "%config": {
+              "deep795": {}
+            },
+            "\u003cport": {
+              "nested722": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
-            "<port"
-          ]
+            "\u003cport"
+          ],
+          "expect": "nested722",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "<port = nested722\n%config = deep795"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "/epsilon = nested268\n{server = deep795"
+      ],
       "name": "s99_fuzz_nested_slash_lbrace_2",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/epsilon",
@@ -991,40 +1071,52 @@
               "key": "{server",
               "value": "deep795"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/epsilon": "nested268",
             "{server": "deep795"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested268",
+          "expect": {
+            "/epsilon": {
+              "nested268": {}
+            },
+            "{server": {
+              "deep795": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "/epsilon"
-          ]
+          ],
+          "expect": "nested268",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "/epsilon = nested268\n{server = deep795"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\"host = nested435\n[server = deep479"
+      ],
       "name": "s99_fuzz_nested_dquote_lbracket_3",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"host",
@@ -1034,40 +1126,52 @@
               "key": "[server",
               "value": "deep479"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"host": "nested435",
             "[server": "deep479"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested435",
+          "expect": {
+            "\"host": {
+              "nested435": {}
+            },
+            "[server": {
+              "deep479": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\"host"
-          ]
+          ],
+          "expect": "nested435",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\"host = nested435\n[server = deep479"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\\item = nested708\n\\name = deep133"
+      ],
       "name": "s99_fuzz_nested_backslash_backslash_4",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\\item",
@@ -1077,40 +1181,52 @@
               "key": "\\name",
               "value": "deep133"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\\item": "nested708",
             "\\name": "deep133"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested708",
+          "expect": {
+            "\\item": {
+              "nested708": {}
+            },
+            "\\name": {
+              "deep133": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\\item"
-          ]
+          ],
+          "expect": "nested708",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\\item = nested708\n\\name = deep133"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "?delta = nested18\n\"item = deep576"
+      ],
       "name": "s99_fuzz_nested_question_dquote_5",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "?delta",
@@ -1120,40 +1236,52 @@
               "key": "\"item",
               "value": "deep576"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"item": "deep576",
             "?delta": "nested18"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested18",
+          "expect": {
+            "\"item": {
+              "deep576": {}
+            },
+            "?delta": {
+              "nested18": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "?delta"
-          ]
+          ],
+          "expect": "nested18",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "?delta = nested18\n\"item = deep576"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "\"user = nested759\n\\data = deep718"
+      ],
       "name": "s99_fuzz_nested_dquote_backslash_6",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "\"user",
@@ -1163,40 +1291,52 @@
               "key": "\\data",
               "value": "deep718"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "\"user": "nested759",
             "\\data": "deep718"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested759",
+          "expect": {
+            "\"user": {
+              "nested759": {}
+            },
+            "\\data": {
+              "deep718": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "\"user"
-          ]
+          ],
+          "expect": "nested759",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "\"user = nested759\n\\data = deep718"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        ")port = nested292\n\\server = deep527"
+      ],
       "name": "s99_fuzz_nested_rparen_backslash_7",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": ")port",
@@ -1206,40 +1346,52 @@
               "key": "\\server",
               "value": "deep527"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             ")port": "nested292",
             "\\server": "deep527"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested292",
+          "expect": {
+            ")port": {
+              "nested292": {}
+            },
+            "\\server": {
+              "deep527": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             ")port"
-          ]
+          ],
+          "expect": "nested292",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        ")port = nested292\n\\server = deep527"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "}delta = nested591\n$gamma = deep225"
+      ],
       "name": "s99_fuzz_nested_rbrace_dollar_8",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "}delta",
@@ -1249,76 +1401,89 @@
               "key": "$gamma",
               "value": "deep225"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "$gamma": "deep225",
             "}delta": "nested591"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested591",
+          "expect": {
+            "$gamma": {
+              "deep225": {}
+            },
+            "}delta": {
+              "nested591": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "}delta"
-          ]
+          ],
+          "expect": "nested591",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "}delta = nested591\n$gamma = deep225"
-      ],
+      ]
+    },
+    {
       "features": [
         "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_string",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "%epsilon = nested761\n\u0026port = deep211"
+      ],
       "name": "s99_fuzz_nested_percent_ampersand_9",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "%epsilon",
               "value": "nested761"
             },
             {
-              "key": "&port",
+              "key": "\u0026port",
               "value": "deep211"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "%epsilon": "nested761",
-            "&port": "deep211"
-          }
+            "\u0026port": "deep211"
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "nested761",
+          "expect": {
+            "%epsilon": {
+              "nested761": {}
+            },
+            "\u0026port": {
+              "deep211": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "%epsilon"
-          ]
+          ],
+          "expect": "nested761",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "%epsilon = nested761\n&port = deep211"
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_list_access.json
+++ b/source_tests/core/api_list_access.json
@@ -2,10 +2,21 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "servers = web1\nservers = web2\nservers = web3"
+      ],
       "name": "basic_list_from_duplicates",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
@@ -19,47 +30,58 @@
               "key": "servers",
               "value": "web3"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "servers": [
               "web1",
               "web2",
               "web3"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "servers": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "servers"
+          ],
           "expect": [
             "web1",
             "web2",
             "web3"
           ],
-          "args": [
-            "servers"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled"
-      ],
-      "inputs": [
-        "servers = web1\nservers = web2\nservers = web3"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "items = item01\nitems = item02\nitems = item03\nitems = item04\nitems = item05\nitems = item06\nitems = item07\nitems = item08\nitems = item09\nitems = item10\nitems = item11\nitems = item12\nitems = item13\nitems = item14\nitems = item15\nitems = item16\nitems = item17\nitems = item18\nitems = item19\nitems = item20"
+      ],
       "name": "large_list",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
@@ -141,10 +163,10 @@
               "key": "items",
               "value": "item20"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": [
               "item01",
@@ -168,10 +190,40 @@
               "item19",
               "item20"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "items": {
+              "item01": {},
+              "item02": {},
+              "item03": {},
+              "item04": {},
+              "item05": {},
+              "item06": {},
+              "item07": {},
+              "item08": {},
+              "item09": {},
+              "item10": {},
+              "item11": {},
+              "item12": {},
+              "item13": {},
+              "item14": {},
+              "item15": {},
+              "item16": {},
+              "item17": {},
+              "item18": {},
+              "item19": {},
+              "item20": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "items"
+          ],
           "expect": [
             "item01",
             "item02",
@@ -194,28 +246,30 @@
             "item19",
             "item20"
           ],
-          "args": [
-            "items"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled"
-      ],
-      "inputs": [
-        "items = item01\nitems = item02\nitems = item03\nitems = item04\nitems = item05\nitems = item06\nitems = item07\nitems = item08\nitems = item09\nitems = item10\nitems = item11\nitems = item12\nitems = item13\nitems = item14\nitems = item15\nitems = item16\nitems = item17\nitems = item18\nitems = item19\nitems = item20"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion"
+      ],
+      "features": [
+        "comments"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
+      ],
       "name": "list_with_comments",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
@@ -237,10 +291,10 @@
               "key": "/",
               "value": "End of list"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/": [
               "Production servers",
@@ -251,41 +305,56 @@
               "web2",
               "web3"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "/": {
+              "End of list": {},
+              "Production servers": {}
+            },
+            "servers": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "servers"
+          ],
           "expect": [
             "web1",
             "web2",
             "web3"
           ],
-          "args": [
-            "servers"
-          ]
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_enabled",
-        "array_order_insertion"
+        "array_order_lexicographic"
       ],
       "features": [
         "comments"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
       "inputs": [
         "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
-      ]
-    },
-    {
       "name": "list_with_comments_lexicographic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
@@ -307,10 +376,10 @@
               "key": "/",
               "value": "End of list"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/": [
               "End of list",
@@ -321,187 +390,232 @@
               "web2",
               "web3"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "/": {
+              "End of list": {},
+              "Production servers": {}
+            },
+            "servers": {
+              "web1": {},
+              "web2": {},
+              "web3": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "servers"
+          ],
           "expect": [
             "web1",
             "web2",
             "web3"
           ],
-          "args": [
-            "servers"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_lexicographic"
-      ],
-      "features": [
-        "comments"
-      ],
-      "inputs": [
-        "servers = web1\n/= Production servers\nservers = web2\nservers = web3\n/= End of list"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
       "name": "list_error_missing_key",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "existing": "value"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "existing": {
+              "value": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "missing"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "existing",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "existing = value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  server = web1"
+      ],
       "name": "list_error_nested_missing_key",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  server = web1"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "server": "web1"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "config": {
+              "server": {
+                "web1": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "missing"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "inputs": [
-        "config =\n  server = web1"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "value = simple"
+      ],
       "name": "list_error_non_object_path",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "value",
               "value": "simple"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "value": "simple"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "value": {
+              "simple": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "value",
             "nested"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "inputs": [
-        "value = simple"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
-      "name": "list_edge_case_zero_length",
-      "tests": [
-        {
-          "function": "get_list",
-          "expect": null,
-          "args": [
-            "nonexistent"
-          ]
-        },
-        {
-          "function": "parse",
-          "expect": []
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {}
-        }
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
       ],
       "inputs": [
         ""
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
+      "name": "list_edge_case_zero_length",
+      "tests": [
+        {
+          "args": [
+            "nonexistent"
+          ],
+          "expect": null,
+          "function": "get_list"
+        },
+        {
+          "expect": [],
+          "function": "parse"
+        },
+        {
+          "expect": {},
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {},
+          "function": "build_model"
+        }
       ]
     },
     {
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "servers =\n  = web1\n  = web2\n  = web3"
+      ],
       "name": "bare_list_basic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "servers",
               "value": "\n  = web1\n  = web2\n  = web3"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "servers": {
               "": [
@@ -510,101 +624,133 @@
                 "web3"
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "servers": {
+              "": {
+                "web1": {},
+                "web2": {},
+                "web3": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "servers"
+          ],
           "expect": [
             "web1",
             "web2",
             "web3"
           ],
-          "args": [
-            "servers"
-          ]
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys"
-      ],
-      "inputs": [
-        "servers =\n  = web1\n  = web2\n  = web3"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
-      "name": "bare_list_nested",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "network",
-              "value": "\n  ports =\n    = 80\n    = 443\n    = 8080"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "network": {
-              "ports": {
-                "": [
-                  "80",
-                  "443",
-                  "8080"
-                ]
-              }
-            }
-          }
-        },
-        {
-          "function": "get_list",
-          "expect": [
-            "80",
-            "443",
-            "8080"
-          ],
-          "args": [
-            "network",
-            "ports"
-          ]
-        }
-      ],
-      "features": [
-        "empty_keys"
-      ],
       "behaviors": [
         "array_order_insertion",
         "path_traversal"
       ],
-      "inputs": [
-        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      "features": [
+        "empty_keys"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
-      "name": "bare_list_nested_lexicographic",
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "network",
               "value": "\n  ports =\n    = 80\n    = 443\n    = 8080"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
+          "expect": {
+            "network": {
+              "ports": {
+                "": [
+                  "80",
+                  "443",
+                  "8080"
+                ]
+              }
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "network": {
+              "ports": {
+                "": {
+                  "443": {},
+                  "80": {},
+                  "8080": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "network",
+            "ports"
+          ],
+          "expect": [
+            "80",
+            "443",
+            "8080"
+          ],
+          "function": "get_list"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "array_order_lexicographic",
+        "path_traversal"
+      ],
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
+      ],
+      "name": "bare_list_nested_lexicographic",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "network",
+              "value": "\n  ports =\n    = 80\n    = 443\n    = 8080"
+            }
+          ],
+          "function": "parse"
+        },
+        {
           "expect": {
             "network": {
               "ports": {
@@ -615,51 +761,66 @@
                 ]
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "network": {
+              "ports": {
+                "": {
+                  "443": {},
+                  "80": {},
+                  "8080": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "network",
+            "ports"
+          ],
           "expect": [
             "443",
             "80",
             "8080"
           ],
-          "args": [
-            "network",
-            "ports"
-          ]
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys"
-      ],
-      "behaviors": [
-        "array_order_lexicographic",
-        "path_traversal"
-      ],
-      "inputs": [
-        "network =\n  ports =\n    = 80\n    = 443\n    = 8080"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "array_order_insertion"
+      ],
+      "features": [
+        "empty_keys",
+        "comments"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
+      ],
       "name": "bare_list_with_comments",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "allowed_hosts",
               "value": "\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "allowed_hosts": {
               "": [
@@ -669,50 +830,66 @@
               ],
               "/": "Production hosts"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "allowed_hosts": {
+              "": {
+                "127.0.0.1": {},
+                "example.com": {},
+                "localhost": {}
+              },
+              "/": {
+                "Production hosts": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "allowed_hosts"
+          ],
           "expect": [
             "localhost",
             "127.0.0.1",
             "example.com"
           ],
-          "args": [
-            "allowed_hosts"
-          ]
+          "function": "get_list"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "array_order_lexicographic"
       ],
       "features": [
         "empty_keys",
         "comments"
       ],
-      "behaviors": [
-        "array_order_insertion"
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
       ],
       "inputs": [
         "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
-      ]
-    },
-    {
       "name": "bare_list_with_comments_lexicographic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "allowed_hosts",
               "value": "\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "allowed_hosts": {
               "": [
@@ -722,50 +899,66 @@
               ],
               "/": "Production hosts"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "allowed_hosts": {
+              "": {
+                "127.0.0.1": {},
+                "example.com": {},
+                "localhost": {}
+              },
+              "/": {
+                "Production hosts": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "allowed_hosts"
+          ],
           "expect": [
             "127.0.0.1",
             "example.com",
             "localhost"
           ],
-          "args": [
-            "allowed_hosts"
-          ]
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "comments"
-      ],
-      "behaviors": [
-        "array_order_lexicographic"
-      ],
-      "inputs": [
-        "allowed_hosts =\n  /= Production hosts\n  = localhost\n  = 127.0.0.1\n  = example.com"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "array_order_insertion",
+        "path_traversal"
+      ],
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
+      ],
       "name": "bare_list_deeply_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "environments": {
@@ -780,53 +973,72 @@
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "web1",
-            "web2",
-            "api1"
-          ],
+          "expect": {
+            "config": {
+              "environments": {
+                "production": {
+                  "servers": {
+                    "": {
+                      "api1": {},
+                      "web1": {},
+                      "web2": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "environments",
             "production",
             "servers"
-          ]
+          ],
+          "expect": [
+            "web1",
+            "web2",
+            "api1"
+          ],
+          "function": "get_list"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "array_order_lexicographic",
+        "path_traversal"
       ],
       "features": [
         "empty_keys"
       ],
-      "behaviors": [
-        "array_order_insertion",
-        "path_traversal"
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
       ],
       "inputs": [
         "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
-      ]
-    },
-    {
       "name": "bare_list_deeply_nested_lexicographic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "environments": {
@@ -841,53 +1053,71 @@
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "api1",
-            "web1",
-            "web2"
-          ],
+          "expect": {
+            "config": {
+              "environments": {
+                "production": {
+                  "servers": {
+                    "": {
+                      "api1": {},
+                      "web1": {},
+                      "web2": {}
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "environments",
             "production",
             "servers"
-          ]
+          ],
+          "expect": [
+            "api1",
+            "web1",
+            "web2"
+          ],
+          "function": "get_list"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "path_traversal"
       ],
       "features": [
         "empty_keys"
       ],
-      "behaviors": [
-        "array_order_lexicographic",
-        "path_traversal"
-      ],
-      "inputs": [
-        "config =\n  environments =\n    production =\n      servers =\n        = web1\n        = web2\n        = api1"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
+      ],
       "name": "bare_list_mixed_with_other_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "database",
               "value": "\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "host": "localhost",
@@ -899,91 +1129,118 @@
                 ]
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "database": {
+              "host": {
+                "localhost": {}
+              },
+              "port": {
+                "5432": {}
+              },
+              "replicas": {
+                "": {
+                  "replica1": {},
+                  "replica2": {}
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "database",
+            "replicas"
+          ],
           "expect": [
             "replica1",
             "replica2"
           ],
-          "args": [
-            "database",
-            "replicas"
-          ]
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys"
-      ],
-      "inputs": [
-        "database =\n  host = localhost\n  port = 5432\n  replicas =\n    = replica1\n    = replica2"
-      ],
+      ]
+    },
+    {
       "behaviors": [
+        "list_coercion_disabled",
         "path_traversal"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "config =\n  setting = value"
+      ],
       "name": "bare_list_error_not_a_list",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  setting = value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "setting": "value"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "config": {
+              "setting": {
+                "value": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "setting"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "path_traversal"
-      ],
-      "inputs": [
-        "config =\n  setting = value"
+      ]
+    },
+    {
+      "features": [
+        "empty_keys"
       ],
       "functions": [
         "build_hierarchy",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
+      ],
       "name": "bare_list_nested_objects_basic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
               "value": "\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": {
               "": [
@@ -997,10 +1254,13 @@
                 }
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "args": [
+            "items"
+          ],
           "expect": [
             {
               "name": "first",
@@ -1011,37 +1271,34 @@
               "value": "2"
             }
           ],
-          "args": [
-            "items"
-          ]
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys"
-      ],
-      "inputs": [
-        "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
       ],
       "functions": [
         "build_hierarchy",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =\n  =\n    name = only\n    value = 42"
+      ],
       "name": "bare_list_nested_objects_single_item",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
               "value": "\n  =\n    name = only\n    value = 42"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": {
               "": [
@@ -1051,47 +1308,46 @@
                 }
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "args": [
+            "items"
+          ],
           "expect": [
             {
               "name": "only",
               "value": "42"
             }
           ],
-          "args": [
-            "items"
-          ]
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys"
-      ],
-      "inputs": [
-        "items =\n  =\n    name = only\n    value = 42"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "features": [
+        "empty_keys"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "parse"
+      ],
+      "inputs": [
+        "items =\n  =\n    name = first\n  =\n    name = second"
+      ],
       "name": "bare_list_nested_objects_minimal",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
               "value": "\n  =\n    name = first\n  =\n    name = second"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": {
               "": [
@@ -1103,34 +1359,34 @@
                 }
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         }
-      ],
+      ]
+    },
+    {
       "features": [
         "empty_keys"
-      ],
-      "inputs": [
-        "items =\n  =\n    name = first\n  =\n    name = second"
       ],
       "functions": [
         "build_hierarchy",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =\n  =\n    config =\n      host = localhost\n      port = 8080\n  =\n    config =\n      host = example.com\n      port = 443"
+      ],
       "name": "bare_list_nested_objects_deeply_nested",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
               "value": "\n  =\n    config =\n      host = localhost\n      port = 8080\n  =\n    config =\n      host = example.com\n      port = 443"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": {
               "": [
@@ -1148,34 +1404,37 @@
                 }
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "array_order_insertion"
       ],
       "features": [
         "empty_keys"
       ],
-      "inputs": [
-        "items =\n  =\n    config =\n      host = localhost\n      port = 8080\n  =\n    config =\n      host = example.com\n      port = 443"
-      ],
       "functions": [
         "build_hierarchy",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =\n  = simple_string\n  =\n    name = nested\n    value = obj\n  = another_string"
+      ],
       "name": "bare_list_nested_objects_mixed_with_strings",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
               "value": "\n  = simple_string\n  =\n    name = nested\n    value = obj\n  = another_string"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": {
               "": [
@@ -1187,54 +1446,42 @@
                 "another_string"
               ]
             }
-          }
+          },
+          "function": "build_hierarchy"
         }
-      ],
-      "features": [
-        "empty_keys"
-      ],
-      "behaviors": [
-        "array_order_insertion"
-      ],
-      "inputs": [
-        "items =\n  = simple_string\n  =\n    name = nested\n    value = obj\n  = another_string"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
-      "name": "bare_list_nested_objects_round_trip",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "items",
-              "value": "\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
-            }
-          ]
-        },
-        {
-          "function": "print",
-          "expect": "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
-        },
-        {
-          "function": "round_trip",
-          "expect": true
-        }
-      ],
       "features": [
         "empty_keys"
-      ],
-      "inputs": [
-        "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
       ],
       "functions": [
         "parse",
         "print",
         "round_trip"
+      ],
+      "inputs": [
+        "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
+      ],
+      "name": "bare_list_nested_objects_round_trip",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "items",
+              "value": "\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": "items =\n  =\n    name = first\n    value = 1\n  =\n    name = second\n    value = 2",
+          "function": "print"
+        },
+        {
+          "expect": true,
+          "function": "round_trip"
+        }
       ]
     }
   ]

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -2,10 +2,22 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "behaviors": [
+        "multiline_values"
+      ],
+      "features": [
+        "empty_keys",
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse_indented"
+      ],
+      "inputs": [
+        "== Section Header =\n  This continues the header\nkey = value"
+      ],
       "name": "multiline_section_header_value",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "",
@@ -15,28 +27,25 @@
               "key": "key",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
-      "behaviors": [
-        "multiline_values"
-      ],
-      "features": [
-        "empty_keys",
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "== Section Header =\n  This continues the header\nkey = value"
-      ],
-      "functions": [
-        "parse_indented"
       ]
     },
     {
+      "features": [
+        "empty_keys",
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse_indented"
+      ],
+      "inputs": [
+        "== Section Header =\nThis continues the header\nkey = value"
+      ],
       "name": "unindented_line_does_not_continue_value",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "",
@@ -46,28 +55,35 @@
               "key": "This continues the header\nkey",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "multiline_keys"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "== Section Header =\nThis continues the header\nkey = value"
-      ],
-      "functions": [
-        "parse_indented"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion",
+        "multiline_values"
+      ],
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse_indented"
+      ],
+      "inputs": [
+        "descriptions = First line\n  second line\ndescriptions = Another item"
+      ],
       "name": "indented_line_is_continuation",
       "tests": [
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "descriptions",
@@ -77,90 +93,105 @@
               "key": "descriptions",
               "value": "Another item"
             }
-          ]
+          ],
+          "function": "parse_indented"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "descriptions": [
               "First line\n  second line",
               "Another item"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "descriptions": {
+              "Another item": {},
+              "First line\n  second line": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "descriptions"
+          ],
           "expect": [
             "First line\n  second line",
             "Another item"
           ],
-          "args": [
-            "descriptions"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion",
-        "multiline_values"
-      ],
-      "features": [
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "descriptions = First line\n  second line\ndescriptions = Another item"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse_indented"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "item = single"
+      ],
       "name": "single_item_as_list",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item",
               "value": "single"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "item": "single"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "item": {
+              "single": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "item"
+          ],
           "expect": [
             "single"
           ],
-          "args": [
-            "item"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled"
-      ],
-      "inputs": [
-        "item = single"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
       "name": "mixed_duplicate_single_keys",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "ports",
@@ -174,65 +205,78 @@
               "key": "host",
               "value": "localhost"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "host": "localhost",
             "ports": [
               "80",
               "443"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "host": {
+              "localhost": {}
+            },
+            "ports": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "ports"
+          ],
           "expect": [
             "80",
             "443"
           ],
-          "args": [
-            "ports"
-          ]
+          "function": "get_list"
         },
         {
-          "function": "get_list",
+          "args": [
+            "host"
+          ],
           "expect": [
             "localhost"
           ],
-          "args": [
-            "host"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion"
-      ],
-      "inputs": [
-        "ports = 80\nports = 443\nhost = localhost"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
       "name": "nested_list_access",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "database",
               "value": "\n  hosts = primary\n  hosts = secondary\n  port = 5432"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "hosts": [
@@ -241,89 +285,113 @@
               ],
               "port": "5432"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "database": {
+              "hosts": {
+                "primary": {},
+                "secondary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "database",
+            "hosts"
+          ],
           "expect": [
             "primary",
             "secondary"
           ],
-          "args": [
-            "database",
-            "hosts"
-          ]
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "5432"
-          ],
           "args": [
             "database",
             "port"
-          ]
+          ],
+          "expect": [
+            "5432"
+          ],
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "path_traversal"
-      ],
-      "inputs": [
-        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
       "name": "empty_list",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "empty_list",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "empty_list": ""
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "empty_list": {
+              "": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "empty_list"
+          ],
           "expect": [
             ""
           ],
-          "args": [
-            "empty_list"
-          ]
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_enabled",
         "array_order_insertion"
       ],
-      "inputs": [
-        "empty_list ="
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
       "name": "list_with_numbers",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "numbers",
@@ -341,10 +409,10 @@
               "key": "numbers",
               "value": "0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "numbers": [
               "1",
@@ -352,39 +420,51 @@
               "-17",
               "0"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "numbers": {
+              "-17": {},
+              "0": {},
+              "1": {},
+              "42": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "numbers"
+          ],
           "expect": [
             "1",
             "42",
             "-17",
             "0"
           ],
-          "args": [
-            "numbers"
-          ]
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_enabled",
         "array_order_insertion"
       ],
-      "inputs": [
-        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
       "name": "list_with_booleans",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flags",
@@ -402,10 +482,10 @@
               "key": "flags",
               "value": "no"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "flags": [
               "true",
@@ -413,39 +493,54 @@
               "yes",
               "no"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "flags": {
+              "false": {},
+              "no": {},
+              "true": {},
+              "yes": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "flags"
+          ],
           "expect": [
             "true",
             "false",
             "yes",
             "no"
           ],
-          "args": [
-            "flags"
-          ]
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_enabled",
         "array_order_insertion"
       ],
-      "inputs": [
-        "flags = true\nflags = false\nflags = yes\nflags = no"
+      "features": [
+        "whitespace"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
       "name": "list_with_whitespace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
@@ -463,10 +558,10 @@
               "key": "items",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": [
               "spaced",
@@ -474,85 +569,34 @@
               "",
               ""
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "items": {
+              "": {},
+              "normal": {},
+              "spaced": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "items"
+          ],
           "expect": [
             "spaced",
             "normal",
             "",
             ""
           ],
-          "args": [
-            "items"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "items =   spaced   \nitems = normal\nitems =\nitems =   "
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
-      "name": "list_with_unicode",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "names",
-              "value": "\u5f20\u4e09"
-            },
-            {
-              "key": "names",
-              "value": "Jos\u00e9"
-            },
-            {
-              "key": "names",
-              "value": "Fran\u00e7ois"
-            },
-            {
-              "key": "names",
-              "value": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "names": [
-              "\u5f20\u4e09",
-              "Jos\u00e9",
-              "Fran\u00e7ois",
-              "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-            ]
-          }
-        },
-        {
-          "function": "get_list",
-          "expect": [
-            "\u5f20\u4e09",
-            "Jos\u00e9",
-            "Fran\u00e7ois",
-            "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-          ],
-          "args": [
-            "names"
-          ]
-        }
-      ],
       "behaviors": [
         "list_coercion_enabled",
         "array_order_insertion"
@@ -560,20 +604,91 @@
       "features": [
         "unicode"
       ],
-      "inputs": [
-        "names = \u5f20\u4e09\nnames = Jos\u00e9\nnames = Fran\u00e7ois\nnames = \u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "names",
+              "value": "张三"
+            },
+            {
+              "key": "names",
+              "value": "José"
+            },
+            {
+              "key": "names",
+              "value": "François"
+            },
+            {
+              "key": "names",
+              "value": "العربية"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "names": [
+              "张三",
+              "José",
+              "François",
+              "العربية"
+            ]
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "names": {
+              "François": {},
+              "José": {},
+              "العربية": {},
+              "张三": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "names"
+          ],
+          "expect": [
+            "张三",
+            "José",
+            "François",
+            "العربية"
+          ],
+          "function": "get_list"
+        }
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^\u0026*()\nsymbols = []{}|\nsymbols = \u003c\u003e=+"
+      ],
       "name": "list_with_special_characters",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "symbols",
@@ -581,7 +696,7 @@
             },
             {
               "key": "symbols",
-              "value": "!^&*()"
+              "value": "!^\u0026*()"
             },
             {
               "key": "symbols",
@@ -589,52 +704,68 @@
             },
             {
               "key": "symbols",
-              "value": "<>=+"
+              "value": "\u003c\u003e=+"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "symbols": [
               "@#$%",
-              "!^&*()",
+              "!^\u0026*()",
               "[]{}|",
-              "<>=+"
+              "\u003c\u003e=+"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "@#$%",
-            "!^&*()",
-            "[]{}|",
-            "<>=+"
-          ],
+          "expect": {
+            "symbols": {
+              "!^\u0026*()": {},
+              "\u003c\u003e=+": {},
+              "@#$%": {},
+              "[]{}|": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "symbols"
-          ]
+          ],
+          "expect": [
+            "@#$%",
+            "!^\u0026*()",
+            "[]{}|",
+            "\u003c\u003e=+"
+          ],
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion"
-      ],
-      "inputs": [
-        "symbols = @#$%\nsymbols = !^&*()\nsymbols = []{}|\nsymbols = <>=+"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion",
+        "multiline_values"
+      ],
+      "features": [
+        "multiline_continuation"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse_indented"
+      ],
+      "inputs": [
+        "descriptions = First line\nsecond line\ndescriptions = Another item\ndescriptions = Third item"
+      ],
       "name": "list_multiline_values",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "descriptions": [
               "First line",
@@ -642,21 +773,34 @@
               "Third item"
             ],
             "second line": ""
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
+          "expect": {
+            "descriptions": {
+              "Another item": {},
+              "First line": {},
+              "Third item": {}
+            },
+            "second line": {
+              "": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "descriptions"
+          ],
           "expect": [
             "First line",
             "Another item",
             "Third item"
           ],
-          "args": [
-            "descriptions"
-          ]
+          "function": "get_list"
         },
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "descriptions",
@@ -674,75 +818,73 @@
               "key": "descriptions",
               "value": "Third item"
             }
-          ]
+          ],
+          "function": "parse_indented"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion",
-        "multiline_values"
-      ],
-      "features": [
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "descriptions = First line\nsecond line\ndescriptions = Another item\ndescriptions = Third item"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse_indented"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled",
+        "array_order_insertion",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse_indented"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
       "name": "complex_mixed_list_scenarios",
       "tests": [
         {
-          "function": "get_list",
+          "args": [
+            "config",
+            "servers"
+          ],
           "expect": [
             "web1",
             "web2"
           ],
-          "args": [
-            "config",
-            "servers"
-          ]
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "primary",
-            "backup"
-          ],
           "args": [
             "config",
             "database",
             "hosts"
-          ]
+          ],
+          "expect": [
+            "primary",
+            "backup"
+          ],
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": [
-            "redis"
-          ],
           "args": [
             "config",
             "cache"
-          ]
+          ],
+          "expect": [
+            "redis"
+          ],
+          "function": "get_list"
         },
         {
-          "function": "get_list",
+          "args": [
+            "features"
+          ],
           "expect": [
             "auth",
             "api",
             "ui"
           ],
-          "args": [
-            "features"
-          ]
+          "function": "get_list"
         },
         {
-          "function": "parse_indented",
           "expect": [
             {
               "key": "config",
@@ -760,10 +902,10 @@
               "key": "features",
               "value": "ui"
             }
-          ]
+          ],
+          "function": "parse_indented"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "cache": "redis",
@@ -784,107 +926,141 @@
               "api",
               "ui"
             ]
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "cache": {
+                "redis": {}
+              },
+              "database": {
+                "hosts": {
+                  "backup": {},
+                  "primary": {}
+                },
+                "port": {
+                  "5432": {}
+                }
+              },
+              "servers": {
+                "web1": {},
+                "web2": {}
+              }
+            },
+            "features": {
+              "api": {},
+              "auth": {},
+              "ui": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled",
-        "array_order_insertion",
-        "path_traversal"
-      ],
-      "inputs": [
-        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse_indented"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_enabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
       "name": "list_path_traversal_protection",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "safe",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "safe": "value"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "safe": {
+              "value": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             ""
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
+          "args": [
+            "safe"
+          ],
           "expect": [
             "value"
           ],
-          "args": [
-            "safe"
-          ]
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_enabled"
-      ],
-      "inputs": [
-        "safe = value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
       "name": "parse_empty_value",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "empty_key": ""
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "",
+          "expect": {
+            "empty_key": {
+              "": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "empty_key"
-          ]
+          ],
+          "expect": "",
+          "function": "get_string"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "empty_key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "inputs": [
-        "empty_key ="
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     }
   ]

--- a/source_tests/core/api_reference_compliant.json
+++ b/source_tests/core/api_reference_compliant.json
@@ -2,51 +2,72 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "item = single"
+      ],
       "name": "single_item_as_list_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "item",
               "value": "single"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "item": "single"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "item": {
+              "single": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "item"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "item = single"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "ports = 80\nports = 443\nhost = localhost"
+      ],
       "name": "mixed_duplicate_single_keys_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "ports",
@@ -60,60 +81,73 @@
               "key": "host",
               "value": "localhost"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "host": "localhost",
             "ports": [
               "443",
               "80"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "host": {
+              "localhost": {}
+            },
+            "ports": {
+              "443": {},
+              "80": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "ports"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "host"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "array_order_lexicographic"
-      ],
-      "inputs": [
-        "ports = 80\nports = 443\nhost = localhost"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
+      ],
       "name": "nested_list_access_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "database",
               "value": "\n  hosts = primary\n  hosts = secondary\n  port = 5432"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "hosts": [
@@ -122,84 +156,108 @@
               ],
               "port": "5432"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "database": {
+              "hosts": {
+                "primary": {},
+                "secondary": {}
+              },
+              "port": {
+                "5432": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "database",
             "hosts"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "database",
             "port"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "path_traversal"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "database =\n  hosts = primary\n  hosts = secondary\n  port = 5432"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "empty_list ="
+      ],
       "name": "empty_list_reference",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "empty_list": ""
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "empty_list": {
+              "": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "empty_list"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "empty_list",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "empty_list ="
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
+      ],
       "name": "list_with_numbers_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "numbers",
@@ -217,10 +275,10 @@
               "key": "numbers",
               "value": "0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "numbers": [
               "-17",
@@ -228,41 +286,53 @@
               "1",
               "42"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "numbers": {
+              "-17": {},
+              "0": {},
+              "1": {},
+              "42": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "numbers"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
-      "inputs": [
-        "numbers = 1\nnumbers = 42\nnumbers = -17\nnumbers = 0"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "flags = true\nflags = false\nflags = yes\nflags = no"
+      ],
       "name": "list_with_booleans_reference",
       "tests": [
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "flags"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flags",
@@ -280,10 +350,10 @@
               "key": "flags",
               "value": "no"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "flags": [
               "false",
@@ -291,27 +361,43 @@
               "true",
               "yes"
             ]
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "flags": {
+              "false": {},
+              "no": {},
+              "true": {},
+              "yes": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
-      "inputs": [
-        "flags = true\nflags = false\nflags = yes\nflags = no"
+      "features": [
+        "empty_keys",
+        "whitespace"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "items =   spaced   \nitems = normal\nitems =\nitems =   "
+      ],
       "name": "list_with_whitespace_reference",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "items",
@@ -329,10 +415,10 @@
               "key": "items",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "items": [
               "",
@@ -340,104 +426,123 @@
               "normal",
               "spaced"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "items": {
+              "": {},
+              "normal": {},
+              "spaced": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "items"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "whitespace"
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "array_order_lexicographic"
-      ],
-      "inputs": [
-        "items =   spaced   \nitems = normal\nitems =\nitems =   "
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
-      "name": "list_with_unicode_reference",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "names",
-              "value": "\u5f20\u4e09"
-            },
-            {
-              "key": "names",
-              "value": "Jos\u00e9"
-            },
-            {
-              "key": "names",
-              "value": "Fran\u00e7ois"
-            },
-            {
-              "key": "names",
-              "value": "\u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "names": [
-              "Fran\u00e7ois",
-              "Jos\u00e9",
-              "\u0627\u0644\u0639\u0631\u0628\u064a\u0629",
-              "\u5f20\u4e09"
-            ]
-          }
-        },
-        {
-          "function": "get_list",
-          "expect": null,
-          "args": [
-            "names"
-          ]
-        }
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic"
       ],
       "features": [
         "unicode"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "names = 张三\nnames = José\nnames = François\nnames = العربية"
+      ],
+      "name": "list_with_unicode_reference",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "names",
+              "value": "张三"
+            },
+            {
+              "key": "names",
+              "value": "José"
+            },
+            {
+              "key": "names",
+              "value": "François"
+            },
+            {
+              "key": "names",
+              "value": "العربية"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "names": [
+              "François",
+              "José",
+              "العربية",
+              "张三"
+            ]
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "names": {
+              "François": {},
+              "José": {},
+              "العربية": {},
+              "张三": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "names"
+          ],
+          "expect": null,
+          "function": "get_list"
+        }
+      ]
+    },
+    {
       "behaviors": [
         "list_coercion_disabled",
         "array_order_lexicographic"
       ],
-      "inputs": [
-        "names = \u5f20\u4e09\nnames = Jos\u00e9\nnames = Fran\u00e7ois\nnames = \u0627\u0644\u0639\u0631\u0628\u064a\u0629"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_list",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "symbols = @#$%\nsymbols = !^\u0026*()\nsymbols = []{}|"
+      ],
       "name": "list_with_special_characters_reference",
       "tests": [
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "symbols"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "symbols",
@@ -445,43 +550,54 @@
             },
             {
               "key": "symbols",
-              "value": "!^&*()"
+              "value": "!^\u0026*()"
             },
             {
               "key": "symbols",
               "value": "[]{}|"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "symbols": [
-              "!^&*()",
+              "!^\u0026*()",
               "@#$%",
               "[]{}|"
             ]
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "symbols": {
+              "!^\u0026*()": {},
+              "@#$%": {},
+              "[]{}|": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "array_order_lexicographic"
-      ],
-      "inputs": [
-        "symbols = @#$%\nsymbols = !^&*()\nsymbols = []{}|"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled",
+        "array_order_lexicographic",
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list"
+      ],
+      "inputs": [
+        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
+      ],
       "name": "complex_mixed_list_scenarios_reference",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "cache": "redis",
@@ -502,181 +618,226 @@
               "auth",
               "ui"
             ]
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_list",
-          "expect": null,
+          "expect": {
+            "config": {
+              "cache": {
+                "redis": {}
+              },
+              "database": {
+                "hosts": {
+                  "backup": {},
+                  "primary": {}
+                },
+                "port": {
+                  "5432": {}
+                }
+              },
+              "servers": {
+                "web1": {},
+                "web2": {}
+              }
+            },
+            "features": {
+              "api": {},
+              "auth": {},
+              "ui": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "servers"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "config",
             "database",
             "hosts"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "config",
             "cache"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             "features"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled",
-        "array_order_lexicographic",
-        "path_traversal"
-      ],
-      "inputs": [
-        "config =\n  servers = web1\n  servers = web2\n  database =\n    hosts = primary\n    hosts = backup\n    port = 5432\n  cache = redis\nfeatures = auth\nfeatures = api\nfeatures = ui"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list"
       ]
     },
     {
+      "behaviors": [
+        "list_coercion_disabled"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_list",
+        "parse"
+      ],
+      "inputs": [
+        "safe = value"
+      ],
       "name": "list_path_traversal_protection_reference",
       "tests": [
         {
-          "function": "get_list",
-          "expect": null,
           "args": [
             ""
-          ]
-        },
-        {
-          "function": "get_list",
-          "expect": null
-        },
-        {
-          "function": "get_list",
+          ],
           "expect": null,
+          "function": "get_list"
+        },
+        {
+          "expect": null,
+          "function": "get_list"
+        },
+        {
           "args": [
             "safe"
-          ]
+          ],
+          "expect": null,
+          "function": "get_list"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "safe",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "safe": "value"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "safe": {
+              "value": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "list_coercion_disabled"
       ],
       "variants": [
         "reference_compliant"
-      ],
-      "inputs": [
-        "safe = value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_list",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "empty_key ="
+      ],
       "name": "empty_value_reference_behavior",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "empty_key": ""
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "parse",
+          "expect": {
+            "empty_key": {
+              "": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "expect": [
             {
               "key": "empty_key",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         }
       ],
       "variants": [
         "reference_compliant"
+      ]
+    },
+    {
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "empty_key ="
       ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
-      ]
-    },
-    {
       "name": "canonical_format_empty_values_ocaml_reference",
       "tests": [
         {
-          "function": "canonical_format",
-          "expect": "empty_key =\n"
+          "expect": "empty_key =\n",
+          "function": "canonical_format"
         }
-      ],
-      "inputs": [
-        "empty_key ="
-      ],
-      "functions": [
-        "canonical_format"
       ]
     },
     {
-      "name": "canonical_format_unicode_ocaml_reference",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "emo =\n  \ud83c\udf1f\u2728 =\nunicode =\n  \u4f60\u597d\u4e16\u754c =\n"
-        }
+      "behaviors": [
+        "indent_spaces"
       ],
       "features": [
         "unicode"
       ],
-      "behaviors": [
-        "indent_spaces"
-      ],
-      "inputs": [
-        "unicode = \u4f60\u597d\u4e16\u754c\nemo = \ud83c\udf1f\u2728"
-      ],
       "functions": [
         "canonical_format"
+      ],
+      "inputs": [
+        "unicode = 你好世界\nemo = 🌟✨"
+      ],
+      "name": "canonical_format_unicode_ocaml_reference",
+      "tests": [
+        {
+          "expect": "emo =\n  🌟✨ =\nunicode =\n  你好世界 =\n",
+          "function": "canonical_format"
+        }
       ]
     },
     {
+      "behaviors": [
+        "crlf_preserve_literal",
+        "indent_spaces"
+      ],
+      "functions": [
+        "canonical_format",
+        "parse"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
       "name": "canonical_format_line_endings_reference_behavior",
       "tests": [
         {
-          "function": "canonical_format",
-          "expect": "key1 =\n  value1\r =\nkey2 =\n  value2\r =\n"
+          "expect": "key1 =\n  value1\r =\nkey2 =\n  value2\r =\n",
+          "function": "canonical_format"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key1",
@@ -686,55 +847,45 @@
               "key": "key2",
               "value": "value2\r"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "behaviors": [
-        "crlf_preserve_literal",
-        "indent_spaces"
-      ],
-      "inputs": [
-        "key1 = value1\r\nkey2 = value2\r\n"
-      ],
-      "functions": [
-        "canonical_format",
-        "parse"
       ]
     },
     {
-      "name": "canonical_format_consistent_spacing_ocaml_reference",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "key1 =\n  value1 =\nkey2 =\n  value2 =\nkey3 =\n  value3 =\n"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "key1=value1\nkey2  =  value2\nkey3\t=\tvalue3"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "canonical_format_consistent_spacing_ocaml_reference",
+      "tests": [
+        {
+          "expect": "key1 =\n  value1 =\nkey2 =\n  value2 =\nkey3 =\n  value3 =\n",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "deterministic_output_ocaml_reference",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "a =\n  first =\nm =\n  middle =\nz =\n  last =\n"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "z = last\na = first\nm = middle"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "deterministic_output_ocaml_reference",
+      "tests": [
+        {
+          "expect": "a =\n  first =\nm =\n  middle =\nz =\n  last =\n",
+          "function": "canonical_format"
+        }
       ]
     }
   ]

--- a/source_tests/core/api_typed_access.json
+++ b/source_tests/core/api_typed_access.json
@@ -2,354 +2,457 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "port = 8080"
+      ],
       "name": "parse_basic_integer",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "port",
               "value": "8080"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "port": "8080"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 8080,
+          "expect": {
+            "port": {
+              "8080": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "port"
-          ]
+          ],
+          "expect": 8080,
+          "function": "get_int"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "port = 8080"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_int",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_float",
+        "parse"
+      ],
+      "inputs": [
+        "temperature = 98.6"
+      ],
       "name": "parse_basic_float",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "temperature",
               "value": "98.6"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "temperature": "98.6"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_float",
-          "expect": 98.6,
+          "expect": {
+            "temperature": {
+              "98.6": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "temperature"
-          ]
+          ],
+          "expect": 98.6,
+          "function": "get_float"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "temperature = 98.6"
-      ],
       "functions": [
         "build_hierarchy",
-        "get_float",
+        "build_model",
+        "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "enabled = true"
+      ],
       "name": "parse_boolean_true",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "enabled",
               "value": "true"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "enabled": "true"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": true,
+          "expect": {
+            "enabled": {
+              "true": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "enabled"
-          ]
+          ],
+          "expect": true,
+          "function": "get_bool"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_lenient"
       ],
       "features": [
         "optional_typed_accessors"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "parse"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "active",
+              "value": "yes"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "active": "yes"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "active": {
+              "yes": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "active"
+          ],
+          "expect": true,
+          "function": "get_bool"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "parse"
+      ],
+      "inputs": [
+        "active = yes"
+      ],
+      "name": "parse_boolean_yes_strict_literal",
+      "tests": [
+        {
+          "expect": {
+            "active": "yes"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "active": {
+              "yes": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "active"
+          ],
+          "expect": null,
+          "function": "get_bool"
+        },
+        {
+          "expect": [
+            {
+              "key": "active",
+              "value": "yes"
+            }
+          ],
+          "function": "parse"
+        }
+      ]
+    },
+    {
       "behaviors": [
         "boolean_strict",
         "boolean_lenient"
       ],
-      "inputs": [
-        "enabled = true"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "parse"
-      ]
-    },
-    {
-      "name": "parse_boolean_yes",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "active",
-              "value": "yes"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "active": "yes"
-          }
-        },
-        {
-          "function": "get_bool",
-          "expect": true,
-          "args": [
-            "active"
-          ]
-        }
-      ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_lenient"
-      ],
-      "inputs": [
-        "active = yes"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "parse"
-      ]
-    },
-    {
-      "name": "parse_boolean_yes_strict_literal",
-      "tests": [
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "active": "yes"
-          }
-        },
-        {
-          "function": "get_bool",
-          "expect": null,
-          "args": [
-            "active"
-          ]
-        },
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "active",
-              "value": "yes"
-            }
-          ]
-        }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
       ],
       "inputs": [
-        "active = yes"
+        "disabled = false"
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "parse"
-      ]
-    },
-    {
       "name": "parse_boolean_false",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "disabled",
               "value": "false"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "disabled": "false"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": false,
+          "expect": {
+            "disabled": {
+              "false": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "disabled"
-          ]
+          ],
+          "expect": false,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict",
-        "boolean_lenient"
-      ],
-      "inputs": [
-        "disabled = false"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "name = Alice"
+      ],
       "name": "parse_string_fallback",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "name",
               "value": "Alice"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "name": "Alice"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "Alice",
+          "expect": {
+            "name": {
+              "Alice": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "name"
-          ]
+          ],
+          "expect": "Alice",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "name = Alice"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "offset = -42"
+      ],
       "name": "parse_negative_integer",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "offset",
               "value": "-42"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "offset": "-42"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": -42,
+          "expect": {
+            "offset": {
+              "-42": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "offset"
-          ]
+          ],
+          "expect": -42,
+          "function": "get_int"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "offset = -42"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_int",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "boolean_lenient"
+      ],
+      "features": [
+        "empty_keys",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "get_float",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
       "name": "parse_zero_values",
       "tests": [
         {
-          "function": "build_hierarchy",
           "expect": {
             "count": "0",
             "disabled": "no",
             "distance": "0.0"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 0,
+          "expect": {
+            "count": {
+              "0": {}
+            },
+            "disabled": {
+              "no": {}
+            },
+            "distance": {
+              "0.0": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "count"
-          ]
+          ],
+          "expect": 0,
+          "function": "get_int"
         },
         {
-          "function": "get_float",
-          "expect": 0,
           "args": [
             "distance"
-          ]
+          ],
+          "expect": 0,
+          "function": "get_float"
         },
         {
-          "function": "get_bool",
-          "expect": false,
           "args": [
             "disabled"
-          ]
+          ],
+          "expect": false,
+          "function": "get_bool"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "count",
@@ -363,32 +466,33 @@
               "key": "disabled",
               "value": "no"
             }
-          ]
+          ],
+          "function": "parse"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "empty_keys",
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_lenient"
-      ],
-      "inputs": [
-        "count = 0\ndistance = 0.0\ndisabled = no"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "get_float",
         "get_int",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "count = 0\ndistance = 0.0\ndisabled = no"
+      ],
       "name": "parse_zero_values_strict_literal",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "count",
@@ -402,61 +506,74 @@
               "key": "disabled",
               "value": "no"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "count": "0",
             "disabled": "no",
             "distance": "0.0"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 0,
+          "expect": {
+            "count": {
+              "0": {}
+            },
+            "disabled": {
+              "no": {}
+            },
+            "distance": {
+              "0.0": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "count"
-          ]
+          ],
+          "expect": 0,
+          "function": "get_int"
         },
         {
-          "function": "get_float",
-          "expect": 0,
           "args": [
             "distance"
-          ]
+          ],
+          "expect": 0,
+          "function": "get_float"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "disabled"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "empty_keys",
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "count = 0\ndistance = 0.0\ndisabled = no"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "get_float",
-        "get_int",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "boolean_lenient"
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
+      ],
       "name": "parse_boolean_variants",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flag1",
@@ -486,10 +603,10 @@
               "key": "flag7",
               "value": "0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "flag1": "yes",
             "flag2": "on",
@@ -498,51 +615,78 @@
             "flag5": "no",
             "flag6": "off",
             "flag7": "0"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": true,
+          "expect": {
+            "flag1": {
+              "yes": {}
+            },
+            "flag2": {
+              "on": {}
+            },
+            "flag3": {
+              "1": {}
+            },
+            "flag4": {
+              "false": {}
+            },
+            "flag5": {
+              "no": {}
+            },
+            "flag6": {
+              "off": {}
+            },
+            "flag7": {
+              "0": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "flag1"
-          ]
+          ],
+          "expect": true,
+          "function": "get_bool"
         },
         {
-          "function": "get_int",
-          "expect": 1,
           "args": [
             "flag3"
-          ]
+          ],
+          "expect": 1,
+          "function": "get_int"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_lenient"
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "get_int",
+        "parse"
       ],
       "inputs": [
         "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
       ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "get_int",
-        "parse"
-      ]
-    },
-    {
       "name": "parse_boolean_variants_strict_literal",
       "tests": [
         {
-          "function": "get_int",
-          "expect": 1,
           "args": [
             "flag3"
-          ]
+          ],
+          "expect": 1,
+          "function": "get_int"
         },
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flag1",
@@ -572,10 +716,10 @@
               "key": "flag7",
               "value": "0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "flag1": "yes",
             "flag2": "on",
@@ -584,160 +728,66 @@
             "flag5": "no",
             "flag6": "off",
             "flag7": "0"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": null,
+          "expect": {
+            "flag1": {
+              "yes": {}
+            },
+            "flag2": {
+              "on": {}
+            },
+            "flag3": {
+              "1": {}
+            },
+            "flag4": {
+              "false": {}
+            },
+            "flag5": {
+              "no": {}
+            },
+            "flag6": {
+              "off": {}
+            },
+            "flag7": {
+              "0": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "flag1"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "flag1 = yes\nflag2 = on\nflag3 = 1\nflag4 = false\nflag5 = no\nflag6 = off\nflag7 = 0"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "get_int",
-        "parse"
       ]
     },
     {
-      "name": "parse_mixed_types",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "host",
-              "value": "localhost"
-            },
-            {
-              "key": "port",
-              "value": "8080"
-            },
-            {
-              "key": "ssl",
-              "value": "true"
-            },
-            {
-              "key": "timeout",
-              "value": "30.5"
-            },
-            {
-              "key": "debug",
-              "value": "off"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "debug": "off",
-            "host": "localhost",
-            "port": "8080",
-            "ssl": "true",
-            "timeout": "30.5"
-          }
-        },
-        {
-          "function": "get_string",
-          "expect": "localhost",
-          "args": [
-            "host"
-          ]
-        },
-        {
-          "function": "get_int",
-          "expect": 8080,
-          "args": [
-            "port"
-          ]
-        },
-        {
-          "function": "get_bool",
-          "expect": true,
-          "args": [
-            "ssl"
-          ]
-        },
-        {
-          "function": "get_float",
-          "expect": 30.5,
-          "args": [
-            "timeout"
-          ]
-        }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
       "behaviors": [
         "boolean_lenient"
       ],
-      "inputs": [
-        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      "features": [
+        "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "get_float",
         "get_int",
         "get_string",
         "parse"
-      ]
-    },
-    {
-      "name": "parse_mixed_types_strict_literal",
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types",
       "tests": [
         {
-          "function": "build_hierarchy",
-          "expect": {
-            "debug": "off",
-            "host": "localhost",
-            "port": "8080",
-            "ssl": "true",
-            "timeout": "30.5"
-          }
-        },
-        {
-          "function": "get_string",
-          "expect": "localhost",
-          "args": [
-            "host"
-          ]
-        },
-        {
-          "function": "get_int",
-          "expect": 8080,
-          "args": [
-            "port"
-          ]
-        },
-        {
-          "function": "get_bool",
-          "expect": true,
-          "args": [
-            "ssl"
-          ]
-        },
-        {
-          "function": "get_float",
-          "expect": 30.5,
-          "args": [
-            "timeout"
-          ]
-        },
-        {
-          "function": "parse",
           "expect": [
             {
               "key": "host",
@@ -759,32 +809,193 @@
               "key": "debug",
               "value": "off"
             }
-          ]
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "debug": "off",
+            "host": "localhost",
+            "port": "8080",
+            "ssl": "true",
+            "timeout": "30.5"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "debug": {
+              "off": {}
+            },
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "8080": {}
+            },
+            "ssl": {
+              "true": {}
+            },
+            "timeout": {
+              "30.5": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "host"
+          ],
+          "expect": "localhost",
+          "function": "get_string"
+        },
+        {
+          "args": [
+            "port"
+          ],
+          "expect": 8080,
+          "function": "get_int"
+        },
+        {
+          "args": [
+            "ssl"
+          ],
+          "expect": true,
+          "function": "get_bool"
+        },
+        {
+          "args": [
+            "timeout"
+          ],
+          "expect": 30.5,
+          "function": "get_float"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "get_float",
         "get_int",
         "get_string",
         "parse"
+      ],
+      "inputs": [
+        "host = localhost\nport = 8080\nssl = true\ntimeout = 30.5\ndebug = off"
+      ],
+      "name": "parse_mixed_types_strict_literal",
+      "tests": [
+        {
+          "expect": {
+            "debug": "off",
+            "host": "localhost",
+            "port": "8080",
+            "ssl": "true",
+            "timeout": "30.5"
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "debug": {
+              "off": {}
+            },
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "8080": {}
+            },
+            "ssl": {
+              "true": {}
+            },
+            "timeout": {
+              "30.5": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "host"
+          ],
+          "expect": "localhost",
+          "function": "get_string"
+        },
+        {
+          "args": [
+            "port"
+          ],
+          "expect": 8080,
+          "function": "get_int"
+        },
+        {
+          "args": [
+            "ssl"
+          ],
+          "expect": true,
+          "function": "get_bool"
+        },
+        {
+          "args": [
+            "timeout"
+          ],
+          "expect": 30.5,
+          "function": "get_float"
+        },
+        {
+          "expect": [
+            {
+              "key": "host",
+              "value": "localhost"
+            },
+            {
+              "key": "port",
+              "value": "8080"
+            },
+            {
+              "key": "ssl",
+              "value": "true"
+            },
+            {
+              "key": "timeout",
+              "value": "30.5"
+            },
+            {
+              "key": "debug",
+              "value": "off"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
+      "features": [
+        "whitespace",
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_bool",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "number =   42   \nflag =  true  "
+      ],
       "name": "parse_with_whitespace",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "number",
@@ -794,49 +1005,60 @@
               "key": "flag",
               "value": "true"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "flag": "true",
             "number": "42"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 42,
+          "expect": {
+            "flag": {
+              "true": {}
+            },
+            "number": {
+              "42": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "number"
-          ]
+          ],
+          "expect": 42,
+          "function": "get_int"
         },
         {
-          "function": "get_bool",
-          "expect": true,
           "args": [
             "flag"
-          ]
+          ],
+          "expect": true,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "whitespace",
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "number =   42   \nflag =  true  "
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "get_int",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_int",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "number = 42\ndecimal = 3.14\nflag = true\ntext = hello"
+      ],
       "name": "parse_with_conservative_options",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "number",
@@ -854,202 +1076,256 @@
               "key": "text",
               "value": "hello"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "decimal": "3.14",
             "flag": "true",
             "number": "42",
             "text": "hello"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 42,
+          "expect": {
+            "decimal": {
+              "3.14": {}
+            },
+            "flag": {
+              "true": {}
+            },
+            "number": {
+              "42": {}
+            },
+            "text": {
+              "hello": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "number"
-          ]
+          ],
+          "expect": 42,
+          "function": "get_int"
         },
         {
-          "function": "get_string",
-          "expect": "3.14",
           "args": [
             "decimal"
-          ]
+          ],
+          "expect": "3.14",
+          "function": "get_string"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "number = 42\ndecimal = 3.14\nflag = true\ntext = hello"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_int",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "port = not_a_number"
+      ],
       "name": "parse_integer_error",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "port",
               "value": "not_a_number"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "port": "not_a_number"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": null,
+          "expect": {
+            "port": {
+              "not_a_number": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "port"
-          ]
+          ],
+          "expect": null,
+          "function": "get_int"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "port = not_a_number"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_int",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_float",
+        "parse"
+      ],
+      "inputs": [
+        "temperature = invalid"
+      ],
       "name": "parse_float_error",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "temperature",
               "value": "invalid"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "temperature": "invalid"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_float",
-          "expect": null,
+          "expect": {
+            "temperature": {
+              "invalid": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "temperature"
-          ]
+          ],
+          "expect": null,
+          "function": "get_float"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "temperature = invalid"
-      ],
       "functions": [
         "build_hierarchy",
-        "get_float",
+        "build_model",
+        "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "enabled = maybe"
+      ],
       "name": "parse_boolean_error",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "enabled",
               "value": "maybe"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "enabled": "maybe"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": null,
+          "expect": {
+            "enabled": {
+              "maybe": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "enabled"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "enabled = maybe"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "parse"
       ]
     },
     {
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "existing = value"
+      ],
       "name": "parse_missing_path_error",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "existing",
               "value": "value"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "existing": "value"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": null,
+          "expect": {
+            "existing": {
+              "value": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "missing"
-          ]
+          ],
+          "expect": null,
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "existing = value"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool",
+        "parse"
+      ],
+      "inputs": [
+        "upper_true = TRUE\nupper_false = FALSE"
+      ],
       "name": "boolean_case_sensitivity_uppercase",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "upper_true",
@@ -1059,35 +1335,35 @@
               "key": "upper_false",
               "value": "FALSE"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "upper_true"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "upper_true = TRUE\nupper_false = FALSE"
-      ],
       "functions": [
         "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "mixed_true = True\nmixed_false = False"
+      ],
       "name": "boolean_case_sensitivity_mixed",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "mixed_true",
@@ -1097,35 +1373,35 @@
               "key": "mixed_false",
               "value": "False"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "mixed_true"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_lenient"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "mixed_true = True\nmixed_false = False"
-      ],
       "functions": [
         "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "upper_yes = YES\nupper_no = NO"
+      ],
       "name": "boolean_lenient_uppercase_yes_no",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "upper_yes",
@@ -1135,35 +1411,36 @@
               "key": "upper_no",
               "value": "NO"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "upper_yes"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_lenient"
-      ],
-      "inputs": [
-        "upper_yes = YES\nupper_no = NO"
-      ],
       "functions": [
         "get_bool",
+        "get_int",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "one = 1\nzero = 0"
+      ],
       "name": "boolean_numeric_one_zero_strict",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "one",
@@ -1173,720 +1450,868 @@
               "key": "zero",
               "value": "0"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
+          "args": [
+            "one"
+          ],
           "expect": null,
-          "args": [
-            "one"
-          ]
+          "function": "get_bool"
         },
         {
-          "function": "get_int",
-          "expect": 1,
           "args": [
             "one"
-          ]
+          ],
+          "expect": 1,
+          "function": "get_int"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "one = 1\nzero = 0"
-      ],
-      "functions": [
-        "get_bool",
-        "get_int",
-        "parse"
       ]
     },
     {
-      "name": "boolean_with_whitespace",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "padded",
-              "value": "true"
-            }
-          ]
-        },
-        {
-          "function": "get_bool",
-          "expect": true,
-          "args": [
-            "padded"
-          ]
-        }
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors",
         "whitespace"
       ],
-      "behaviors": [
-        "boolean_strict"
+      "functions": [
+        "get_bool",
+        "parse"
       ],
       "inputs": [
         "padded =   true   "
       ],
-      "functions": [
-        "get_bool",
-        "parse"
+      "name": "boolean_with_whitespace",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "padded",
+              "value": "true"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "args": [
+            "padded"
+          ],
+          "expect": true,
+          "function": "get_bool"
+        }
       ]
     },
     {
-      "name": "boolean_nested_object",
-      "tests": [
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "config": {
-              "debug": "true",
-              "verbose": "false",
-              "experimental": "yes"
-            }
-          }
-        }
-      ],
       "features": [
         "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model"
       ],
       "inputs": [
         "config =\n  debug = true\n  verbose = false\n  experimental = yes"
       ],
-      "functions": [
-        "build_hierarchy"
+      "name": "boolean_nested_object",
+      "tests": [
+        {
+          "expect": {
+            "config": {
+              "debug": "true",
+              "experimental": "yes",
+              "verbose": "false"
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "debug": {
+                "true": {}
+              },
+              "experimental": {
+                "yes": {}
+              },
+              "verbose": {
+                "false": {}
+              }
+            }
+          },
+          "function": "build_model"
+        }
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_int",
+        "parse"
+      ],
+      "inputs": [
+        "flag = true"
+      ],
       "name": "type_mismatch_get_int_on_bool",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flag",
               "value": "true"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_int",
-          "expect": null,
           "args": [
             "flag"
-          ]
+          ],
+          "expect": null,
+          "function": "get_int"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "flag = true"
-      ],
       "functions": [
-        "get_int",
+        "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "number = 42"
+      ],
       "name": "type_mismatch_get_bool_on_int",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "number",
               "value": "42"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "number"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict"
-      ],
-      "inputs": [
-        "number = 42"
-      ],
-      "functions": [
-        "get_bool",
-        "parse"
       ]
     },
     {
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_float",
+        "parse"
+      ],
+      "inputs": [
+        "flag = false"
+      ],
       "name": "type_mismatch_get_float_on_bool",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "flag",
               "value": "false"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_float",
-          "expect": null,
           "args": [
             "flag"
-          ]
+          ],
+          "expect": null,
+          "function": "get_float"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "inputs": [
-        "flag = false"
-      ],
-      "functions": [
-        "get_float",
-        "parse"
       ]
     },
     {
-      "name": "type_mismatch_nested_path",
-      "tests": [
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "config": {
-              "name": "test",
-              "count": "abc"
-            }
-          }
-        }
-      ],
       "features": [
         "optional_typed_accessors"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model"
       ],
       "inputs": [
         "config =\n  name = test\n  count = abc"
       ],
-      "functions": [
-        "build_hierarchy"
+      "name": "type_mismatch_nested_path",
+      "tests": [
+        {
+          "expect": {
+            "config": {
+              "count": "abc",
+              "name": "test"
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "count": {
+                "abc": {}
+              },
+              "name": {
+                "test": {}
+              }
+            }
+          },
+          "function": "build_model"
+        }
       ]
     },
     {
+      "behaviors": [
+        "boolean_strict"
+      ],
+      "features": [
+        "optional_typed_accessors"
+      ],
+      "functions": [
+        "get_bool",
+        "parse"
+      ],
+      "inputs": [
+        "empty ="
+      ],
       "name": "boolean_empty_value_error",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "empty",
               "value": ""
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_bool",
-          "expect": null,
           "args": [
             "empty"
-          ]
+          ],
+          "expect": null,
+          "function": "get_bool"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "path_traversal"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "behaviors": [
-        "boolean_strict"
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_int",
+        "parse"
       ],
       "inputs": [
-        "empty ="
+        "server =\n  port = 8080\n  max_connections = 1000"
       ],
-      "functions": [
-        "get_bool",
-        "parse"
-      ]
-    },
-    {
       "name": "nested_get_int",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "server",
               "value": "\n  port = 8080\n  max_connections = 1000"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "server": {
-              "port": "8080",
-              "max_connections": "1000"
+              "max_connections": "1000",
+              "port": "8080"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 8080,
+          "expect": {
+            "server": {
+              "max_connections": {
+                "1000": {}
+              },
+              "port": {
+                "8080": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "server",
             "port"
-          ]
+          ],
+          "expect": 8080,
+          "function": "get_int"
         },
         {
-          "function": "get_int",
-          "expect": 1000,
           "args": [
             "server",
             "max_connections"
-          ]
+          ],
+          "expect": 1000,
+          "function": "get_int"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "path_traversal"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "server =\n  port = 8080\n  max_connections = 1000"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_int",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
+      ],
       "name": "deeply_nested_get_int",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  database =\n    pool =\n      min = 5\n      max = 50"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "database": {
                 "pool": {
-                  "min": "5",
-                  "max": "50"
+                  "max": "50",
+                  "min": "5"
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_int",
-          "expect": 5,
+          "expect": {
+            "config": {
+              "database": {
+                "pool": {
+                  "max": {
+                    "50": {}
+                  },
+                  "min": {
+                    "5": {}
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "config",
             "database",
             "pool",
             "min"
-          ]
+          ],
+          "expect": 5,
+          "function": "get_int"
         },
         {
-          "function": "get_int",
-          "expect": 50,
           "args": [
             "config",
             "database",
             "pool",
             "max"
-          ]
+          ],
+          "expect": 50,
+          "function": "get_int"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "path_traversal"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "config =\n  database =\n    pool =\n      min = 5\n      max = 50"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
       "functions": [
         "build_hierarchy",
-        "get_int",
+        "build_model",
+        "get_float",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
+      ],
       "name": "nested_get_float",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "metrics",
               "value": "\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "metrics": {
               "cpu_threshold": "0.85",
               "memory_limit": "2.5"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_float",
-          "expect": 0.85,
+          "expect": {
+            "metrics": {
+              "cpu_threshold": {
+                "0.85": {}
+              },
+              "memory_limit": {
+                "2.5": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "metrics",
             "cpu_threshold"
-          ]
+          ],
+          "expect": 0.85,
+          "function": "get_float"
         },
         {
-          "function": "get_float",
-          "expect": 2.5,
           "args": [
             "metrics",
             "memory_limit"
-          ]
+          ],
+          "expect": 2.5,
+          "function": "get_float"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "path_traversal"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "metrics =\n  cpu_threshold = 0.85\n  memory_limit = 2.5"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_float",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
+      ],
       "name": "deeply_nested_get_float",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "app",
               "value": "\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "app": {
               "scoring": {
                 "weights": {
-                  "relevance": "0.6",
-                  "freshness": "0.4"
+                  "freshness": "0.4",
+                  "relevance": "0.6"
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_float",
-          "expect": 0.6,
+          "expect": {
+            "app": {
+              "scoring": {
+                "weights": {
+                  "freshness": {
+                    "0.4": {}
+                  },
+                  "relevance": {
+                    "0.6": {}
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "app",
             "scoring",
             "weights",
             "relevance"
-          ]
+          ],
+          "expect": 0.6,
+          "function": "get_float"
         },
         {
-          "function": "get_float",
-          "expect": 0.4,
           "args": [
             "app",
             "scoring",
             "weights",
             "freshness"
-          ]
+          ],
+          "expect": 0.4,
+          "function": "get_float"
         }
+      ]
+    },
+    {
+      "behaviors": [
+        "boolean_strict",
+        "boolean_lenient",
+        "path_traversal"
       ],
       "features": [
         "optional_typed_accessors"
       ],
-      "inputs": [
-        "app =\n  scoring =\n    weights =\n      relevance = 0.6\n      freshness = 0.4"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
       "functions": [
         "build_hierarchy",
-        "get_float",
+        "build_model",
+        "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      ],
       "name": "nested_get_bool",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "feature_flags",
               "value": "\n  dark_mode = true\n  beta_access = false"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "feature_flags": {
-              "dark_mode": "true",
-              "beta_access": "false"
+              "beta_access": "false",
+              "dark_mode": "true"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": true,
+          "expect": {
+            "feature_flags": {
+              "beta_access": {
+                "false": {}
+              },
+              "dark_mode": {
+                "true": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "feature_flags",
             "dark_mode"
-          ]
+          ],
+          "expect": true,
+          "function": "get_bool"
         },
         {
-          "function": "get_bool",
-          "expect": false,
           "args": [
             "feature_flags",
             "beta_access"
-          ]
+          ],
+          "expect": false,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "boolean_strict",
         "boolean_lenient",
         "path_traversal"
       ],
-      "inputs": [
-        "feature_flags =\n  dark_mode = true\n  beta_access = false"
+      "features": [
+        "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
+      ],
       "name": "deeply_nested_get_bool",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "services",
               "value": "\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "services": {
               "auth": {
                 "settings": {
-                  "require_mfa": "true",
-                  "allow_anonymous": "false"
+                  "allow_anonymous": "false",
+                  "require_mfa": "true"
                 }
               }
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_bool",
-          "expect": true,
+          "expect": {
+            "services": {
+              "auth": {
+                "settings": {
+                  "allow_anonymous": {
+                    "false": {}
+                  },
+                  "require_mfa": {
+                    "true": {}
+                  }
+                }
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "services",
             "auth",
             "settings",
             "require_mfa"
-          ]
+          ],
+          "expect": true,
+          "function": "get_bool"
         },
         {
-          "function": "get_bool",
-          "expect": false,
           "args": [
             "services",
             "auth",
             "settings",
             "allow_anonymous"
-          ]
+          ],
+          "expect": false,
+          "function": "get_bool"
         }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
-      "behaviors": [
-        "boolean_strict",
-        "boolean_lenient",
-        "path_traversal"
-      ],
-      "inputs": [
-        "services =\n  auth =\n    settings =\n      require_mfa = true\n      allow_anonymous = false"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_bool",
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "path_traversal"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "database =\n  host = localhost\n  name = mydb"
+      ],
       "name": "nested_get_string_basic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "database",
               "value": "\n  host = localhost\n  name = mydb"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "database": {
               "host": "localhost",
               "name": "mydb"
             }
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
-          "expect": "localhost",
+          "expect": {
+            "database": {
+              "host": {
+                "localhost": {}
+              },
+              "name": {
+                "mydb": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "database",
             "host"
-          ]
+          ],
+          "expect": "localhost",
+          "function": "get_string"
         },
         {
-          "function": "get_string",
-          "expect": "mydb",
           "args": [
             "database",
             "name"
-          ]
+          ],
+          "expect": "mydb",
+          "function": "get_string"
         }
-      ],
-      "inputs": [
-        "database =\n  host = localhost\n  name = mydb"
-      ],
-      "behaviors": [
-        "path_traversal"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
-      "name": "nested_mixed_typed_access",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "server",
-              "value": "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
-            }
-          ]
-        },
-        {
-          "function": "build_hierarchy",
-          "expect": {
-            "server": {
-              "host": "0.0.0.0",
-              "port": "3000",
-              "debug": "true",
-              "rate_limit": "1.5"
-            }
-          }
-        },
-        {
-          "function": "get_string",
-          "expect": "0.0.0.0",
-          "args": [
-            "server",
-            "host"
-          ]
-        },
-        {
-          "function": "get_int",
-          "expect": 3000,
-          "args": [
-            "server",
-            "port"
-          ]
-        },
-        {
-          "function": "get_bool",
-          "expect": true,
-          "args": [
-            "server",
-            "debug"
-          ]
-        },
-        {
-          "function": "get_float",
-          "expect": 1.5,
-          "args": [
-            "server",
-            "rate_limit"
-          ]
-        }
-      ],
-      "features": [
-        "optional_typed_accessors"
-      ],
       "behaviors": [
         "boolean_strict",
         "boolean_lenient",
         "path_traversal"
       ],
-      "inputs": [
-        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      "features": [
+        "optional_typed_accessors"
       ],
       "functions": [
         "build_hierarchy",
+        "build_model",
         "get_bool",
         "get_float",
         "get_int",
         "get_string",
         "parse"
+      ],
+      "inputs": [
+        "server =\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+      ],
+      "name": "nested_mixed_typed_access",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "server",
+              "value": "\n  host = 0.0.0.0\n  port = 3000\n  debug = true\n  rate_limit = 1.5"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": {
+            "server": {
+              "debug": "true",
+              "host": "0.0.0.0",
+              "port": "3000",
+              "rate_limit": "1.5"
+            }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "server": {
+              "debug": {
+                "true": {}
+              },
+              "host": {
+                "0.0.0.0": {}
+              },
+              "port": {
+                "3000": {}
+              },
+              "rate_limit": {
+                "1.5": {}
+              }
+            }
+          },
+          "function": "build_model"
+        },
+        {
+          "args": [
+            "server",
+            "host"
+          ],
+          "expect": "0.0.0.0",
+          "function": "get_string"
+        },
+        {
+          "args": [
+            "server",
+            "port"
+          ],
+          "expect": 3000,
+          "function": "get_int"
+        },
+        {
+          "args": [
+            "server",
+            "debug"
+          ],
+          "expect": true,
+          "function": "get_bool"
+        },
+        {
+          "args": [
+            "server",
+            "rate_limit"
+          ],
+          "expect": 1.5,
+          "function": "get_float"
+        }
       ]
     }
   ]

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -2,111 +2,136 @@
   "$schema": "../../schemas/source-format.json",
   "tests": [
     {
+      "features": [
+        "whitespace",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "key = \tvalue\twith\ttabs"
+      ],
       "name": "tabs_as_whitespace_in_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "value\twith\ttabs"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "key": "value\twith\ttabs"
-          }
+          },
+          "function": "build_hierarchy"
         },
         {
-          "function": "get_string",
+          "expect": {
+            "key": {
+              "value\twith\ttabs": {}
+            }
+          },
+          "function": "build_model"
+        },
+        {
           "args": [
             "key"
           ],
-          "expect": "value\twith\ttabs"
+          "expect": "value\twith\ttabs",
+          "function": "get_string"
         }
-      ],
-      "features": [
-        "whitespace",
-        "tab_in_value_preserved"
-      ],
-      "inputs": [
-        "key = \tvalue\twith\ttabs"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "get_string",
-        "parse"
       ]
     },
     {
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "get_string",
+        "parse"
+      ],
+      "inputs": [
+        "key = \tindented"
+      ],
       "name": "tabs_as_whitespace_leading_tab",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "indented"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "get_string",
           "args": [
             "key"
           ],
-          "expect": "indented"
+          "expect": "indented",
+          "function": "get_string"
         }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = \tindented"
-      ],
-      "functions": [
-        "get_string",
-        "parse"
       ]
     },
     {
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "key = \t\t\tthree_tabs"
+      ],
       "name": "tabs_as_whitespace_multiple_tabs",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key",
               "value": "three_tabs"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key = \t\t\tthree_tabs"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
+      "behaviors": [
+        "multiline_values",
+        "continuation_tab_to_space"
+      ],
+      "features": [
+        "whitespace",
+        "multiline_continuation"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+      ],
       "name": "tabs_as_whitespace_multiline",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "section",
               "value": "\n  indented_with_tabs\n  another_line"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "multiline_values",
         "continuation_tab_to_space"
@@ -115,67 +140,44 @@
         "whitespace",
         "multiline_continuation"
       ],
-      "inputs": [
-        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
-      ],
       "functions": [
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "section =\n \tmixed_indent\n\t another_line"
+      ],
       "name": "tabs_as_whitespace_mixed_indent",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "section",
               "value": "\n  mixed_indent\n  another_line"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
-      "behaviors": [
-        "multiline_values",
-        "continuation_tab_to_space"
-      ],
-      "features": [
-        "whitespace",
-        "multiline_continuation"
-      ],
-      "inputs": [
-        "section =\n \tmixed_indent\n\t another_line"
-      ],
-      "functions": [
-        "parse"
       ]
     },
     {
-      "name": "tabs_canonical_format_as_whitespace",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "key = value"
-        }
-      ],
       "features": [
         "whitespace"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "key = \tvalue"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "tabs_canonical_format_as_whitespace",
+      "tests": [
+        {
+          "expect": "key = value",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "tabs_as_whitespace_multiline_print",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "section =\n  indented\n  another"
-        }
-      ],
       "behaviors": [
         "indent_spaces",
         "multiline_values",
@@ -185,62 +187,62 @@
         "whitespace",
         "multiline_continuation"
       ],
+      "functions": [
+        "canonical_format"
+      ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "tabs_as_whitespace_multiline_print",
+      "tests": [
+        {
+          "expect": "section =\n  indented\n  another",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "tabs_as_whitespace_round_trip",
-      "tests": [
-        {
-          "function": "round_trip",
-          "expect": "key = value\twith\ttabs"
-        }
-      ],
       "features": [
         "whitespace",
         "tab_in_value_preserved"
       ],
+      "functions": [
+        "round_trip"
+      ],
       "inputs": [
         "key = \tvalue\twith\ttabs"
       ],
-      "functions": [
-        "round_trip"
+      "name": "tabs_as_whitespace_round_trip",
+      "tests": [
+        {
+          "expect": "key = value\twith\ttabs",
+          "function": "round_trip"
+        }
       ]
     },
     {
-      "name": "nested_bare_list_indentation",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "package =\n  = brew\n  = scoop\n  = nix"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
       ],
       "features": [
         "empty_keys",
         "whitespace"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "package =\n  = brew\n  = scoop\n  = nix"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "nested_bare_list_indentation",
+      "tests": [
+        {
+          "expect": "package =\n  = brew\n  = scoop\n  = nix",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "deeply_nested_bare_list_indentation",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "app =\n  = item1\n  = item2\n  config =\n    = nested1\n    = nested2\n    deep =\n      = level3a\n      = level3b"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
       ],
@@ -248,147 +250,147 @@
         "empty_keys",
         "whitespace"
       ],
+      "functions": [
+        "canonical_format"
+      ],
       "inputs": [
         "app =\n  = item1\n  config =\n    = nested1\n    = nested2\n    deep =\n      = level3a\n      = level3b\n  = item2"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "deeply_nested_bare_list_indentation",
+      "tests": [
+        {
+          "expect": "app =\n  = item1\n  = item2\n  config =\n    = nested1\n    = nested2\n    deep =\n      = level3a\n      = level3b",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "print_nested_indent_spaces",
-      "tests": [
-        {
-          "function": "print",
-          "expect": "database =\n  host = localhost\n  port = 5432"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
+      ],
+      "functions": [
+        "print"
       ],
       "inputs": [
         "database =\n  host = localhost\n  port = 5432"
       ],
-      "functions": [
-        "print"
+      "name": "print_nested_indent_spaces",
+      "tests": [
+        {
+          "expect": "database =\n  host = localhost\n  port = 5432",
+          "function": "print"
+        }
       ]
     },
     {
-      "name": "print_deeply_nested_indent_spaces",
-      "tests": [
-        {
-          "function": "print",
-          "expect": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
-        }
-      ],
       "behaviors": [
         "indent_spaces"
+      ],
+      "functions": [
+        "print"
       ],
       "inputs": [
         "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true"
       ],
-      "functions": [
-        "print"
+      "name": "print_deeply_nested_indent_spaces",
+      "tests": [
+        {
+          "expect": "server =\n  database =\n    host = localhost\n    port = 5432\n  cache =\n    enabled = true",
+          "function": "print"
+        }
       ]
     },
     {
-      "name": "print_nested_indent_tabs",
-      "tests": [
-        {
-          "function": "print",
-          "expect": "database =\n\thost = localhost\n\tport = 5432"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
+      ],
+      "functions": [
+        "print"
       ],
       "inputs": [
         "database =\n\thost = localhost\n\tport = 5432"
       ],
-      "functions": [
-        "print"
+      "name": "print_nested_indent_tabs",
+      "tests": [
+        {
+          "expect": "database =\n\thost = localhost\n\tport = 5432",
+          "function": "print"
+        }
       ]
     },
     {
-      "name": "print_deeply_nested_indent_tabs",
-      "tests": [
-        {
-          "function": "print",
-          "expect": "server =\n\tdatabase =\n\t\thost = localhost\n\t\tport = 5432\n\tcache =\n\t\tenabled = true"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
+      ],
+      "functions": [
+        "print"
       ],
       "inputs": [
         "server =\n\tdatabase =\n\t\thost = localhost\n\t\tport = 5432\n\tcache =\n\t\tenabled = true"
       ],
-      "functions": [
-        "print"
+      "name": "print_deeply_nested_indent_tabs",
+      "tests": [
+        {
+          "expect": "server =\n\tdatabase =\n\t\thost = localhost\n\t\tport = 5432\n\tcache =\n\t\tenabled = true",
+          "function": "print"
+        }
       ]
     },
     {
-      "name": "print_mixed_flat_and_nested_indent_tabs",
-      "tests": [
-        {
-          "function": "print",
-          "expect": "name = Alice\nconfig =\n\tdebug = true\n\ttimeout = 30\nversion = 1.0"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
+      ],
+      "functions": [
+        "print"
       ],
       "inputs": [
         "name = Alice\nconfig =\n\tdebug = true\n\ttimeout = 30\nversion = 1.0"
       ],
-      "functions": [
-        "print"
+      "name": "print_mixed_flat_and_nested_indent_tabs",
+      "tests": [
+        {
+          "expect": "name = Alice\nconfig =\n\tdebug = true\n\ttimeout = 30\nversion = 1.0",
+          "function": "print"
+        }
       ]
     },
     {
-      "name": "canonical_format_deterministic_indent_tabs",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "a =\n\tfirst =\nm =\n\tmiddle =\nz =\n\tlast =\n"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "z = last\na = first\nm = middle"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "canonical_format_deterministic_indent_tabs",
+      "tests": [
+        {
+          "expect": "a =\n\tfirst =\nm =\n\tmiddle =\nz =\n\tlast =\n",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "canonical_format_consistent_spacing_indent_tabs",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "key1 =\n\tvalue1 =\nkey2 =\n\tvalue2 =\nkey3 =\n\tvalue3 =\n"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "key1=value1\nkey2  =  value2\nkey3\t=\tvalue3"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "canonical_format_consistent_spacing_indent_tabs",
+      "tests": [
+        {
+          "expect": "key1 =\n\tvalue1 =\nkey2 =\n\tvalue2 =\nkey3 =\n\tvalue3 =\n",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "tabs_as_whitespace_multiline_canonical_indent_tabs",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "section =\n\tindented\n\tanother"
-        }
-      ],
       "behaviors": [
         "indent_tabs",
         "multiline_values",
@@ -398,43 +400,43 @@
         "whitespace",
         "multiline_continuation"
       ],
+      "functions": [
+        "canonical_format"
+      ],
       "inputs": [
         "section =\n\t\tindented\n\t\tanother"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "tabs_as_whitespace_multiline_canonical_indent_tabs",
+      "tests": [
+        {
+          "expect": "section =\n\tindented\n\tanother",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "nested_bare_list_indentation_tabs",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "package =\n\t= brew\n\t= scoop\n\t= nix"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
       ],
       "features": [
         "empty_keys",
         "whitespace"
+      ],
+      "functions": [
+        "canonical_format"
       ],
       "inputs": [
         "package =\n\t= brew\n\t= scoop\n\t= nix"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "nested_bare_list_indentation_tabs",
+      "tests": [
+        {
+          "expect": "package =\n\t= brew\n\t= scoop\n\t= nix",
+          "function": "canonical_format"
+        }
       ]
     },
     {
-      "name": "deeply_nested_bare_list_indentation_tabs",
-      "tests": [
-        {
-          "function": "canonical_format",
-          "expect": "app =\n\t= item1\n\t= item2\n\tconfig =\n\t\t= nested1\n\t\t= nested2\n\t\tdeep =\n\t\t\t= level3a\n\t\t\t= level3b"
-        }
-      ],
       "behaviors": [
         "indent_tabs"
       ],
@@ -442,18 +444,38 @@
         "empty_keys",
         "whitespace"
       ],
+      "functions": [
+        "canonical_format"
+      ],
       "inputs": [
         "app =\n\t= item1\n\tconfig =\n\t\t= nested1\n\t\t= nested2\n\t\tdeep =\n\t\t\t= level3a\n\t\t\t= level3b\n\t= item2"
       ],
-      "functions": [
-        "canonical_format"
+      "name": "deeply_nested_bare_list_indentation_tabs",
+      "tests": [
+        {
+          "expect": "app =\n\t= item1\n\t= item2\n\tconfig =\n\t\t= nested1\n\t\t= nested2\n\t\tdeep =\n\t\t\t= level3a\n\t\t\t= level3b",
+          "function": "canonical_format"
+        }
       ]
     },
     {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
+      "inputs": [
+        "key1 = value1\r\nkey2 = value2\r\n"
+      ],
       "name": "crlf_normalize_to_lf_basic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key1",
@@ -463,35 +485,47 @@
               "key": "key2",
               "value": "value2"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "key1": "value1",
             "key2": "value2"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "key1": {
+              "value1": {}
+            },
+            "key2": {
+              "value2": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_preserve_literal"
       ],
       "features": [
         "whitespace"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
       "inputs": [
         "key1 = value1\r\nkey2 = value2\r\n"
       ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
-      ]
-    },
-    {
       "name": "crlf_preserve_literal_basic",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "key1",
@@ -501,43 +535,30 @@
               "key": "key2",
               "value": "value2\r"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "key1": "value1\r",
             "key2": "value2\r"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "key1": {
+              "value1\r": {}
+            },
+            "key2": {
+              "value2\r": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "crlf_preserve_literal"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "key1 = value1\r\nkey2 = value2\r\n"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
-      "name": "crlf_normalize_multiline_value",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "multiline",
-              "value": "\n  line1\n  line2"
-            }
-          ]
-        }
-      ],
       "behaviors": [
         "crlf_normalize_to_lf",
         "multiline_values"
@@ -546,26 +567,26 @@
         "whitespace",
         "multiline_continuation"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "multiline =\r\n  line1\r\n  line2"
       ],
-      "functions": [
-        "parse"
-      ]
-    },
-    {
-      "name": "crlf_preserve_multiline_value",
+      "name": "crlf_normalize_multiline_value",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "multiline",
-              "value": "\r\n  line1\r\n  line2"
+              "value": "\n  line1\n  line2"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "crlf_preserve_literal",
         "multiline_values"
@@ -574,18 +595,41 @@
         "whitespace",
         "multiline_continuation"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "multiline =\r\n  line1\r\n  line2"
       ],
-      "functions": [
-        "parse"
+      "name": "crlf_preserve_multiline_value",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "multiline",
+              "value": "\r\n  line1\r\n  line2"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     },
     {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
+      ],
       "name": "crlf_mixed_line_endings",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "lf_line",
@@ -599,116 +643,112 @@
               "key": "lf_again",
               "value": "value3"
             }
-          ]
+          ],
+          "function": "parse"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
       "features": [
         "whitespace"
       ],
-      "inputs": [
-        "lf_line = value1\ncrlf_line = value2\r\nlf_again = value3\n"
-      ],
       "functions": [
+        "build_hierarchy",
+        "build_model",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "config =\r\n  host = localhost\r\n  port = 8080"
+      ],
       "name": "crlf_nested_structure",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\n  host = localhost\n  port = 8080"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "host": "localhost",
               "port": "8080"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "host": {
+                "localhost": {}
+              },
+              "port": {
+                "8080": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_preserve_literal"
       ],
       "features": [
         "whitespace"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "parse"
+      ],
       "inputs": [
         "config =\r\n  host = localhost\r\n  port = 8080"
       ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
-      ]
-    },
-    {
       "name": "crlf_preserve_nested_structure",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "config",
               "value": "\r\n  host = localhost\r\n  port = 8080"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "config": {
               "host": "localhost\r",
               "port": "8080"
             }
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "config": {
+              "host": {
+                "localhost\r": {}
+              },
+              "port": {
+                "8080": {}
+              }
+            }
+          },
+          "function": "build_model"
         }
-      ],
-      "behaviors": [
-        "crlf_preserve_literal"
-      ],
-      "features": [
-        "whitespace"
-      ],
-      "inputs": [
-        "config =\r\n  host = localhost\r\n  port = 8080"
-      ],
-      "functions": [
-        "build_hierarchy",
-        "parse"
       ]
     },
     {
-      "name": "crlf_normalize_comment_only",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "/",
-              "value": "this is a comment"
-            }
-          ]
-        },
-        {
-          "function": "filter",
-          "predicate": {
-            "field": "key",
-            "op": "!=",
-            "value": "/"
-          },
-          "expect": []
-        }
-      ],
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
@@ -716,36 +756,36 @@
         "comments",
         "whitespace"
       ],
-      "inputs": [
-        "/= this is a comment\r\n"
-      ],
       "functions": [
         "filter",
         "parse"
-      ]
-    },
-    {
-      "name": "crlf_preserve_comment_only",
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_normalize_comment_only",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
-              "value": "this is a comment\r"
+              "value": "this is a comment"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
+          "expect": [],
           "function": "filter",
           "predicate": {
             "field": "key",
             "op": "!=",
             "value": "/"
-          },
-          "expect": []
+          }
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
         "crlf_preserve_literal"
       ],
@@ -753,19 +793,55 @@
         "comments",
         "whitespace"
       ],
-      "inputs": [
-        "/= this is a comment\r\n"
-      ],
       "functions": [
         "filter",
         "parse"
+      ],
+      "inputs": [
+        "/= this is a comment\r\n"
+      ],
+      "name": "crlf_preserve_comment_only",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "/",
+              "value": "this is a comment\r"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": [],
+          "function": "filter",
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          }
+        }
       ]
     },
     {
+      "behaviors": [
+        "crlf_normalize_to_lf"
+      ],
+      "features": [
+        "comments",
+        "whitespace"
+      ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "filter",
+        "parse"
+      ],
+      "inputs": [
+        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
+      ],
       "name": "crlf_normalize_comments_and_values",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
@@ -783,15 +859,10 @@
               "key": "port",
               "value": "8080"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "filter",
-          "predicate": {
-            "field": "key",
-            "op": "!=",
-            "value": "/"
-          },
           "expect": [
             {
               "key": "host",
@@ -801,10 +872,15 @@
               "key": "port",
               "value": "8080"
             }
-          ]
+          ],
+          "function": "filter",
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          }
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/": [
               "Server config",
@@ -812,30 +888,46 @@
             ],
             "host": "localhost",
             "port": "8080"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "/": {
+              "Port setting": {},
+              "Server config": {}
+            },
+            "host": {
+              "localhost": {}
+            },
+            "port": {
+              "8080": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_preserve_literal"
       ],
       "features": [
         "comments",
         "whitespace"
       ],
+      "functions": [
+        "build_hierarchy",
+        "build_model",
+        "filter",
+        "parse"
+      ],
       "inputs": [
         "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
       ],
-      "functions": [
-        "build_hierarchy",
-        "filter",
-        "parse"
-      ]
-    },
-    {
       "name": "crlf_preserve_comments_and_values",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
@@ -853,15 +945,10 @@
               "key": "port",
               "value": "8080\r"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
-          "function": "filter",
-          "predicate": {
-            "field": "key",
-            "op": "!=",
-            "value": "/"
-          },
           "expect": [
             {
               "key": "host",
@@ -871,10 +958,15 @@
               "key": "port",
               "value": "8080\r"
             }
-          ]
+          ],
+          "function": "filter",
+          "predicate": {
+            "field": "key",
+            "op": "!=",
+            "value": "/"
+          }
         },
         {
-          "function": "build_hierarchy",
           "expect": {
             "/": [
               "Server config\r",
@@ -882,30 +974,44 @@
             ],
             "host": "localhost\r",
             "port": "8080\r"
-          }
+          },
+          "function": "build_hierarchy"
+        },
+        {
+          "expect": {
+            "/": {
+              "Port setting\r": {},
+              "Server config\r": {}
+            },
+            "host": {
+              "localhost\r": {}
+            },
+            "port": {
+              "8080\r": {}
+            }
+          },
+          "function": "build_model"
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "crlf_preserve_literal"
+        "crlf_normalize_to_lf"
       ],
       "features": [
         "comments",
         "whitespace"
       ],
-      "inputs": [
-        "/= Server config\r\nhost = localhost\r\n/= Port setting\r\nport = 8080\r\n"
-      ],
       "functions": [
-        "build_hierarchy",
         "filter",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
       "name": "crlf_normalize_multiple_comments",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
@@ -919,38 +1025,38 @@
               "key": "/",
               "value": "third comment"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
+          "expect": [],
           "function": "filter",
           "predicate": {
             "field": "key",
             "op": "!=",
             "value": "/"
-          },
-          "expect": []
+          }
         }
-      ],
+      ]
+    },
+    {
       "behaviors": [
-        "crlf_normalize_to_lf"
+        "crlf_preserve_literal"
       ],
       "features": [
         "comments",
         "whitespace"
       ],
-      "inputs": [
-        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
-      ],
       "functions": [
         "filter",
         "parse"
-      ]
-    },
-    {
+      ],
+      "inputs": [
+        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
+      ],
       "name": "crlf_preserve_multiple_comments",
       "tests": [
         {
-          "function": "parse",
           "expect": [
             {
               "key": "/",
@@ -964,46 +1070,21 @@
               "key": "/",
               "value": "third comment\r"
             }
-          ]
+          ],
+          "function": "parse"
         },
         {
+          "expect": [],
           "function": "filter",
           "predicate": {
             "field": "key",
             "op": "!=",
             "value": "/"
-          },
-          "expect": []
+          }
         }
-      ],
-      "behaviors": [
-        "crlf_preserve_literal"
-      ],
-      "features": [
-        "comments",
-        "whitespace"
-      ],
-      "inputs": [
-        "/= first comment\r\n/= second comment\r\n/= third comment\r\n"
-      ],
-      "functions": [
-        "filter",
-        "parse"
       ]
     },
     {
-      "name": "behavior_combo_tabs_and_crlf",
-      "tests": [
-        {
-          "function": "parse",
-          "expect": [
-            {
-              "key": "key",
-              "value": "value\twith\ttabs"
-            }
-          ]
-        }
-      ],
       "behaviors": [
         "crlf_normalize_to_lf"
       ],
@@ -1011,11 +1092,23 @@
         "whitespace",
         "tab_in_value_preserved"
       ],
+      "functions": [
+        "parse"
+      ],
       "inputs": [
         "key = \tvalue\twith\ttabs\r\n"
       ],
-      "functions": [
-        "parse"
+      "name": "behavior_combo_tabs_and_crlf",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "key",
+              "value": "value\twith\ttabs"
+            }
+          ],
+          "function": "parse"
+        }
       ]
     }
   ]

--- a/types/generated/flat_format.go
+++ b/types/generated/flat_format.go
@@ -5,9 +5,11 @@ package generated
 import "encoding/json"
 import "fmt"
 import "reflect"
+import "regexp"
 
+// Schema for existing generated flat test files
 type GeneratedFormatSimpleJson struct {
-	// Schema corresponds to the JSON schema field "$schema".
+	// JSON Schema reference
 	Schema string `json:"$schema" yaml:"$schema" mapstructure:"$schema"`
 
 	// Tests corresponds to the JSON schema field "tests".
@@ -15,49 +17,51 @@ type GeneratedFormatSimpleJson struct {
 }
 
 type GeneratedFormatSimpleJsonTestsElem struct {
-	// Args corresponds to the JSON schema field "args".
-	Args []string `json:"args,omitempty" yaml:"args,omitempty" mapstructure:"args,omitempty"`
+	// Arguments for typed access functions (get_string, get_int, get_bool, get_float,
+	// get_list). Required for these functions, omitted for others.
+	Args []string `json:"args,omitempty,omitzero" yaml:"args,omitempty" mapstructure:"args,omitempty"`
 
-	// Behaviors corresponds to the JSON schema field "behaviors".
+	// Implementation behavior choices
 	Behaviors []GeneratedFormatSimpleJsonTestsElemBehaviorsElem `json:"behaviors" yaml:"behaviors" mapstructure:"behaviors"`
 
-	// Conflicts corresponds to the JSON schema field "conflicts".
-	Conflicts *GeneratedFormatSimpleJsonTestsElemConflicts `json:"conflicts,omitempty" yaml:"conflicts,omitempty" mapstructure:"conflicts,omitempty"`
+	// Mutually exclusive options by category
+	Conflicts *GeneratedFormatSimpleJsonTestsElemConflicts `json:"conflicts,omitempty,omitzero" yaml:"conflicts,omitempty" mapstructure:"conflicts,omitempty"`
 
-	// ErrorType corresponds to the JSON schema field "error_type".
-	ErrorType *string `json:"error_type,omitempty" yaml:"error_type,omitempty" mapstructure:"error_type,omitempty"`
+	// Expected error type for error tests
+	ErrorType *string `json:"error_type,omitempty,omitzero" yaml:"error_type,omitempty" mapstructure:"error_type,omitempty"`
 
-	// ExpectError corresponds to the JSON schema field "expect_error".
-	ExpectError *bool `json:"expect_error,omitempty" yaml:"expect_error,omitempty" mapstructure:"expect_error,omitempty"`
+	// Whether this test should produce an error
+	ExpectError bool `json:"expect_error,omitempty,omitzero" yaml:"expect_error,omitempty" mapstructure:"expect_error,omitempty"`
 
-	// Expected corresponds to the JSON schema field "expected".
+	// Expected result in standardized format
 	Expected GeneratedFormatSimpleJsonTestsElemExpected `json:"expected" yaml:"expected" mapstructure:"expected"`
 
-	// Features corresponds to the JSON schema field "features".
+	// Language features exercised by this test (informational, for gap reporting)
 	Features []string `json:"features" yaml:"features" mapstructure:"features"`
 
-	// Functions corresponds to the JSON schema field "functions".
-	Functions []GeneratedFormatSimpleJsonTestsElemFunctionsElem `json:"functions,omitempty" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
+	// CCL functions tested by this test
+	Functions []GeneratedFormatSimpleJsonTestsElemFunctionsElem `json:"functions,omitempty,omitzero" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
 
-	// Inputs corresponds to the JSON schema field "inputs".
+	// CCL input text(s) to be tested. Single-input tests use a 1-element array.
 	Inputs []string `json:"inputs" yaml:"inputs" mapstructure:"inputs"`
 
-	// Name corresponds to the JSON schema field "name".
+	// Unique test name (source_name + validation function)
 	Name string `json:"name" yaml:"name" mapstructure:"name"`
 
-	// Predicate corresponds to the JSON schema field "predicate".
-	Predicate *GeneratedFormatSimpleJsonTestsElemPredicate `json:"predicate,omitempty" yaml:"predicate,omitempty" mapstructure:"predicate,omitempty"`
+	// Filter predicate specification. Defines how to filter entries based on a field
+	// comparison.
+	Predicate *GeneratedFormatSimpleJsonTestsElemPredicate `json:"predicate,omitempty,omitzero" yaml:"predicate,omitempty" mapstructure:"predicate,omitempty"`
 
-	// Requires corresponds to the JSON schema field "requires".
-	Requires []string `json:"requires,omitempty" yaml:"requires,omitempty" mapstructure:"requires,omitempty"`
+	// Functions that must be implemented as prerequisites
+	Requires []string `json:"requires,omitempty,omitzero" yaml:"requires,omitempty" mapstructure:"requires,omitempty"`
 
-	// SourceTest corresponds to the JSON schema field "source_test".
-	SourceTest *string `json:"source_test,omitempty" yaml:"source_test,omitempty" mapstructure:"source_test,omitempty"`
+	// Original source test name for traceability
+	SourceTest *string `json:"source_test,omitempty,omitzero" yaml:"source_test,omitempty" mapstructure:"source_test,omitempty"`
 
-	// Validation corresponds to the JSON schema field "validation".
+	// Single CCL function to validate
 	Validation GeneratedFormatSimpleJsonTestsElemValidation `json:"validation" yaml:"validation" mapstructure:"validation"`
 
-	// Variants corresponds to the JSON schema field "variants".
+	// Specification variants
 	Variants []GeneratedFormatSimpleJsonTestsElemVariantsElem `json:"variants" yaml:"variants" mapstructure:"variants"`
 }
 
@@ -67,34 +71,42 @@ const GeneratedFormatSimpleJsonTestsElemBehaviorsElemArrayOrderInsertion Generat
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemArrayOrderLexicographic GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "array_order_lexicographic"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemBooleanLenient GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "boolean_lenient"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemBooleanStrict GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "boolean_strict"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemContinuationTabPreserve GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "continuation_tab_preserve"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemContinuationTabToSpace GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "continuation_tab_to_space"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemCrlfNormalizeToLf GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "crlf_normalize_to_lf"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemCrlfPreserveLiteral GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "crlf_preserve_literal"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemDelimiterFirstEquals GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "delimiter_first_equals"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemDelimiterPreferSpaced GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "delimiter_prefer_spaced"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemIndentSpaces GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "indent_spaces"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemIndentTabs GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "indent_tabs"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemListCoercionDisabled GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "list_coercion_disabled"
 const GeneratedFormatSimpleJsonTestsElemBehaviorsElemListCoercionEnabled GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "list_coercion_enabled"
-const GeneratedFormatSimpleJsonTestsElemBehaviorsElemTabsAsContent GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "tabs_as_content"
-const GeneratedFormatSimpleJsonTestsElemBehaviorsElemTabsAsWhitespace GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "tabs_as_whitespace"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemMultilineValues GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "multiline_values"
+const GeneratedFormatSimpleJsonTestsElemBehaviorsElemPathTraversal GeneratedFormatSimpleJsonTestsElemBehaviorsElem = "path_traversal"
 
 var enumValues_GeneratedFormatSimpleJsonTestsElemBehaviorsElem = []interface{}{
 	"boolean_strict",
 	"boolean_lenient",
 	"crlf_preserve_literal",
 	"crlf_normalize_to_lf",
-	"tabs_as_content",
-	"tabs_as_whitespace",
 	"indent_spaces",
 	"indent_tabs",
+	"continuation_tab_to_space",
+	"continuation_tab_preserve",
 	"list_coercion_enabled",
 	"list_coercion_disabled",
 	"array_order_insertion",
 	"array_order_lexicographic",
+	"delimiter_first_equals",
+	"delimiter_prefer_spaced",
+	"path_traversal",
+	"multiline_values",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemBehaviorsElem) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemBehaviorsElem) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -111,56 +123,46 @@ func (j *GeneratedFormatSimpleJsonTestsElemBehaviorsElem) UnmarshalJSON(b []byte
 	return nil
 }
 
+// Mutually exclusive options by category
 type GeneratedFormatSimpleJsonTestsElemConflicts struct {
 	// Behaviors corresponds to the JSON schema field "behaviors".
-	Behaviors []string `json:"behaviors,omitempty" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
+	Behaviors []string `json:"behaviors,omitempty,omitzero" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
 
 	// Features corresponds to the JSON schema field "features".
-	Features []string `json:"features,omitempty" yaml:"features,omitempty" mapstructure:"features,omitempty"`
+	Features []string `json:"features,omitempty,omitzero" yaml:"features,omitempty" mapstructure:"features,omitempty"`
 
 	// Functions corresponds to the JSON schema field "functions".
-	Functions []string `json:"functions,omitempty" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
+	Functions []string `json:"functions,omitempty,omitzero" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
 
 	// Variants corresponds to the JSON schema field "variants".
-	Variants []string `json:"variants,omitempty" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
+	Variants []string `json:"variants,omitempty,omitzero" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
 }
 
-// GeneratedFormatSimpleJsonTestsElemPredicate represents a filter predicate specification.
-type GeneratedFormatSimpleJsonTestsElemPredicate struct {
-	// Field corresponds to the JSON schema field "field".
-	Field string `json:"field" yaml:"field" mapstructure:"field"`
-
-	// Op corresponds to the JSON schema field "op".
-	Op string `json:"op" yaml:"op" mapstructure:"op"`
-
-	// Value corresponds to the JSON schema field "value".
-	Value string `json:"value" yaml:"value" mapstructure:"value"`
-}
-
+// Expected result in standardized format
 type GeneratedFormatSimpleJsonTestsElemExpected struct {
-	// Boolean corresponds to the JSON schema field "boolean".
-	Boolean *bool `json:"boolean,omitempty" yaml:"boolean,omitempty" mapstructure:"boolean,omitempty"`
+	// Expected boolean result for algebraic property tests
+	Boolean *bool `json:"boolean,omitempty,omitzero" yaml:"boolean,omitempty" mapstructure:"boolean,omitempty"`
 
-	// Count corresponds to the JSON schema field "count".
+	// Number of expected results/assertions
 	Count int `json:"count" yaml:"count" mapstructure:"count"`
 
-	// Entries corresponds to the JSON schema field "entries".
-	Entries []GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem `json:"entries,omitempty" yaml:"entries,omitempty" mapstructure:"entries,omitempty"`
+	// Expected entries for parse functions
+	Entries []GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem `json:"entries,omitempty,omitzero" yaml:"entries,omitempty" mapstructure:"entries,omitempty"`
 
-	// Error corresponds to the JSON schema field "error".
-	Error *bool `json:"error,omitempty" yaml:"error,omitempty" mapstructure:"error,omitempty"`
+	// Whether this should produce an error
+	Error bool `json:"error,omitempty,omitzero" yaml:"error,omitempty" mapstructure:"error,omitempty"`
 
-	// List corresponds to the JSON schema field "list".
-	List []interface{} `json:"list,omitempty" yaml:"list,omitempty" mapstructure:"list,omitempty"`
+	// Expected list for list access functions
+	List []interface{} `json:"list,omitempty,omitzero" yaml:"list,omitempty" mapstructure:"list,omitempty"`
 
-	// Object corresponds to the JSON schema field "object".
-	Object interface{} `json:"object,omitempty" yaml:"object,omitempty" mapstructure:"object,omitempty"`
+	// Expected object for hierarchy functions
+	Object interface{} `json:"object,omitempty,omitzero" yaml:"object,omitempty" mapstructure:"object,omitempty"`
 
-	// Text corresponds to the JSON schema field "text".
-	Text *string `json:"text,omitempty" yaml:"text,omitempty" mapstructure:"text,omitempty"`
+	// Expected text output for print function
+	Text *string `json:"text,omitempty,omitzero" yaml:"text,omitempty" mapstructure:"text,omitempty"`
 
-	// Value corresponds to the JSON schema field "value".
-	Value interface{} `json:"value,omitempty" yaml:"value,omitempty" mapstructure:"value,omitempty"`
+	// Expected single value for typed access functions
+	Value interface{} `json:"value,omitempty,omitzero" yaml:"value,omitempty" mapstructure:"value,omitempty"`
 }
 
 type GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem struct {
@@ -172,9 +174,9 @@ type GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem struct {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["key"]; raw != nil && !ok {
@@ -185,7 +187,7 @@ func (j *GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem) UnmarshalJSON(b 
 	}
 	type Plain GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	*j = GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem(plain)
@@ -193,9 +195,9 @@ func (j *GeneratedFormatSimpleJsonTestsElemExpectedEntriesElem) UnmarshalJSON(b 
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemExpected) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemExpected) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["count"]; raw != nil && !ok {
@@ -203,8 +205,14 @@ func (j *GeneratedFormatSimpleJsonTestsElemExpected) UnmarshalJSON(b []byte) err
 	}
 	type Plain GeneratedFormatSimpleJsonTestsElemExpected
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
+	}
+	if 0 > plain.Count {
+		return fmt.Errorf("field %s: must be >= %v", "count", 0)
+	}
+	if v, ok := raw["error"]; !ok || v == nil {
+		plain.Error = false
 	}
 	*j = GeneratedFormatSimpleJsonTestsElemExpected(plain)
 	return nil
@@ -213,6 +221,7 @@ func (j *GeneratedFormatSimpleJsonTestsElemExpected) UnmarshalJSON(b []byte) err
 type GeneratedFormatSimpleJsonTestsElemFunctionsElem string
 
 const GeneratedFormatSimpleJsonTestsElemFunctionsElemBuildHierarchy GeneratedFormatSimpleJsonTestsElemFunctionsElem = "build_hierarchy"
+const GeneratedFormatSimpleJsonTestsElemFunctionsElemBuildModel GeneratedFormatSimpleJsonTestsElemFunctionsElem = "build_model"
 const GeneratedFormatSimpleJsonTestsElemFunctionsElemCanonicalFormat GeneratedFormatSimpleJsonTestsElemFunctionsElem = "canonical_format"
 const GeneratedFormatSimpleJsonTestsElemFunctionsElemCompose GeneratedFormatSimpleJsonTestsElemFunctionsElem = "compose"
 const GeneratedFormatSimpleJsonTestsElemFunctionsElemComposeAssociative GeneratedFormatSimpleJsonTestsElemFunctionsElem = "compose_associative"
@@ -236,6 +245,7 @@ var enumValues_GeneratedFormatSimpleJsonTestsElemFunctionsElem = []interface{}{
 	"filter",
 	"compose",
 	"build_hierarchy",
+	"build_model",
 	"get_string",
 	"get_int",
 	"get_bool",
@@ -251,9 +261,9 @@ var enumValues_GeneratedFormatSimpleJsonTestsElemFunctionsElem = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemFunctionsElem) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemFunctionsElem) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -270,9 +280,106 @@ func (j *GeneratedFormatSimpleJsonTestsElemFunctionsElem) UnmarshalJSON(b []byte
 	return nil
 }
 
+// Filter predicate specification. Defines how to filter entries based on a field
+// comparison.
+type GeneratedFormatSimpleJsonTestsElemPredicate struct {
+	// Which Entry field to compare
+	Field GeneratedFormatSimpleJsonTestsElemPredicateField `json:"field" yaml:"field" mapstructure:"field"`
+
+	// Comparison operator
+	Op GeneratedFormatSimpleJsonTestsElemPredicateOp `json:"op" yaml:"op" mapstructure:"op"`
+
+	// Value to compare against
+	Value string `json:"value" yaml:"value" mapstructure:"value"`
+}
+
+type GeneratedFormatSimpleJsonTestsElemPredicateField string
+
+const GeneratedFormatSimpleJsonTestsElemPredicateFieldKey GeneratedFormatSimpleJsonTestsElemPredicateField = "key"
+const GeneratedFormatSimpleJsonTestsElemPredicateFieldValue GeneratedFormatSimpleJsonTestsElemPredicateField = "value"
+
+var enumValues_GeneratedFormatSimpleJsonTestsElemPredicateField = []interface{}{
+	"key",
+	"value",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *GeneratedFormatSimpleJsonTestsElemPredicateField) UnmarshalJSON(value []byte) error {
+	var v string
+	if err := json.Unmarshal(value, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_GeneratedFormatSimpleJsonTestsElemPredicateField {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_GeneratedFormatSimpleJsonTestsElemPredicateField, v)
+	}
+	*j = GeneratedFormatSimpleJsonTestsElemPredicateField(v)
+	return nil
+}
+
+type GeneratedFormatSimpleJsonTestsElemPredicateOp string
+
+const GeneratedFormatSimpleJsonTestsElemPredicateOpUndefined GeneratedFormatSimpleJsonTestsElemPredicateOp = "=="
+
+var enumValues_GeneratedFormatSimpleJsonTestsElemPredicateOp = []interface{}{
+	"==",
+	"!=",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *GeneratedFormatSimpleJsonTestsElemPredicateOp) UnmarshalJSON(value []byte) error {
+	var v string
+	if err := json.Unmarshal(value, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_GeneratedFormatSimpleJsonTestsElemPredicateOp {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_GeneratedFormatSimpleJsonTestsElemPredicateOp, v)
+	}
+	*j = GeneratedFormatSimpleJsonTestsElemPredicateOp(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *GeneratedFormatSimpleJsonTestsElemPredicate) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(value, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["field"]; raw != nil && !ok {
+		return fmt.Errorf("field field in GeneratedFormatSimpleJsonTestsElemPredicate: required")
+	}
+	if _, ok := raw["op"]; raw != nil && !ok {
+		return fmt.Errorf("field op in GeneratedFormatSimpleJsonTestsElemPredicate: required")
+	}
+	if _, ok := raw["value"]; raw != nil && !ok {
+		return fmt.Errorf("field value in GeneratedFormatSimpleJsonTestsElemPredicate: required")
+	}
+	type Plain GeneratedFormatSimpleJsonTestsElemPredicate
+	var plain Plain
+	if err := json.Unmarshal(value, &plain); err != nil {
+		return err
+	}
+	*j = GeneratedFormatSimpleJsonTestsElemPredicate(plain)
+	return nil
+}
+
 type GeneratedFormatSimpleJsonTestsElemValidation string
 
 const GeneratedFormatSimpleJsonTestsElemValidationBuildHierarchy GeneratedFormatSimpleJsonTestsElemValidation = "build_hierarchy"
+const GeneratedFormatSimpleJsonTestsElemValidationBuildModel GeneratedFormatSimpleJsonTestsElemValidation = "build_model"
 const GeneratedFormatSimpleJsonTestsElemValidationCanonicalFormat GeneratedFormatSimpleJsonTestsElemValidation = "canonical_format"
 const GeneratedFormatSimpleJsonTestsElemValidationCompose GeneratedFormatSimpleJsonTestsElemValidation = "compose"
 const GeneratedFormatSimpleJsonTestsElemValidationComposeAssociative GeneratedFormatSimpleJsonTestsElemValidation = "compose_associative"
@@ -296,6 +403,7 @@ var enumValues_GeneratedFormatSimpleJsonTestsElemValidation = []interface{}{
 	"filter",
 	"compose",
 	"build_hierarchy",
+	"build_model",
 	"get_string",
 	"get_int",
 	"get_bool",
@@ -311,9 +419,9 @@ var enumValues_GeneratedFormatSimpleJsonTestsElemValidation = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemValidation) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemValidation) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -341,9 +449,9 @@ var enumValues_GeneratedFormatSimpleJsonTestsElemVariantsElem = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElemVariantsElem) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElemVariantsElem) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -361,9 +469,9 @@ func (j *GeneratedFormatSimpleJsonTestsElemVariantsElem) UnmarshalJSON(b []byte)
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJsonTestsElem) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJsonTestsElem) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["behaviors"]; raw != nil && !ok {
@@ -389,20 +497,26 @@ func (j *GeneratedFormatSimpleJsonTestsElem) UnmarshalJSON(b []byte) error {
 	}
 	type Plain GeneratedFormatSimpleJsonTestsElem
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
+	}
+	if v, ok := raw["expect_error"]; !ok || v == nil {
+		plain.ExpectError = false
 	}
 	if plain.Inputs != nil && len(plain.Inputs) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "inputs", 1)
+	}
+	if matched, _ := regexp.MatchString(`^[a-zA-Z0-9_]+$`, string(plain.Name)); !matched {
+		return fmt.Errorf("field %s pattern match: must match %s", "Name", `^[a-zA-Z0-9_]+$`)
 	}
 	*j = GeneratedFormatSimpleJsonTestsElem(plain)
 	return nil
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *GeneratedFormatSimpleJson) UnmarshalJSON(b []byte) error {
+func (j *GeneratedFormatSimpleJson) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["$schema"]; raw != nil && !ok {
@@ -413,7 +527,7 @@ func (j *GeneratedFormatSimpleJson) UnmarshalJSON(b []byte) error {
 	}
 	type Plain GeneratedFormatSimpleJson
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	if plain.Tests != nil && len(plain.Tests) < 1 {

--- a/types/generated/source_format.go
+++ b/types/generated/source_format.go
@@ -5,226 +5,229 @@ package generated
 import "encoding/json"
 import "fmt"
 import "reflect"
+import "regexp"
 
 // Metadata about CCL behaviors including function affinity and mutual exclusivity.
 // Used by the generator to filter behaviors to only the functions they affect.
 type BehaviorMetadata struct {
 	// ArrayOrderInsertion corresponds to the JSON schema field
 	// "array_order_insertion".
-	ArrayOrderInsertion *BehaviorMetadataArrayOrderInsertion `json:"array_order_insertion,omitempty" yaml:"array_order_insertion,omitempty" mapstructure:"array_order_insertion,omitempty"`
+	ArrayOrderInsertion *BehaviorMetadataArrayOrderInsertion `json:"array_order_insertion,omitempty,omitzero" yaml:"array_order_insertion,omitempty" mapstructure:"array_order_insertion,omitempty"`
 
 	// ArrayOrderLexicographic corresponds to the JSON schema field
 	// "array_order_lexicographic".
-	ArrayOrderLexicographic *BehaviorMetadataArrayOrderLexicographic `json:"array_order_lexicographic,omitempty" yaml:"array_order_lexicographic,omitempty" mapstructure:"array_order_lexicographic,omitempty"`
+	ArrayOrderLexicographic *BehaviorMetadataArrayOrderLexicographic `json:"array_order_lexicographic,omitempty,omitzero" yaml:"array_order_lexicographic,omitempty" mapstructure:"array_order_lexicographic,omitempty"`
 
 	// BooleanLenient corresponds to the JSON schema field "boolean_lenient".
-	BooleanLenient *BehaviorMetadataBooleanLenient `json:"boolean_lenient,omitempty" yaml:"boolean_lenient,omitempty" mapstructure:"boolean_lenient,omitempty"`
+	BooleanLenient *BehaviorMetadataBooleanLenient `json:"boolean_lenient,omitempty,omitzero" yaml:"boolean_lenient,omitempty" mapstructure:"boolean_lenient,omitempty"`
 
 	// BooleanStrict corresponds to the JSON schema field "boolean_strict".
-	BooleanStrict *BehaviorMetadataBooleanStrict `json:"boolean_strict,omitempty" yaml:"boolean_strict,omitempty" mapstructure:"boolean_strict,omitempty"`
+	BooleanStrict *BehaviorMetadataBooleanStrict `json:"boolean_strict,omitempty,omitzero" yaml:"boolean_strict,omitempty" mapstructure:"boolean_strict,omitempty"`
+
+	// ContinuationTabPreserve corresponds to the JSON schema field
+	// "continuation_tab_preserve".
+	ContinuationTabPreserve *BehaviorMetadataContinuationTabPreserve `json:"continuation_tab_preserve,omitempty,omitzero" yaml:"continuation_tab_preserve,omitempty" mapstructure:"continuation_tab_preserve,omitempty"`
+
+	// ContinuationTabToSpace corresponds to the JSON schema field
+	// "continuation_tab_to_space".
+	ContinuationTabToSpace *BehaviorMetadataContinuationTabToSpace `json:"continuation_tab_to_space,omitempty,omitzero" yaml:"continuation_tab_to_space,omitempty" mapstructure:"continuation_tab_to_space,omitempty"`
 
 	// CrlfNormalizeToLf corresponds to the JSON schema field "crlf_normalize_to_lf".
-	CrlfNormalizeToLf *BehaviorMetadataCrlfNormalizeToLf `json:"crlf_normalize_to_lf,omitempty" yaml:"crlf_normalize_to_lf,omitempty" mapstructure:"crlf_normalize_to_lf,omitempty"`
+	CrlfNormalizeToLf *BehaviorMetadataCrlfNormalizeToLf `json:"crlf_normalize_to_lf,omitempty,omitzero" yaml:"crlf_normalize_to_lf,omitempty" mapstructure:"crlf_normalize_to_lf,omitempty"`
 
 	// CrlfPreserveLiteral corresponds to the JSON schema field
 	// "crlf_preserve_literal".
-	CrlfPreserveLiteral *BehaviorMetadataCrlfPreserveLiteral `json:"crlf_preserve_literal,omitempty" yaml:"crlf_preserve_literal,omitempty" mapstructure:"crlf_preserve_literal,omitempty"`
+	CrlfPreserveLiteral *BehaviorMetadataCrlfPreserveLiteral `json:"crlf_preserve_literal,omitempty,omitzero" yaml:"crlf_preserve_literal,omitempty" mapstructure:"crlf_preserve_literal,omitempty"`
+
+	// DelimiterFirstEquals corresponds to the JSON schema field
+	// "delimiter_first_equals".
+	DelimiterFirstEquals *BehaviorMetadataDelimiterFirstEquals `json:"delimiter_first_equals,omitempty,omitzero" yaml:"delimiter_first_equals,omitempty" mapstructure:"delimiter_first_equals,omitempty"`
+
+	// DelimiterPreferSpaced corresponds to the JSON schema field
+	// "delimiter_prefer_spaced".
+	DelimiterPreferSpaced *BehaviorMetadataDelimiterPreferSpaced `json:"delimiter_prefer_spaced,omitempty,omitzero" yaml:"delimiter_prefer_spaced,omitempty" mapstructure:"delimiter_prefer_spaced,omitempty"`
 
 	// IndentSpaces corresponds to the JSON schema field "indent_spaces".
-	IndentSpaces *BehaviorMetadataIndentSpaces `json:"indent_spaces,omitempty" yaml:"indent_spaces,omitempty" mapstructure:"indent_spaces,omitempty"`
+	IndentSpaces *BehaviorMetadataIndentSpaces `json:"indent_spaces,omitempty,omitzero" yaml:"indent_spaces,omitempty" mapstructure:"indent_spaces,omitempty"`
 
 	// IndentTabs corresponds to the JSON schema field "indent_tabs".
-	IndentTabs *BehaviorMetadataIndentTabs `json:"indent_tabs,omitempty" yaml:"indent_tabs,omitempty" mapstructure:"indent_tabs,omitempty"`
+	IndentTabs *BehaviorMetadataIndentTabs `json:"indent_tabs,omitempty,omitzero" yaml:"indent_tabs,omitempty" mapstructure:"indent_tabs,omitempty"`
 
 	// ListCoercionDisabled corresponds to the JSON schema field
 	// "list_coercion_disabled".
-	ListCoercionDisabled *BehaviorMetadataListCoercionDisabled `json:"list_coercion_disabled,omitempty" yaml:"list_coercion_disabled,omitempty" mapstructure:"list_coercion_disabled,omitempty"`
+	ListCoercionDisabled *BehaviorMetadataListCoercionDisabled `json:"list_coercion_disabled,omitempty,omitzero" yaml:"list_coercion_disabled,omitempty" mapstructure:"list_coercion_disabled,omitempty"`
 
 	// ListCoercionEnabled corresponds to the JSON schema field
 	// "list_coercion_enabled".
-	ListCoercionEnabled *BehaviorMetadataListCoercionEnabled `json:"list_coercion_enabled,omitempty" yaml:"list_coercion_enabled,omitempty" mapstructure:"list_coercion_enabled,omitempty"`
-
-	// TabsAsContent corresponds to the JSON schema field "tabs_as_content".
-	TabsAsContent *BehaviorMetadataTabsAsContent `json:"tabs_as_content,omitempty" yaml:"tabs_as_content,omitempty" mapstructure:"tabs_as_content,omitempty"`
-
-	// TabsAsWhitespace corresponds to the JSON schema field "tabs_as_whitespace".
-	TabsAsWhitespace *BehaviorMetadataTabsAsWhitespace `json:"tabs_as_whitespace,omitempty" yaml:"tabs_as_whitespace,omitempty" mapstructure:"tabs_as_whitespace,omitempty"`
-
-	// ToplevelIndentPreserve corresponds to the JSON schema field
-	// "toplevel_indent_preserve".
-	ToplevelIndentPreserve *BehaviorMetadataToplevelIndentPreserve `json:"toplevel_indent_preserve,omitempty" yaml:"toplevel_indent_preserve,omitempty" mapstructure:"toplevel_indent_preserve,omitempty"`
-
-	// ToplevelIndentStrip corresponds to the JSON schema field
-	// "toplevel_indent_strip".
-	ToplevelIndentStrip *BehaviorMetadataToplevelIndentStrip `json:"toplevel_indent_strip,omitempty" yaml:"toplevel_indent_strip,omitempty" mapstructure:"toplevel_indent_strip,omitempty"`
+	ListCoercionEnabled *BehaviorMetadataListCoercionEnabled `json:"list_coercion_enabled,omitempty,omitzero" yaml:"list_coercion_enabled,omitempty" mapstructure:"list_coercion_enabled,omitempty"`
 }
 
 type BehaviorMetadataArrayOrderInsertion struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataArrayOrderLexicographic struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataBooleanLenient struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataBooleanStrict struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+}
+
+type BehaviorMetadataContinuationTabPreserve struct {
+	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+
+	// Description corresponds to the JSON schema field "description".
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+
+	// MutuallyExclusiveWith corresponds to the JSON schema field
+	// "mutuallyExclusiveWith".
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+}
+
+type BehaviorMetadataContinuationTabToSpace struct {
+	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+
+	// Description corresponds to the JSON schema field "description".
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+
+	// MutuallyExclusiveWith corresponds to the JSON schema field
+	// "mutuallyExclusiveWith".
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataCrlfNormalizeToLf struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataCrlfPreserveLiteral struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+}
+
+type BehaviorMetadataDelimiterFirstEquals struct {
+	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+
+	// Description corresponds to the JSON schema field "description".
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+
+	// MutuallyExclusiveWith corresponds to the JSON schema field
+	// "mutuallyExclusiveWith".
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+}
+
+type BehaviorMetadataDelimiterPreferSpaced struct {
+	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+
+	// Description corresponds to the JSON schema field "description".
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+
+	// MutuallyExclusiveWith corresponds to the JSON schema field
+	// "mutuallyExclusiveWith".
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataIndentSpaces struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataIndentTabs struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataListCoercionDisabled struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorMetadataListCoercionEnabled struct {
 	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
+	AffectedFunctions interface{} `json:"affectedFunctions,omitempty,omitzero" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
 
 	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
+	Description interface{} `json:"description,omitempty,omitzero" yaml:"description,omitempty" mapstructure:"description,omitempty"`
 
 	// MutuallyExclusiveWith corresponds to the JSON schema field
 	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
-}
-
-type BehaviorMetadataTabsAsContent struct {
-	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
-
-	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
-
-	// MutuallyExclusiveWith corresponds to the JSON schema field
-	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
-}
-
-type BehaviorMetadataTabsAsWhitespace struct {
-	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
-
-	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
-
-	// MutuallyExclusiveWith corresponds to the JSON schema field
-	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
-}
-
-type BehaviorMetadataToplevelIndentPreserve struct {
-	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
-
-	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
-
-	// MutuallyExclusiveWith corresponds to the JSON schema field
-	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
-}
-
-type BehaviorMetadataToplevelIndentStrip struct {
-	// AffectedFunctions corresponds to the JSON schema field "affectedFunctions".
-	AffectedFunctions interface{} `json:"affectedFunctions,omitempty" yaml:"affectedFunctions,omitempty" mapstructure:"affectedFunctions,omitempty"`
-
-	// Description corresponds to the JSON schema field "description".
-	Description interface{} `json:"description,omitempty" yaml:"description,omitempty" mapstructure:"description,omitempty"`
-
-	// MutuallyExclusiveWith corresponds to the JSON schema field
-	// "mutuallyExclusiveWith".
-	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
+	MutuallyExclusiveWith interface{} `json:"mutuallyExclusiveWith,omitempty,omitzero" yaml:"mutuallyExclusiveWith,omitempty" mapstructure:"mutuallyExclusiveWith,omitempty"`
 }
 
 type BehaviorName string
@@ -233,38 +236,42 @@ const BehaviorNameArrayOrderInsertion BehaviorName = "array_order_insertion"
 const BehaviorNameArrayOrderLexicographic BehaviorName = "array_order_lexicographic"
 const BehaviorNameBooleanLenient BehaviorName = "boolean_lenient"
 const BehaviorNameBooleanStrict BehaviorName = "boolean_strict"
+const BehaviorNameContinuationTabPreserve BehaviorName = "continuation_tab_preserve"
+const BehaviorNameContinuationTabToSpace BehaviorName = "continuation_tab_to_space"
 const BehaviorNameCrlfNormalizeToLf BehaviorName = "crlf_normalize_to_lf"
 const BehaviorNameCrlfPreserveLiteral BehaviorName = "crlf_preserve_literal"
+const BehaviorNameDelimiterFirstEquals BehaviorName = "delimiter_first_equals"
+const BehaviorNameDelimiterPreferSpaced BehaviorName = "delimiter_prefer_spaced"
 const BehaviorNameIndentSpaces BehaviorName = "indent_spaces"
 const BehaviorNameIndentTabs BehaviorName = "indent_tabs"
 const BehaviorNameListCoercionDisabled BehaviorName = "list_coercion_disabled"
 const BehaviorNameListCoercionEnabled BehaviorName = "list_coercion_enabled"
-const BehaviorNameTabsAsContent BehaviorName = "tabs_as_content"
-const BehaviorNameTabsAsWhitespace BehaviorName = "tabs_as_whitespace"
-const BehaviorNameToplevelIndentPreserve BehaviorName = "toplevel_indent_preserve"
-const BehaviorNameToplevelIndentStrip BehaviorName = "toplevel_indent_strip"
+const BehaviorNameMultilineValues BehaviorName = "multiline_values"
+const BehaviorNamePathTraversal BehaviorName = "path_traversal"
 
 var enumValues_BehaviorName = []interface{}{
 	"boolean_strict",
 	"boolean_lenient",
 	"crlf_preserve_literal",
 	"crlf_normalize_to_lf",
-	"tabs_as_content",
-	"tabs_as_whitespace",
 	"indent_spaces",
 	"indent_tabs",
+	"continuation_tab_to_space",
+	"continuation_tab_preserve",
 	"list_coercion_enabled",
 	"list_coercion_disabled",
 	"array_order_insertion",
 	"array_order_lexicographic",
-	"toplevel_indent_strip",
-	"toplevel_indent_preserve",
+	"delimiter_first_equals",
+	"delimiter_prefer_spaced",
+	"path_traversal",
+	"multiline_values",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *BehaviorName) UnmarshalJSON(b []byte) error {
+func (j *BehaviorName) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -286,17 +293,15 @@ type FeatureName string
 type FunctionName string
 
 const FunctionNameBuildHierarchy FunctionName = "build_hierarchy"
+const FunctionNameBuildModel FunctionName = "build_model"
 const FunctionNameCanonicalFormat FunctionName = "canonical_format"
 const FunctionNameCompose FunctionName = "compose"
-const FunctionNameComposeAssociative FunctionName = "compose_associative"
 const FunctionNameFilter FunctionName = "filter"
 const FunctionNameGetBool FunctionName = "get_bool"
 const FunctionNameGetFloat FunctionName = "get_float"
 const FunctionNameGetInt FunctionName = "get_int"
 const FunctionNameGetList FunctionName = "get_list"
 const FunctionNameGetString FunctionName = "get_string"
-const FunctionNameIdentityLeft FunctionName = "identity_left"
-const FunctionNameIdentityRight FunctionName = "identity_right"
 const FunctionNameLoad FunctionName = "load"
 const FunctionNameParse FunctionName = "parse"
 const FunctionNameParseIndented FunctionName = "parse_indented"
@@ -309,6 +314,7 @@ var enumValues_FunctionName = []interface{}{
 	"filter",
 	"compose",
 	"build_hierarchy",
+	"build_model",
 	"get_string",
 	"get_int",
 	"get_bool",
@@ -318,15 +324,12 @@ var enumValues_FunctionName = []interface{}{
 	"canonical_format",
 	"load",
 	"round_trip",
-	"compose_associative",
-	"identity_left",
-	"identity_right",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *FunctionName) UnmarshalJSON(b []byte) error {
+func (j *FunctionName) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool
@@ -346,7 +349,7 @@ func (j *FunctionName) UnmarshalJSON(b []byte) error {
 // Schema for source test files (api_*.json)
 type SourceFormatJson struct {
 	// JSON Schema reference (relative path to schema file)
-	Schema *string `json:"$schema,omitempty" yaml:"$schema,omitempty" mapstructure:"$schema,omitempty"`
+	Schema *string `json:"$schema,omitempty,omitzero" yaml:"$schema,omitempty" mapstructure:"$schema,omitempty"`
 
 	// Array of test cases
 	Tests []SourceFormatJsonTestsElem `json:"tests" yaml:"tests" mapstructure:"tests"`
@@ -355,14 +358,18 @@ type SourceFormatJson struct {
 type SourceFormatJsonTestsElem struct {
 	// Implementation behavior requirements (optional). Conflicts are auto-generated
 	// from behavior metadata.
-	Behaviors []BehaviorName `json:"behaviors,omitempty" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
+	Behaviors []BehaviorName `json:"behaviors,omitempty,omitzero" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
 
 	// DEPRECATED: Conflicts are now auto-generated from $defs/behaviorMetadata. This
 	// field is ignored and will be removed in a future version.
-	Conflicts *SourceFormatJsonTestsElemConflicts `json:"conflicts,omitempty" yaml:"conflicts,omitempty" mapstructure:"conflicts,omitempty"`
+	Conflicts *SourceFormatJsonTestsElemConflicts `json:"conflicts,omitempty,omitzero" yaml:"conflicts,omitempty" mapstructure:"conflicts,omitempty"`
 
-	// Required language features for this test
-	Features []FeatureName `json:"features,omitempty" yaml:"features,omitempty" mapstructure:"features,omitempty"`
+	// Language features exercised by this test (informational, for gap reporting)
+	Features []FeatureName `json:"features,omitempty,omitzero" yaml:"features,omitempty" mapstructure:"features,omitempty"`
+
+	// CCL functions exercised by this test. Used by validate-tags to map tests to
+	// function:* tags.
+	Functions []FunctionName `json:"functions,omitempty,omitzero" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
 
 	// CCL input text(s) to be tested. Single-input tests use a 1-element array.
 	Inputs []string `json:"inputs" yaml:"inputs" mapstructure:"inputs"`
@@ -374,43 +381,143 @@ type SourceFormatJsonTestsElem struct {
 	Tests []SourceFormatJsonTestsElemTestsElem `json:"tests" yaml:"tests" mapstructure:"tests"`
 
 	// Specification variants (optional)
-	Variants []VariantName `json:"variants,omitempty" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
+	Variants []VariantName `json:"variants,omitempty,omitzero" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
 }
 
 // DEPRECATED: Conflicts are now auto-generated from $defs/behaviorMetadata. This
 // field is ignored and will be removed in a future version.
 type SourceFormatJsonTestsElemConflicts struct {
 	// Behaviors corresponds to the JSON schema field "behaviors".
-	Behaviors []string `json:"behaviors,omitempty" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
+	Behaviors []string `json:"behaviors,omitempty,omitzero" yaml:"behaviors,omitempty" mapstructure:"behaviors,omitempty"`
 
 	// Features corresponds to the JSON schema field "features".
-	Features []string `json:"features,omitempty" yaml:"features,omitempty" mapstructure:"features,omitempty"`
+	Features []string `json:"features,omitempty,omitzero" yaml:"features,omitempty" mapstructure:"features,omitempty"`
 
 	// Functions corresponds to the JSON schema field "functions".
-	Functions []string `json:"functions,omitempty" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
+	Functions []string `json:"functions,omitempty,omitzero" yaml:"functions,omitempty" mapstructure:"functions,omitempty"`
 
 	// Variants corresponds to the JSON schema field "variants".
-	Variants []string `json:"variants,omitempty" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
+	Variants []string `json:"variants,omitempty,omitzero" yaml:"variants,omitempty" mapstructure:"variants,omitempty"`
 }
 
 type SourceFormatJsonTestsElemTestsElem struct {
 	// Optional arguments for parameterized functions
-	Args []string `json:"args,omitempty" yaml:"args,omitempty" mapstructure:"args,omitempty"`
+	Args []string `json:"args,omitempty,omitzero" yaml:"args,omitempty" mapstructure:"args,omitempty"`
 
 	// Whether function should produce an error
-	Error bool `json:"error,omitempty" yaml:"error,omitempty" mapstructure:"error,omitempty"`
+	Error bool `json:"error,omitempty,omitzero" yaml:"error,omitempty" mapstructure:"error,omitempty"`
 
 	// Expected result from the function
 	Expect interface{} `json:"expect" yaml:"expect" mapstructure:"expect"`
 
-	// CCL function to test
-	Function FunctionName `json:"function" yaml:"function" mapstructure:"function"`
+	// Named test validation (a CCL function, or an algebraic-property assertion)
+	Function ValidationName `json:"function" yaml:"function" mapstructure:"function"`
+
+	// Filter predicate specification. Defines how to filter entries based on a field
+	// comparison.
+	Predicate *SourceFormatJsonTestsElemTestsElemPredicate `json:"predicate,omitempty,omitzero" yaml:"predicate,omitempty" mapstructure:"predicate,omitempty"`
+}
+
+// Filter predicate specification. Defines how to filter entries based on a field
+// comparison.
+type SourceFormatJsonTestsElemTestsElemPredicate struct {
+	// Which Entry field to compare
+	Field SourceFormatJsonTestsElemTestsElemPredicateField `json:"field" yaml:"field" mapstructure:"field"`
+
+	// Comparison operator
+	Op SourceFormatJsonTestsElemTestsElemPredicateOp `json:"op" yaml:"op" mapstructure:"op"`
+
+	// Value to compare against
+	Value string `json:"value" yaml:"value" mapstructure:"value"`
+}
+
+type SourceFormatJsonTestsElemTestsElemPredicateField string
+
+const SourceFormatJsonTestsElemTestsElemPredicateFieldKey SourceFormatJsonTestsElemTestsElemPredicateField = "key"
+const SourceFormatJsonTestsElemTestsElemPredicateFieldValue SourceFormatJsonTestsElemTestsElemPredicateField = "value"
+
+var enumValues_SourceFormatJsonTestsElemTestsElemPredicateField = []interface{}{
+	"key",
+	"value",
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SourceFormatJsonTestsElemTestsElem) UnmarshalJSON(b []byte) error {
+func (j *SourceFormatJsonTestsElemTestsElemPredicateField) UnmarshalJSON(value []byte) error {
+	var v string
+	if err := json.Unmarshal(value, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SourceFormatJsonTestsElemTestsElemPredicateField {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SourceFormatJsonTestsElemTestsElemPredicateField, v)
+	}
+	*j = SourceFormatJsonTestsElemTestsElemPredicateField(v)
+	return nil
+}
+
+type SourceFormatJsonTestsElemTestsElemPredicateOp string
+
+const SourceFormatJsonTestsElemTestsElemPredicateOpUndefined SourceFormatJsonTestsElemTestsElemPredicateOp = "=="
+
+var enumValues_SourceFormatJsonTestsElemTestsElemPredicateOp = []interface{}{
+	"==",
+	"!=",
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SourceFormatJsonTestsElemTestsElemPredicateOp) UnmarshalJSON(value []byte) error {
+	var v string
+	if err := json.Unmarshal(value, &v); err != nil {
+		return err
+	}
+	var ok bool
+	for _, expected := range enumValues_SourceFormatJsonTestsElemTestsElemPredicateOp {
+		if reflect.DeepEqual(v, expected) {
+			ok = true
+			break
+		}
+	}
+	if !ok {
+		return fmt.Errorf("invalid value (expected one of %#v): %#v", enumValues_SourceFormatJsonTestsElemTestsElemPredicateOp, v)
+	}
+	*j = SourceFormatJsonTestsElemTestsElemPredicateOp(v)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SourceFormatJsonTestsElemTestsElemPredicate) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
+		return err
+	}
+	if _, ok := raw["field"]; raw != nil && !ok {
+		return fmt.Errorf("field field in SourceFormatJsonTestsElemTestsElemPredicate: required")
+	}
+	if _, ok := raw["op"]; raw != nil && !ok {
+		return fmt.Errorf("field op in SourceFormatJsonTestsElemTestsElemPredicate: required")
+	}
+	if _, ok := raw["value"]; raw != nil && !ok {
+		return fmt.Errorf("field value in SourceFormatJsonTestsElemTestsElemPredicate: required")
+	}
+	type Plain SourceFormatJsonTestsElemTestsElemPredicate
+	var plain Plain
+	if err := json.Unmarshal(value, &plain); err != nil {
+		return err
+	}
+	*j = SourceFormatJsonTestsElemTestsElemPredicate(plain)
+	return nil
+}
+
+// UnmarshalJSON implements json.Unmarshaler.
+func (j *SourceFormatJsonTestsElemTestsElem) UnmarshalJSON(value []byte) error {
+	var raw map[string]interface{}
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["expect"]; raw != nil && !ok {
@@ -421,7 +528,7 @@ func (j *SourceFormatJsonTestsElemTestsElem) UnmarshalJSON(b []byte) error {
 	}
 	type Plain SourceFormatJsonTestsElemTestsElem
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	if v, ok := raw["error"]; !ok || v == nil {
@@ -432,9 +539,9 @@ func (j *SourceFormatJsonTestsElemTestsElem) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SourceFormatJsonTestsElem) UnmarshalJSON(b []byte) error {
+func (j *SourceFormatJsonTestsElem) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["inputs"]; raw != nil && !ok {
@@ -448,11 +555,14 @@ func (j *SourceFormatJsonTestsElem) UnmarshalJSON(b []byte) error {
 	}
 	type Plain SourceFormatJsonTestsElem
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	if plain.Inputs != nil && len(plain.Inputs) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "inputs", 1)
+	}
+	if matched, _ := regexp.MatchString(`^[a-zA-Z0-9_]+$`, string(plain.Name)); !matched {
+		return fmt.Errorf("field %s pattern match: must match %s", "Name", `^[a-zA-Z0-9_]+$`)
 	}
 	if plain.Tests != nil && len(plain.Tests) < 1 {
 		return fmt.Errorf("field %s length: must be >= %d", "tests", 1)
@@ -462,9 +572,9 @@ func (j *SourceFormatJsonTestsElem) UnmarshalJSON(b []byte) error {
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *SourceFormatJson) UnmarshalJSON(b []byte) error {
+func (j *SourceFormatJson) UnmarshalJSON(value []byte) error {
 	var raw map[string]interface{}
-	if err := json.Unmarshal(b, &raw); err != nil {
+	if err := json.Unmarshal(value, &raw); err != nil {
 		return err
 	}
 	if _, ok := raw["tests"]; raw != nil && !ok {
@@ -472,7 +582,7 @@ func (j *SourceFormatJson) UnmarshalJSON(b []byte) error {
 	}
 	type Plain SourceFormatJson
 	var plain Plain
-	if err := json.Unmarshal(b, &plain); err != nil {
+	if err := json.Unmarshal(value, &plain); err != nil {
 		return err
 	}
 	if plain.Tests != nil && len(plain.Tests) < 1 {
@@ -481,6 +591,10 @@ func (j *SourceFormatJson) UnmarshalJSON(b []byte) error {
 	*j = SourceFormatJson(plain)
 	return nil
 }
+
+// A named test validation. Superset of functionName: includes the 15 CCL functions
+// plus algebraic-property assertions validated by the test runner.
+type ValidationName string
 
 type VariantName string
 
@@ -493,9 +607,9 @@ var enumValues_VariantName = []interface{}{
 }
 
 // UnmarshalJSON implements json.Unmarshaler.
-func (j *VariantName) UnmarshalJSON(b []byte) error {
+func (j *VariantName) UnmarshalJSON(value []byte) error {
 	var v string
-	if err := json.Unmarshal(b, &v); err != nil {
+	if err := json.Unmarshal(value, &v); err != nil {
 		return err
 	}
 	var ok bool

--- a/types/structured.go
+++ b/types/structured.go
@@ -94,6 +94,7 @@ const (
 	FunctionCompose         CCLFunction = "compose"
 	FunctionExpandDotted    CCLFunction = "expand_dotted"
 	FunctionBuildHierarchy  CCLFunction = "build_hierarchy"
+	FunctionBuildModel      CCLFunction = "build_model"
 	FunctionGetString       CCLFunction = "get_string"
 	FunctionGetInt          CCLFunction = "get_int"
 	FunctionGetBool         CCLFunction = "get_bool"
@@ -127,8 +128,8 @@ const (
 	FeatureExperimentalDottedKeys Feature = "experimental_dotted_keys"
 	FeatureUnicode                Feature = "unicode"
 	FeatureWhitespace             Feature = "whitespace"
-	FeatureTabInValuePreserved Feature = "tab_in_value_preserved"
-	FeatureToplevelIndentStrip Feature = "toplevel_indent_strip"
+	FeatureTabInValuePreserved    Feature = "tab_in_value_preserved"
+	FeatureToplevelIndentStrip    Feature = "toplevel_indent_strip"
 )
 
 // Variant represents specification variants

--- a/types/types.go
+++ b/types/types.go
@@ -56,6 +56,7 @@ type ValidationSet struct {
 	Combine            interface{} `json:"combine,omitempty"`
 	ExpandDotted       interface{} `json:"expand_dotted,omitempty"`
 	BuildHierarchy     interface{} `json:"build_hierarchy,omitempty"`
+	BuildModel         interface{} `json:"build_model,omitempty"`
 	GetString          interface{} `json:"get_string,omitempty"`
 	GetInt             interface{} `json:"get_int,omitempty"`
 	GetBool            interface{} `json:"get_bool,omitempty"`


### PR DESCRIPTION
Adds `build_model` as a peer to `build_hierarchy`, exposing the OCaml-canonical recursive `Map<string, Model>` model where string values become keys pointing to `{}` and duplicate keys merge. Closes #142. Also restores the type-codegen pipeline (silently broken since the `ccl-test-lib` consolidation) so `go generate ./types/...` now works end-to-end.

* feat(tests): add build_model canonical model function

Defines `build_model` as a function that produces the recursive `Map<string, Model>` shape — the abstraction OCaml's `fix` actually builds. Wires it through the schema, mock, loader, generator dispatch, and stats. Adds 5 fixtures in `api_core_ccl_model.json` and cross-links 3 entries in `api_core_ccl_hierarchy.json` so implementations' two views are validated against the same inputs.

`build_hierarchy` is **not** redefined as a projection of `build_model` (issue #142 open questions 1–4 are explicitly deferred). The two functions remain independent, with cross-linked tests as the consistency check.

One mock parity boundary: `TestDeepNestedObjectsBuildModel` is skipped under the `function:parse` run-only filter — same boundary as the long-standing `TestDeepNestedObjectsBuildHierarchy`. The mock walks entries flat and doesn't recurse into block values; pre-existing behavior, documented in the `BuildModel` mock comment.

* build: restore go-jsonschema codegen pipeline

Adds `cmd/simplify-schema/main.go` (~70 lines) — a tiny preprocessor that strips JSON Schema constructs `go-jsonschema` (omissis fork) can't translate (the `allOf`+`if/then` conditional on the test-element schema, and the `oneOf`+`pattern` constraint on `features.items`). Without simplification, the entire test-element type collapses to `interface{}`.

Pins `go-jsonschema` via mise (`github:omissis/go-jsonschema`) so codegen is reproducible without manual `go install`. The intermediate `generated-format-simple.json` is gitignored. The previous `cmd/simplify-schema` had been missing since the consolidation commit `568c1a1` and nobody noticed because the generated package was being hand-edited.

## Test plan

- [x] `go build ./...` passes
- [x] `just test` (basic-only) passes — 461 active, 455 skipped under run-only filter
- [x] `just validate` passes (both schemas)
- [x] `go generate ./types/...` runs cleanly and produces compilable code
- [x] `just stats` shows `function:build_model: 8 tests (25 assertions) across 2 files`
- [x] 7 of 8 `build_model` tests pass under unfiltered run; the one failing case hits the documented mock parity boundary