### PR TITLE
fix(tests): cover behavior:continuation_tab_preserve

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -243,6 +243,76 @@
       "variants": []
     },
     {
+      "behaviors": [
+        "multiline_values",
+        "continuation_tab_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "continuation_tab_to_space"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "section",
+            "value": "\n\t\tindented_with_tabs\n\t\tanother_line"
+          }
+        ]
+      },
+      "features": [
+        "whitespace",
+        "multiline_continuation",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+      ],
+      "name": "tabs_as_whitespace_multiline_preserve_parse",
+      "source_test": "tabs_as_whitespace_multiline_preserve",
+      "validation": "parse",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "multiline_values",
+        "continuation_tab_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "continuation_tab_to_space"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "entries": [
+          {
+            "key": "section",
+            "value": "\n \tmixed_indent\n\t another_line"
+          }
+        ]
+      },
+      "features": [
+        "whitespace",
+        "multiline_continuation",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n \tmixed_indent\n\t another_line"
+      ],
+      "name": "tabs_as_whitespace_mixed_indent_preserve_parse",
+      "source_test": "tabs_as_whitespace_mixed_indent_preserve",
+      "validation": "parse",
+      "variants": []
+    },
+    {
       "behaviors": [],
       "expected": {
         "count": 1,

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -152,6 +152,18 @@ func TestTabsAsWhitespaceMixedIndentParse(t *testing.T) {
 }
 
 
+// tabs_as_whitespace_multiline_preserve_parse - function:parse feature:whitespace feature:multiline_continuation feature:tab_in_value_preserved behavior:multiline_values behavior:continuation_tab_preserve
+func TestTabsAsWhitespaceMultilinePreserveParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:continuation_tab_preserve")
+}
+
+
+// tabs_as_whitespace_mixed_indent_preserve_parse - function:parse feature:whitespace feature:multiline_continuation feature:tab_in_value_preserved behavior:multiline_values behavior:continuation_tab_preserve
+func TestTabsAsWhitespaceMixedIndentPreserveParse(t *testing.T) {
+	t.Skip("Test skipped due to tag filter: behavior:continuation_tab_preserve")
+}
+
+
 // tabs_canonical_format_as_whitespace_canonical_format - function:parse function:print function:canonical_format feature:whitespace
 func TestTabsCanonicalFormatAsWhitespaceCanonicalFormat(t *testing.T) {
 	

--- a/justfile
+++ b/justfile
@@ -16,7 +16,7 @@ default:
 # Generate test files from source JSON
 build:
     go run ./cmd/ccl-test-runner generate-flat --source ./source_tests/core --validate
-    go run ./cmd/ccl-test-runner generate --run-only function:parse --skip-tags behavior:crlf_preserve_literal,behavior:indent_tabs,behavior:delimiter_prefer_spaced
+    go run ./cmd/ccl-test-runner generate --run-only function:parse --skip-tags behavior:crlf_preserve_literal,behavior:indent_tabs,behavior:delimiter_prefer_spaced,behavior:continuation_tab_preserve
 
 # Run tests
 test:

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -160,6 +160,64 @@
       ]
     },
     {
+      "behaviors": [
+        "multiline_values",
+        "continuation_tab_preserve"
+      ],
+      "features": [
+        "whitespace",
+        "multiline_continuation",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n\t\tindented_with_tabs\n\t\tanother_line"
+      ],
+      "name": "tabs_as_whitespace_multiline_preserve",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "section",
+              "value": "\n\t\tindented_with_tabs\n\t\tanother_line"
+            }
+          ],
+          "function": "parse"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "multiline_values",
+        "continuation_tab_preserve"
+      ],
+      "features": [
+        "whitespace",
+        "multiline_continuation",
+        "tab_in_value_preserved"
+      ],
+      "functions": [
+        "parse"
+      ],
+      "inputs": [
+        "section =\n \tmixed_indent\n\t another_line"
+      ],
+      "name": "tabs_as_whitespace_mixed_indent_preserve",
+      "tests": [
+        {
+          "expect": [
+            {
+              "key": "section",
+              "value": "\n \tmixed_indent\n\t another_line"
+            }
+          ],
+          "function": "parse"
+        }
+      ]
+    },
+    {
       "features": [
         "whitespace"
       ],


### PR DESCRIPTION
Closes #137.

Adds symmetric coverage for the `continuation_tab_preserve` half of the `continuation_tab_*` behavior pair — both halves now have parse fixtures.

* test(whitespace): assert continuation_tab_preserve parse semantics

Adds two parse fixtures (`tabs_as_whitespace_multiline_preserve`, `tabs_as_whitespace_mixed_indent_preserve`) asserting that leading tabs on multiline continuation lines are preserved verbatim. They mirror the existing `continuation_tab_to_space` pair so the two halves are now symmetric.

* chore(build): skip behavior:continuation_tab_preserve in basic build

Adds `behavior:continuation_tab_preserve` to the `build` recipe's `--skip-tags` list. The mock implements the OCaml-canonical `continuation_tab_to_space` side, so the opposing variant must be excluded from generated Go tests — same pattern already used for `crlf_preserve_literal` and `indent_tabs`.