### PR TITLE
feat(tests): cover behavior:toplevel_indent_strip/preserve tag pair

### DIFF
--- a/generated_tests/api_whitespace_behaviors.json
+++ b/generated_tests/api_whitespace_behaviors.json
@@ -1801,6 +1801,128 @@
       "source_test": "behavior_combo_tabs_and_crlf",
       "validation": "parse",
       "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_strip"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_preserve"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "key = value\nnested =\n  child = inner"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "  key = value\n  nested =\n    child = inner"
+      ],
+      "name": "toplevel_indent_strip_canonical_canonical_format",
+      "source_test": "toplevel_indent_strip_canonical",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_strip"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "  key = value\n  nested =\n    child = inner"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print",
+        "canonical_format"
+      ],
+      "inputs": [
+        "  key = value\n  nested =\n    child = inner"
+      ],
+      "name": "toplevel_indent_preserve_canonical_canonical_format",
+      "source_test": "toplevel_indent_preserve_canonical",
+      "validation": "canonical_format",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_strip"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_preserve"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "key = value"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_strip_round_trip_round_trip",
+      "source_test": "toplevel_indent_strip_round_trip",
+      "validation": "round_trip",
+      "variants": []
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "conflicts": {
+        "behaviors": [
+          "indent_tabs",
+          "toplevel_indent_strip"
+        ]
+      },
+      "expected": {
+        "count": 1,
+        "value": "  key = value"
+      },
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "parse",
+        "print"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_preserve_round_trip_round_trip",
+      "source_test": "toplevel_indent_preserve_round_trip",
+      "validation": "round_trip",
+      "variants": []
     }
   ]
 }

--- a/go_tests/parsing/api_whitespace_behaviors_test.go
+++ b/go_tests/parsing/api_whitespace_behaviors_test.go
@@ -650,3 +650,91 @@ func TestBehaviorComboTabsAndCrlfParse(t *testing.T) {
 }
 
 
