### PR TITLE
feat(schema): add build_model, fill enum gaps, add optional_behaviors

### DIFF
--- a/ccl-config-schema.json
+++ b/ccl-config-schema.json
@@ -6,6 +6,33 @@
   "type": "object",
   "required": ["functions"],
   "additionalProperties": false,
+  "definitions": {
+    "behaviorName": {
+      "type": "string",
+      "enum": [
+        "array_order_insertion",
+        "array_order_lexicographic",
+        "boolean_lenient",
+        "boolean_strict",
+        "continuation_tab_preserve",
+        "continuation_tab_to_space",
+        "crlf_normalize_to_lf",
+        "crlf_preserve_literal",
+        "delimiter_first_equals",
+        "delimiter_prefer_spaced",
+        "indent_spaces",
+        "indent_tabs",
+        "list_coercion_disabled",
+        "list_coercion_enabled",
+        "multiline_values",
+        "path_traversal",
+        "tabs_as_content",
+        "tabs_as_whitespace",
+        "toplevel_indent_preserve",
+        "toplevel_indent_strip"
+      ]
+    }
+  },
   "properties": {
     "functions": {
       "type": "array",
@@ -16,15 +43,20 @@
         "type": "string",
         "enum": [
           "parse",
+          "parse_indented",
           "build_hierarchy",
+          "build_model",
           "get_string",
           "get_int",
           "get_bool",
           "get_float",
           "get_list",
           "filter",
+          "compose",
           "expand_dotted",
-          "canonical_format"
+          "canonical_format",
+          "load",
+          "print"
         ]
       }
     },
@@ -38,11 +70,12 @@
           {
             "enum": [
               "comments",
-              "unicode",
+              "empty_keys",
               "multiline",
               "multiline_continuation",
-              "whitespace",
-              "empty_keys"
+              "multiline_keys",
+              "unicode",
+              "whitespace"
             ]
           },
           {
@@ -58,26 +91,13 @@
       "type": "array",
       "description": "Behavioral choices for your implementation (mutually exclusive pairs documented via conflicts field in tests)",
       "uniqueItems": true,
-      "items": {
-        "type": "string",
-        "enum": [
-          "boolean_strict",
-          "boolean_lenient",
-          "tabs_as_content",
-          "tabs_as_whitespace",
-          "indent_spaces",
-          "indent_tabs",
-          "crlf_preserve_literal",
-          "crlf_normalize_to_lf",
-          "list_coercion_enabled",
-          "list_coercion_disabled",
-          "array_order_insertion",
-          "array_order_lexicographic",
-          "toplevel_indent_strip",
-          "toplevel_indent_preserve",
-          "path_traversal"
-        ]
-      }
+      "items": { "$ref": "#/definitions/behaviorName" }
+    },
+    "optional_behaviors": {
+      "type": "array",
+      "description": "Behaviors your implementation supports as opt-in (e.g. via function options) but does not select as primary. Used by tests that allow multiple behavior choices.",
+      "uniqueItems": true,
+      "items": { "$ref": "#/definitions/behaviorName" }
     },
     "variants": {
       "type": "array",


### PR DESCRIPTION
Aligns `ccl-config-schema.json` with the functions, behaviors, and features actually dispatched by the test runner and used by source/generated fixtures + implementation `ccl-config.yaml` files.

Validated against all impl configs in the workspace (`ccl-dotnet`, `ccl-c`, `ccl-haskell`, `ccl-java`, `ccl-scala`, `ccl-typescript`, `ccl_gleam`, `ccl-fsharp`). All now pass schema validation except `ccl_gleam`, which fails on a separate taxonomy issue (`toplevel_indent_strip` listed under `features:` rather than `behaviors:`) that is out of scope for this PR.

* feat(schema): add build_model to functions enum

Adds `build_model` as a peer of `build_hierarchy` so implementations can declare canonical-model support per https://catconflang.com/reference/functions/#build_model.

* fix(schema): fill missing functions in enum

Adds `parse_indented`, `compose`, `load`, and `print` — all dispatched by the test runner and used in fixtures, but previously rejected by schema validation when listed in an implementation's `ccl-config.yaml`.

* fix(schema): fill missing behaviors in enum

Adds `continuation_tab_preserve`, `continuation_tab_to_space`, `delimiter_first_equals`, `delimiter_prefer_spaced`, and `multiline_values` — all referenced by source/generated fixtures and impl configs but previously absent from the behaviors enum. Reordered the enum alphabetically.

* fix(schema): add multiline_keys to features enum

Used by source fixtures and `ccl_gleam`'s config; previously failed schema validation.

* feat(schema): add optional_behaviors property

Adds a top-level `optional_behaviors` array (same item shape as `behaviors`) to support implementations like `ccl-typescript` that distinguish primary vs opt-in behavior support. Factored `behaviorName` into `definitions` so both arrays share a single enum source of truth.

## Test plan

- [x] \`python3 -m json.tool ccl-config-schema.json\` — valid JSON
- [x] \`just validate\` — passes
- [x] All workspace impl \`ccl-config.yaml\` files validate (except \`ccl_gleam\`'s pre-existing \`toplevel_indent_strip\`-as-feature taxonomy issue)