### PR TITLE
fix(tests): clarify unindented-line fixture and add parse variant

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -127,7 +127,10 @@ This project uses [Python Semantic Release](https://python-semantic-release.read
 
 ### Squash Merge Commit Format
 
-When squash merging PRs with multiple logical changes, format the commit body with `*` prefixes for each sub-commit:
+> [!IMPORTANT]
+> **PRs are squash-merged**, so the **PR description IS the squash commit body** that semantic-release parses for changelog entries. Author the PR body in this format from the start (don't rely on editing it at merge time).
+
+When squash merging PRs with multiple logical changes, format the commit body — i.e. the PR description — with `*` prefixes for each sub-commit:
 
 ```
 feat(scope): main PR title (#123)

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -55,24 +55,15 @@ just test-all                   # Run all tests including failing ones
 ### Test Files Structure
 ```
 source_tests/
-├── core/
-│   ├── api_comments.json
-│   ├── api_core_ccl_hierarchy.json
-│   ├── api_core_ccl_integration.json
-│   ├── api_core_ccl_parsing.json
-│   ├── api_edge_cases.json
-│   ├── api_errors.json
-│   ├── api_advanced_processing.json
-│   ├── api_list_access.json
-│   ├── api_proposed_behavior.json
-│   ├── api_reference_compliant.json
-│   ├── api_typed_access.json
-│   ├── api_whitespace_behaviors.json
-│   ├── property_round_trip.json
-│   └── property_algebraic.json
-└── experimental/
-    └── api_experimental.json
+├── core/                # Stable fixtures grouped by area
+│   ├── api_*.json       # Per-area API tests (parsing, hierarchy, model, errors, comments,
+│   │                    # typed access, list access, advanced processing, edge cases,
+│   │                    # filter predicates, whitespace behaviors, proposed/reference variants)
+│   ├── api_fuzz_*.json  # Generated fuzz seeds
+│   └── property_*.json  # Algebraic + round-trip properties
+└── experimental/        # In-development fixtures (api_experimental.json, etc.)
 ```
+Run `ls source_tests/core/` for the current file list.
 
 ## Command Reference
 
@@ -94,17 +85,21 @@ source_tests/
 - **Go Tests** (`go_tests/`): Generated Go test files for execution
 
 ### CCL Function Groups (per schema)
-- **Core Parsing**: `parse`, `parse_indented`, `build_hierarchy`
+- **Core Parsing**: `parse`, `parse_indented`, `build_hierarchy`, `build_model`
 - **Typed Access**: `get_string`, `get_int`, `get_bool`, `get_float`, `get_list`
 - **Processing**: `filter`, `compose`, `expand_dotted`
 - **Formatting/IO**: `canonical_format`, `load`, `round_trip`
 
-**Note:** Mock implementation (`internal/mock/ccl.go`) provides: Parse, ParseIndented, Filter, Compose, ExpandDotted, BuildHierarchy, GetString, GetInt, GetBool, GetFloat, GetList, PrettyPrint, Print, RoundTrip, ComposeAssociative, IdentityLeft, IdentityRight.
+**Note:** Mock implementation (`internal/mock/ccl.go`) provides: Parse, ParseIndented, Filter, Compose, ExpandDotted, BuildHierarchy, BuildModel, GetString, GetInt, GetBool, GetFloat, GetList, PrettyPrint, Print, RoundTrip, ComposeAssociative, IdentityLeft, IdentityRight.
 
 **Function Details:**
 - **`parse`**: Basic lexical parsing - returns flat entries where values are raw strings
 - **`parse_indented`**: Indentation-normalized parsing - calculates common leading whitespace and strips it from all lines (like Python's `textwrap.dedent`)
 - **`build_hierarchy`**: Recursively parses entry values to create nested object structure
+- **`build_model`**: Canonical OCaml-reference model construction — like `build_hierarchy` but follows the reference semantics for key folding and value coercion
+
+> [!IMPORTANT]
+> **Mock `Parse` multiline-keys gap:** `internal/mock/ccl.go`'s `Parse` does **not** fold unindented non-`=` lines into the next key (OCaml-canonical multiline-keys behavior). When adding a `parse` validation to a fixture that exercises multiline keys, the matching `*Parse` Go test will fail and must be appended to the basic-only skip list in `cmd/ccl-test-runner/main.go` (alongside the existing `TestKeyWithNewlineBeforeEqualsParse` etc.). This is a known mock limitation, not a bug in the test data.
 
 ### Test Metadata
 - **`functions`** - Required CCL functions (filter: skip if unsupported)

--- a/cmd/ccl-test-runner/main.go
+++ b/cmd/ccl-test-runner/main.go
@@ -366,6 +366,7 @@ func testAction(ctx *cli.Context) error {
 			"TestMultilineKeyBlankLinesBetweenParse",
 			"TestMultilineKeyTabsInContinuationParse",
 			"TestRoundTripWhitespaceNormalizationParse",
+			"TestUnindentedLineDoesNotContinueValueParse",
 		}
 		skipTests = append(skipTests, defaultSkipTests...)
 	}

--- a/generated_tests/api_proposed_behavior.json
+++ b/generated_tests/api_proposed_behavior.json
@@ -43,7 +43,39 @@
             "value": "= Section Header ="
           },
           {
-            "key": "This continues the header\nkey",
+            "key": "prefix for next key\nkey",
+            "value": "value"
+          }
+        ]
+      },
+      "features": [
+        "empty_keys",
+        "multiline_keys"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "== Section Header =\nprefix for next key\nkey = value"
+      ],
+      "name": "unindented_line_does_not_continue_value_parse",
+      "source_test": "unindented_line_does_not_continue_value",
+      "validation": "parse",
+      "variants": [
+        "reference_compliant"
+      ]
+    },
+    {
+      "behaviors": [],
+      "expected": {
+        "count": 2,
+        "entries": [
+          {
+            "key": "",
+            "value": "= Section Header ="
+          },
+          {
+            "key": "prefix for next key\nkey",
             "value": "value"
           }
         ]
@@ -56,7 +88,7 @@
         "parse_indented"
       ],
       "inputs": [
-        "== Section Header =\nThis continues the header\nkey = value"
+        "== Section Header =\nprefix for next key\nkey = value"
       ],
       "name": "unindented_line_does_not_continue_value_parse_indented",
       "source_test": "unindented_line_does_not_continue_value",

--- a/go_tests/parsing/api_proposed_behavior_test.go
+++ b/go_tests/parsing/api_proposed_behavior_test.go
@@ -20,6 +20,30 @@ func TestMultilineSectionHeaderValueParseIndented(t *testing.T) {
 }
 
 
+// unindented_line_does_not_continue_value_parse - function:parse feature:empty_keys feature:multiline_keys variant:reference_compliant
+func TestUnindentedLineDoesNotContinueValueParse(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `== Section Header =
+prefix for next key
+key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// Parse validation
+	parseResult, err := ccl.Parse(input)
+	require.NoError(t, err)
+	expected := []mock.Entry{mock.Entry{Key: "", Value: "= Section Header ="}, mock.Entry{Key: "prefix for next key\nkey", Value: "value"}}
+	assert.Equal(t, expected, parseResult)
+
+}
+
+
 // unindented_line_does_not_continue_value_parse_indented - function:parse_indented feature:empty_keys feature:multiline_keys variant:reference_compliant
 func TestUnindentedLineDoesNotContinueValueParseIndented(t *testing.T) {
 	t.Skip("Test does not match run-only filter: [function:parse]")

--- a/source_tests/core/api_proposed_behavior.json
+++ b/source_tests/core/api_proposed_behavior.json
@@ -38,10 +38,11 @@
         "multiline_keys"
       ],
       "functions": [
+        "parse",
         "parse_indented"
       ],
       "inputs": [
-        "== Section Header =\nThis continues the header\nkey = value"
+        "== Section Header =\nprefix for next key\nkey = value"
       ],
       "name": "unindented_line_does_not_continue_value",
       "tests": [
@@ -52,7 +53,20 @@
               "value": "= Section Header ="
             },
             {
-              "key": "This continues the header\nkey",
+              "key": "prefix for next key\nkey",
+              "value": "value"
+            }
+          ],
+          "function": "parse"
+        },
+        {
+          "expect": [
+            {
+              "key": "",
+              "value": "= Section Header ="
+            },
+            {
+              "key": "prefix for next key\nkey",
               "value": "value"
             }
           ],


### PR DESCRIPTION
Clarifies a misleading test fixture, adds a parse-validation variant to close a coverage gap, and refreshes CLAUDE.md to match recent feature work.

* fix(tests): rename misleading fixture text in unindented_line_does_not_continue_value

The fixture in `unindented_line_does_not_continue_value` contained the string `"This continues the header"`, contradicting the test name and expected output — the unindented line does *not* continue the header value, it folds into the next key. Replaced with `"prefix for next key"` so the fixture is self-documenting. Closes #147.

* feat(tests): add parse-validation variant of unindented_line_does_not_continue_value

The input's first content line is at column 0, so `parse_indented` detects baseline N=0 and is behaviorally equivalent to `parse` on the OCaml reference. Added a `parse` validation alongside the existing `parse_indented` one (and `parse` to the test's `functions` list) to close a coverage gap where flat-`parse` defects in multiline-keys + first-`=` folding previously went undetected. Closes #146.

* chore(tests): skip TestUnindentedLineDoesNotContinueValueParse in --basic-only

The bundled mock's `Parse` does not fold multiline keys; the new `*Parse` variant is appended to the existing skip list in `cmd/ccl-test-runner/main.go` alongside its eight peers in the same category.

* docs(claude-md): refresh function groups, file tree, and document mock Parse gap

Adds `build_model` to CCL Function Groups, the mock implementation list, and function details (drift from #143). Replaces the hand-maintained `source_tests/core` tree with a pattern-based description so the doc stops rotting when fixtures are added. Captures the mock `Parse` multiline-keys gap and the `cmd/ccl-test-runner/main.go` skip-list workaround discovered while authoring this PR's parse-variant test. Adds a callout that the PR description is the squash commit body that semantic-release parses, so contributors author the PR body in the required format from the start.

## Test plan

- [x] `just validate` — source + generated schemas pass
- [x] `just reset` — regenerates flat + go tests, lint clean, basic-only test run green
- [ ] Reviewer eyeball: confirm the new `parse` validation mirrors the `parse_indented` expectations exactly in `source_tests/core/api_proposed_behavior.json`