+// toplevel_indent_strip_canonical_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:indent_spaces behavior:toplevel_indent_strip
+func TestToplevelIndentStripCanonicalCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `  key = value
+  nested =
+    child = inner`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// toplevel_indent_preserve_canonical_canonical_format - function:parse function:print function:canonical_format feature:whitespace behavior:indent_spaces behavior:toplevel_indent_preserve
+func TestToplevelIndentPreserveCanonicalCanonicalFormat(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `  key = value
+  nested =
+    child = inner`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement canonical_format validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// toplevel_indent_strip_round_trip_round_trip - function:parse function:print feature:whitespace behavior:indent_spaces behavior:toplevel_indent_strip
+func TestToplevelIndentStripRoundTripRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `  key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+
+// toplevel_indent_preserve_round_trip_round_trip - function:parse function:print feature:whitespace behavior:indent_spaces behavior:toplevel_indent_preserve
+func TestToplevelIndentPreserveRoundTripRoundTrip(t *testing.T) {
+	
+
+	ccl := mock.New()
+	input := `  key = value`
+	
+	// Declare variables for reuse across validations
+	
+	
+	
+	var err error
+	
+	// TODO: Implement round_trip validation
+	_ = ccl // Prevent unused variable warning
+	_ = input // Prevent unused variable warning
+	_ = err // Prevent unused variable warning
+
+}
+
+

--- a/internal/config/simple_config.go
+++ b/internal/config/simple_config.go
@@ -62,6 +62,8 @@ var ValidBehaviors = []string{
 	"list_coercion_disabled",
 	"array_order_insertion",
 	"array_order_lexicographic",
+	"toplevel_indent_strip",
+	"toplevel_indent_preserve",
 }
 
 // ValidVariants defines all supported specification variants
@@ -77,6 +79,7 @@ var ConflictingBehaviors = [][]string{
 	{"continuation_tab_to_space", "continuation_tab_preserve"},
 	{"list_coercion_enabled", "list_coercion_disabled"},
 	{"array_order_insertion", "array_order_lexicographic"},
+	{"toplevel_indent_strip", "toplevel_indent_preserve"},
 }
 
 // LoadConfig loads and validates a YAML configuration file

--- a/schemas/generated-format.json
+++ b/schemas/generated-format.json
@@ -158,6 +158,7 @@
             "list_coercion_enabled", "list_coercion_disabled",
             "array_order_insertion", "array_order_lexicographic",
             "delimiter_first_equals", "delimiter_prefer_spaced",
+            "toplevel_indent_strip", "toplevel_indent_preserve",
             "path_traversal",
             "multiline_values"
           ]

--- a/schemas/source-format.json
+++ b/schemas/source-format.json
@@ -122,6 +122,22 @@
             "affectedFunctions": { "const": ["parse", "parse_indented", "build_hierarchy"] },
             "mutuallyExclusiveWith": { "const": ["delimiter_first_equals"] }
           }
+        },
+        "toplevel_indent_strip": {
+          "type": "object",
+          "properties": {
+            "description": { "const": "When re-serializing, strip leading top-level indentation so canonical output starts at column zero. Implementation choice (output formatting) — distinct from feature:toplevel_indent_strip which is the universal OCaml-canonical parsing rule." },
+            "affectedFunctions": { "const": ["canonical_format", "print", "round_trip"] },
+            "mutuallyExclusiveWith": { "const": ["toplevel_indent_preserve"] }
+          }
+        },
+        "toplevel_indent_preserve": {
+          "type": "object",
+          "properties": {
+            "description": { "const": "When re-serializing, preserve leading top-level indentation verbatim in canonical output. Implementation choice (output formatting) for impls that retain the original layout." },
+            "affectedFunctions": { "const": ["canonical_format", "print", "round_trip"] },
+            "mutuallyExclusiveWith": { "const": ["toplevel_indent_strip"] }
+          }
         }
       }
     },
@@ -135,6 +151,7 @@
         "list_coercion_enabled", "list_coercion_disabled",
         "array_order_insertion", "array_order_lexicographic",
         "delimiter_first_equals", "delimiter_prefer_spaced",
+        "toplevel_indent_strip", "toplevel_indent_preserve",
         "path_traversal",
         "multiline_values"
       ]
@@ -437,6 +454,16 @@
         "description": "Multi-line value construction edge cases: empty first line after '=', continuation line preservation, and empty line lookahead within indented blocks.",
         "affectedFunctions": ["parse", "parse_indented", "build_hierarchy", "canonical_format", "round_trip"],
         "mutuallyExclusiveWith": []
+      },
+      "toplevel_indent_strip": {
+        "description": "When re-serializing, strip leading top-level indentation so canonical output starts at column zero. Implementation choice (output formatting) — distinct from feature:toplevel_indent_strip which is the universal OCaml-canonical parsing rule.",
+        "affectedFunctions": ["canonical_format", "print", "round_trip"],
+        "mutuallyExclusiveWith": ["toplevel_indent_preserve"]
+      },
+      "toplevel_indent_preserve": {
+        "description": "When re-serializing, preserve leading top-level indentation verbatim in canonical output. Implementation choice (output formatting) for impls that retain the original layout.",
+        "affectedFunctions": ["canonical_format", "print", "round_trip"],
+        "mutuallyExclusiveWith": ["toplevel_indent_strip"]
       }
     },
     "defaults": {

--- a/source_tests/core/api_whitespace_behaviors.json
+++ b/source_tests/core/api_whitespace_behaviors.json
@@ -1110,6 +1110,94 @@
           "function": "parse"
         }
       ]
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_strip"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "canonical_format"
+      ],
+      "inputs": [
+        "  key = value\n  nested =\n    child = inner"
+      ],
+      "name": "toplevel_indent_strip_canonical",
+      "tests": [
+        {
+          "expect": "key = value\nnested =\n  child = inner",
+          "function": "canonical_format"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "canonical_format"
+      ],
+      "inputs": [
+        "  key = value\n  nested =\n    child = inner"
+      ],
+      "name": "toplevel_indent_preserve_canonical",
+      "tests": [
+        {
+          "expect": "  key = value\n  nested =\n    child = inner",
+          "function": "canonical_format"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_strip"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "round_trip"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_strip_round_trip",
+      "tests": [
+        {
+          "expect": "key = value",
+          "function": "round_trip"
+        }
+      ]
+    },
+    {
+      "behaviors": [
+        "indent_spaces",
+        "toplevel_indent_preserve"
+      ],
+      "features": [
+        "whitespace"
+      ],
+      "functions": [
+        "round_trip"
+      ],
+      "inputs": [
+        "  key = value"
+      ],
+      "name": "toplevel_indent_preserve_round_trip",
+      "tests": [
+        {
+          "expect": "  key = value",
+          "function": "round_trip"
+        }
+      ]
     }
   ]
 }


### PR DESCRIPTION
Closes #138.

Adds coverage for the `toplevel_indent_strip` / `toplevel_indent_preserve` behavior pair so both tags drop off the validate-tags unused-warning list (41 → 43 distinct tags collected from `source_tests/`).

* feat(tests): exercise toplevel_indent_strip/preserve behaviors

Adds four fixtures in `api_whitespace_behaviors.json` — two `canonical_format` and two `round_trip` — declaring the implementation-choice behavior tags. Inputs use top-level indentation so the two branches diverge in their re-serialized output.

* feat(schema): register toplevel_indent_strip/preserve behavior pair

Adds entries to `schemas/source-format.json` (both `$defs/behaviorMetadata` and `x-behaviorMetadata`) and `schemas/generated-format.json` so the tags validate and auto-conflict generation marks them mutually exclusive.

* chore(config): teach simple_config about the new behavior pair

Adds the two behaviors to `ValidBehaviors` and the pair to `ConflictingBehaviors` in `internal/config/simple_config.go` so runner configs can declare a side without tripping validation.

* chore(tests): regenerate flat + Go tests via just reset

Refreshes `generated_tests/api_whitespace_behaviors.json` and `go_tests/parsing/api_whitespace_behaviors_test.go` to match the new source fixtures. Generated Go tests are TODO stubs (canonical_format / round_trip aren't wired in the mock).

## Test plan
- [x] `just validate` passes
- [x] `just reset` passes (lint + generate + tests)
- [x] Confirmed both `behavior:toplevel_indent_*` tags now collected (41 → 43)
- [ ] CI green

Note: `just validate-tags-offline` still exits 1 because of a pre-existing missing-doc failure for `function:build_model` — unrelated to this PR.